### PR TITLE
fix: stats e2e fixture + admin CSRF token + unsubscribe rate limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ Run migrations in this order:
 6. `schema_pr61_fixes.sql` — RLS policy hardening + pending pothole backfill
 7. `schema_security_hardening.sql` — revokes public EXECUTE on `increment_confirmation`; documents `deferred` photo status
 8. `schema_sprint3.sql` — drops public SELECT on `pothole_actions`; fixes pg_cron interval (90 days); adds pending-pothole expiry (14 days)
+9. `schema_push_unsubscribe_ratelimit.sql` — adds `push_unsubscribe` scope to `api_rate_limit_events` constraint
 
 Two `pg_cron` jobs run nightly:
 

--- a/schema_push_unsubscribe_ratelimit.sql
+++ b/schema_push_unsubscribe_ratelimit.sql
@@ -1,0 +1,9 @@
+-- Add 'push_unsubscribe' scope to api_rate_limit_events constraint.
+-- Required for rate-limiting DELETE /api/subscribe (push notification opt-out).
+
+ALTER TABLE api_rate_limit_events
+  DROP CONSTRAINT IF EXISTS api_rate_limit_events_scope_check;
+
+ALTER TABLE api_rate_limit_events
+  ADD CONSTRAINT api_rate_limit_events_scope_check
+  CHECK (scope IN ('report_submit', 'photo_upload', 'hit_submit', 'push_subscribe', 'push_unsubscribe'));

--- a/src/routes/admin/potholes/+page.svelte
+++ b/src/routes/admin/potholes/+page.svelte
@@ -42,10 +42,11 @@
 	async function togglePhotosPublished(id: string) {
 		const next = !photosPublished[id];
 		localOverrides[id] = next;
+		const csrfToken = document.cookie.split('; ').find((c) => c.startsWith('admin_csrf='))?.split('=')[1] ?? '';
 		try {
 			const res = await fetch(`/api/admin/pothole/${id}`, {
 				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
 				body: JSON.stringify({ photos_published: next })
 			});
 			if (!res.ok) {

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -23,6 +23,7 @@ const unsubscribeSchema = z.object({
 });
 
 const SUBSCRIBE_RATE_LIMIT = 5;
+const UNSUBSCRIBE_RATE_LIMIT = 10;
 const SUBSCRIBE_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /** Save a push subscription. Idempotent — upserts by endpoint. */
@@ -69,12 +70,35 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 };
 
 /** Remove a push subscription when the user revokes permission. */
-export const DELETE: RequestHandler = async ({ request }) => {
+export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 	const raw = await request.json().catch(() => null);
 	const parsed = unsubscribeSchema.safeParse(raw);
 	if (!parsed.success) throw error(400, 'Invalid request');
 
+	const ipHash = await hashIp(getClientAddress());
 	const db = getServiceClient();
+
+	const windowStart = new Date(Date.now() - SUBSCRIBE_RATE_WINDOW_MS).toISOString();
+	const { count: recentUnsubs, error: rateLimitError } = await db
+		.from('api_rate_limit_events')
+		.select('*', { count: 'exact', head: true })
+		.eq('ip_hash', ipHash)
+		.eq('scope', 'push_unsubscribe')
+		.gte('created_at', windowStart);
+
+	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if ((recentUnsubs ?? 0) >= UNSUBSCRIBE_RATE_LIMIT) {
+		throw error(429, 'Too many unsubscribe attempts. Please wait before trying again.');
+	}
+
 	await db.from('push_subscriptions').delete().eq('endpoint', parsed.data.endpoint);
+
+	const { error: rateLimitInsertError } = await db
+		.from('api_rate_limit_events')
+		.insert({ ip_hash: ipHash, scope: 'push_unsubscribe' });
+	if (rateLimitInsertError) {
+		console.error('[subscribe] Failed to record unsubscribe rate limit event:', rateLimitInsertError.message);
+	}
+
 	return json({ ok: true });
 };

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -91,7 +91,11 @@ export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 		throw error(429, 'Too many unsubscribe attempts. Please wait before trying again.');
 	}
 
-	await db.from('push_subscriptions').delete().eq('endpoint', parsed.data.endpoint);
+	const { error: deleteError } = await db
+		.from('push_subscriptions')
+		.delete()
+		.eq('endpoint', parsed.data.endpoint);
+	if (deleteError) throw error(500, 'Failed to remove subscription');
 
 	const { error: rateLimitInsertError } = await db
 		.from('api_rate_limit_events')

--- a/src/routes/stats/+page.server.ts
+++ b/src/routes/stats/+page.server.ts
@@ -22,8 +22,8 @@ const E2E_STATS_FIXTURE: Pothole[] = [
 	}
 ];
 
-export const load: PageServerLoad = async () => {
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+export const load: PageServerLoad = async ({ url }) => {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && url.searchParams.get('__fixture') === '1') {
 		return { potholes: E2E_STATS_FIXTURE };
 	}
 

--- a/src/routes/stats/+page.server.ts
+++ b/src/routes/stats/+page.server.ts
@@ -3,7 +3,30 @@ import { decodeHtmlEntities } from '$lib/escape';
 import type { PageServerLoad } from './$types';
 import type { Pothole } from '$lib/types';
 
+// Fixture pothole for E2E tests. Coordinates fall inside the polygon used in
+// ward-profile.spec.ts (43.40–43.45 lat, -80.55 to -80.50 lng) so ward rows
+// render and the link-to-ward-profile test can find an <a href="/stats/ward/…">.
+const E2E_STATS_FIXTURE: Pothole[] = [
+	{
+		id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+		created_at: '2026-01-15T10:00:00.000Z',
+		lat: 43.42,
+		lng: -80.52,
+		address: '100 Test Street, Kitchener, ON',
+		description: null,
+		status: 'reported',
+		confirmed_count: 3,
+		filled_at: null,
+		expired_at: null,
+		photos_published: false
+	}
+];
+
 export const load: PageServerLoad = async () => {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		return { potholes: E2E_STATS_FIXTURE };
+	}
+
 	const { data, error } = await supabase
 		.from('potholes')
 		.select('id, created_at, lat, lng, status, filled_at, expired_at, address, confirmed_count')

--- a/tests/e2e/ward-profile.spec.ts
+++ b/tests/e2e/ward-profile.spec.ts
@@ -82,7 +82,7 @@ test.describe('Ward profile page', () => {
         })
       })
     );
-    await page.goto('/stats');
+    await page.goto('/stats?__fixture=1');
     await page.waitForSelector('a[href*="/stats/ward/"]', { timeout: 10000 });
     const link = page.locator('a[href*="/stats/ward/"]').first();
     await expect(link).toBeVisible();


### PR DESCRIPTION
## Summary

- **fix(e2e):** `ward-profile › stats page ward rows link to ward profile pages` was failing in CI — `stats/+page.server.ts` had no fixture support so `data.potholes` was always `[]`, `wardRows` never rendered, and the link selector timed out. Fix wires up the `PLAYWRIGHT_E2E_FIXTURES` guard with a stub pothole inside the test polygon.
- **fix(admin):** `togglePhotosPublished` in the admin potholes list was sending `PATCH /api/admin/pothole/:id` without the `x-csrf-token` header — the double-submit CSRF guard in `hooks.server.ts` correctly rejected it with 403. Fix reads the non-HttpOnly `admin_csrf` cookie and attaches it to the request.
- **fix(security):** `DELETE /api/subscribe` had no rate limiting, allowing mass deletion of push subscriptions for known endpoint URLs. Added a 10/hr per-IP limit using the existing `api_rate_limit_events` pattern (`push_unsubscribe` scope).
- **Migration:** `schema_push_unsubscribe_ratelimit.sql` expands the `scope` CHECK constraint to include `push_unsubscribe`. **Already applied to production** before this deploy.

## Test plan

- [x] Ran `npx playwright test ward-profile` locally — all 8 tests pass (including the previously failing one)
- [x] The `ECONNREFUSED` errors in the WebServer log are expected — CI has no real Supabase, and the fixture short-circuits before any DB call
- [ ] Log into admin panel, go to Potholes list, toggle photo visibility on a pothole — should succeed (no more 403)
- [ ] Confirm audit log records the `pothole.photos_published_toggle` event
- [ ] Verify `DELETE /api/subscribe` returns 429 after 10 requests from the same IP within an hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)