### PR TITLE
fix: update dead official reporting links

### DIFF
--- a/src/lib/official-reporting.ts
+++ b/src/lib/official-reporting.ts
@@ -37,7 +37,7 @@ export const CITY_REPORT_LINKS: Record<City, OfficialReportLink> = {
 export const REGION_REPORT_LINK: OfficialReportLink = {
   id: "region",
   label: "Region of Waterloo",
-  href: "https://www.regionofwaterloo.ca/en/living-here/roads-and-traffic.aspx",
+  href: "https://www.regionofwaterloo.ca/en/regional-government/submit-a-claim.aspx",
   scope: "region",
 };
 

--- a/src/lib/official-reporting.ts
+++ b/src/lib/official-reporting.ts
@@ -17,7 +17,7 @@ export const CITY_REPORT_LINKS: Record<City, OfficialReportLink> = {
   kitchener: {
     id: "kitchener",
     label: CITY_LABELS.kitchener,
-    href: "https://www.kitchener.ca/en/transportation-and-parking/report-a-road-concern.aspx",
+    href: "https://form.kitchener.ca/CSD/CCS/Report-a-problem",
     scope: "city",
   },
   waterloo: {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -657,6 +657,12 @@
 													<p class="mt-1 text-[11px] leading-relaxed text-zinc-400 line-clamp-2">
 														{pothole.description || 'Jump to this marker to review details, share it, or mark it fixed.'}
 													</p>
+													{#if pothole.photos_published}
+														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-zinc-500">
+															<Icon name="camera" size={11} />
+															Photo
+														</span>
+													{/if}
 												</div>
 												<span class="shrink-0 rounded-full bg-zinc-800 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-300">
 													Open

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -53,7 +53,7 @@
 					{#if link.scope === 'city'}
 						— Report a pothole or road issue
 					{:else if link.scope === 'region'}
-						— Roads &amp; traffic
+						— Submit a claim for damages
 					{:else}
 						— Report a provincial highway problem
 					{/if}

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -413,7 +413,7 @@
 				Report it officially too
 			</div>
 			<p class="text-zinc-400 text-sm">
-				This page creates public visibility. An official report creates a work order the road owner is expected to track.
+				This page creates public visibility. Filing with the city creates a work order they're expected to track.
 			</p>
 			<div class="grid gap-2 sm:grid-cols-2">
 				{#if officialCityLink}
@@ -434,7 +434,7 @@
 					class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2.5 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
 				>
 					<Icon name="external-link" size={13} class="shrink-0" />
-					File with {REGION_REPORT_LINK.label}
+					Submit a claim — Region of Waterloo
 				</a>
 			</div>
 			<div class="rounded-lg bg-zinc-800/80 p-3 text-xs text-zinc-400 leading-relaxed space-y-1.5">

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -413,7 +413,7 @@
 				Report it officially too
 			</div>
 			<p class="text-zinc-400 text-sm">
-				This page creates public visibility. Filing with the city creates a work order they're expected to track.
+				This page creates public visibility. Reporting it to the road owner through official channels can help start their repair or claims process.
 			</p>
 			<div class="grid gap-2 sm:grid-cols-2">
 				{#if officialCityLink}
@@ -434,7 +434,7 @@
 					class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2.5 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
 				>
 					<Icon name="external-link" size={13} class="shrink-0" />
-					Submit a claim — Region of Waterloo
+					Submit a claim — {REGION_REPORT_LINK.label}
 				</a>
 			</div>
 			<div class="rounded-lg bg-zinc-800/80 p-3 text-xs text-zinc-400 leading-relaxed space-y-1.5">

--- a/tests/e2e/pothole-detail.spec.ts
+++ b/tests/e2e/pothole-detail.spec.ts
@@ -61,13 +61,13 @@ test.describe("Pothole detail page", () => {
       page.getByRole("link", { name: /File with City of Kitchener/i }),
     ).toHaveAttribute(
       "href",
-      "https://www.kitchener.ca/en/transportation-and-parking/report-a-road-concern.aspx",
+      "https://form.kitchener.ca/CSD/CCS/Report-a-problem",
     );
     await expect(
-      page.getByRole("link", { name: /File with Region of Waterloo/i }),
+      page.getByRole("link", { name: /Submit a claim — Region of Waterloo/i }),
     ).toHaveAttribute(
       "href",
-      "https://www.regionofwaterloo.ca/en/living-here/roads-and-traffic.aspx",
+      "https://www.regionofwaterloo.ca/en/regional-government/submit-a-claim.aspx",
     );
     await expect(
       page.getByRole("link", {


### PR DESCRIPTION
## Summary

- **Dead link fixes**: Updated official reporting URLs that were returning 404 or pointing to wrong destinations:
  - Kitchener: old `report-a-road-concern.aspx` → `https://form.kitchener.ca/CSD/CCS/Report-a-problem`
  - Region of Waterloo: old general roads page → `https://www.regionofwaterloo.ca/en/regional-government/submit-a-claim.aspx` (damage claims form — the Region has no direct pothole-reporting form)
  - Cambridge and City of Waterloo URLs verified correct, no change needed
- **UI copy**: Clarified Region of Waterloo link label ("Submit a claim — Region of Waterloo") and made helper text road-owner neutral across city and region links
- **Photo indicator**: Added camera + "Photo" badge to mobile map pothole cards when `photos_published` is true, matching the existing indicator in the watchlist panel

## Test plan

- [ ] Visit a Kitchener pothole detail page — "File with City of Kitchener" link should resolve correctly
- [ ] Confirm "Submit a claim — Region of Waterloo" button is visible and points to the claims form
- [ ] Check the About page official reporting links section — Region entry shows "Submit a claim for damages"
- [ ] On mobile, open the map tool tray — potholes with published photos should show the camera badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)