### PR TITLE
feat(photos): lightbox viewer on pothole detail page

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -14,6 +14,7 @@ export const ICONS = {
 	'share-2':        '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>',
 	'clipboard':      '<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>',
 	'arrow-left':     '<line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>',
+	'arrow-right':    '<line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>',
 	'plus':           '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>',
 	'bar-chart-2':    '<line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>',
 	'globe':          '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -756,7 +756,7 @@
 				class="absolute bottom-5 left-1/2 -translate-x-1/2 flex gap-2"
 				onclick={(e) => e.stopPropagation()}
 			>
-				{#each photos as _, i (i)}
+				{#each photos as photo, i (photo.id)}
 					<button
 						onclick={() => (lightboxIndex = i)}
 						aria-label="Go to photo {i + 1}"

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -131,6 +131,29 @@
 		}
 	}
 
+	// Lightbox
+	let lightboxIndex = $state<number | null>(null);
+
+	function openLightbox(index: number) { lightboxIndex = index; }
+	function closeLightbox() { lightboxIndex = null; }
+	function prevPhoto() { if (lightboxIndex !== null) lightboxIndex = (lightboxIndex - 1 + photos.length) % photos.length; }
+	function nextPhoto() { if (lightboxIndex !== null) lightboxIndex = (lightboxIndex + 1) % photos.length; }
+
+	$effect(() => {
+		if (lightboxIndex === null) return;
+		document.body.style.overflow = 'hidden';
+		function onKeydown(e: KeyboardEvent) {
+			if (e.key === 'Escape') closeLightbox();
+			else if (e.key === 'ArrowLeft') prevPhoto();
+			else if (e.key === 'ArrowRight') nextPhoto();
+		}
+		window.addEventListener('keydown', onKeydown);
+		return () => {
+			document.body.style.overflow = '';
+			window.removeEventListener('keydown', onKeydown);
+		};
+	});
+
 	// Watch state — initialised on mount to avoid SSR/hydration mismatch
 	let watching = $state(false);
 	let watchMounted = $state(false);
@@ -441,15 +464,19 @@
 				{photos.length === 1 ? 'Photo' : 'Photos'}
 			</div>
 			<div class="grid grid-cols-2 gap-2">
-				{#each photos as photo (photo.id)}
-					<a href={photo.url} target="_blank" rel="noopener noreferrer" class="block rounded-lg overflow-hidden ring-1 ring-zinc-700 hover:ring-sky-500 transition-shadow">
+				{#each photos as photo, i (photo.id)}
+					<button
+						onclick={() => openLightbox(i)}
+						class="block rounded-lg overflow-hidden ring-1 ring-zinc-700 hover:ring-sky-500 transition-shadow cursor-zoom-in"
+						aria-label="View photo {i + 1} of {photos.length}"
+					>
 						<img
 							src={photo.url}
 							alt="Pothole at {pothole.address || 'this location'}"
 							class="w-full object-cover aspect-video"
 							loading="lazy"
 						/>
-					</a>
+					</button>
 				{/each}
 			</div>
 		</div>
@@ -676,3 +703,67 @@
 		</div>
 	</div>
 </div>
+
+<!-- Lightbox -->
+{#if lightboxIndex !== null}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/95"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Photo viewer"
+		onclick={closeLightbox}
+	>
+		<!-- Close -->
+		<button
+			onclick={closeLightbox}
+			aria-label="Close photo viewer"
+			class="absolute top-4 right-4 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+		>
+			<Icon name="x" size={20} />
+		</button>
+
+		<!-- Prev -->
+		{#if photos.length > 1}
+			<button
+				onclick={(e) => { e.stopPropagation(); prevPhoto(); }}
+				aria-label="Previous photo"
+				class="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+			>
+				<Icon name="arrow-left" size={20} />
+			</button>
+		{/if}
+
+		<!-- Image -->
+		<img
+			src={photos[lightboxIndex].url}
+			alt="Pothole at {pothole.address || 'this location'} — photo {lightboxIndex + 1} of {photos.length}"
+			class="max-w-full max-h-[90vh] object-contain rounded-lg shadow-2xl"
+			onclick={(e) => e.stopPropagation()}
+		/>
+
+		<!-- Next -->
+		{#if photos.length > 1}
+			<button
+				onclick={(e) => { e.stopPropagation(); nextPhoto(); }}
+				aria-label="Next photo"
+				class="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+			>
+				<Icon name="arrow-right" size={20} />
+			</button>
+
+			<!-- Dots -->
+			<div
+				class="absolute bottom-5 left-1/2 -translate-x-1/2 flex gap-2"
+				onclick={(e) => e.stopPropagation()}
+			>
+				{#each photos as _, i (i)}
+					<button
+						onclick={() => (lightboxIndex = i)}
+						aria-label="Go to photo {i + 1}"
+						class="w-1.5 h-1.5 rounded-full transition-colors {i === lightboxIndex ? 'bg-white' : 'bg-white/30 hover:bg-white/60'}"
+					/>
+				{/each}
+			</div>
+		{/if}
+	</div>
+{/if}


### PR DESCRIPTION
## Summary

- Replace open-in-new-tab photo links (raw Supabase URLs) with an inline fullscreen lightbox
- Clicking a thumbnail opens a full-screen overlay with the image centred and body scroll locked
- Prev/next arrow buttons and dot indicators for multi-photo potholes (hidden for single photos)
- Keyboard support: Escape closes, ←/→ navigates between photos
- Click the dark backdrop to close; clicking the image or nav controls does not
- Adds missing `arrow-right` icon to the shared icon registry

## Test Plan

- [ ] Open a pothole detail page with a published photo — thumbnail should show `cursor-zoom-in`, clicking opens lightbox
- [ ] Lightbox shows X button (top-right), image fills available height, backdrop is near-black
- [ ] Escape key closes lightbox; body scroll resumes
- [ ] For potholes with multiple photos: ← / → arrows appear, dot indicators reflect current position, arrow keys navigate
- [ ] Clicking the backdrop closes; clicking the image or arrows does not

**Note:** One pre-existing E2E test failure (`ward-profile › stats page ward rows link to ward profile pages`) is unrelated to this PR — confirmed failing on `main` before these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)