### PR TITLE
fix(security): validate user agent on trusted device MFA bypass

### DIFF
--- a/src/routes/api/admin/auth/login/+server.ts
+++ b/src/routes/api/admin/auth/login/+server.ts
@@ -15,6 +15,7 @@ import { verifyPassword, hashToken } from '$lib/server/admin-crypto';
 import { generateCsrfToken, buildCsrfCookie } from '$lib/server/admin-csrf';
 import { hashIp } from '$lib/hash';
 import { notify } from '$lib/server/pushover';
+import { logError } from '$lib/server/observability';
 
 function getAdminClient() {
 	return createClient(PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
@@ -121,18 +122,35 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
 			const trustedTokenHash = await hashToken(trustedToken);
 			const { data: device } = await getAdminClient()
 				.from('admin_trusted_devices')
-				.select('user_id')
+				.select('user_id, user_agent')
 				.eq('token', trustedTokenHash)
 				.eq('user_id', user.id)
 				.gt('expires_at', new Date().toISOString())
 				.maybeSingle();
 			if (device) {
-				skipMfa = true;
-				// Update last_used_at
-				await getAdminClient()
-					.from('admin_trusted_devices')
-					.update({ last_used_at: new Date().toISOString() })
-					.eq('token', trustedTokenHash);
+				// Validate user agent — a changed UA likely means a different browser or
+				// device. IP is intentionally not checked: trusted devices last 30 days and
+				// legitimate users frequently change IPs (mobile↔WiFi, travel, VPN).
+				const storedUa = device.user_agent as string | null;
+				const uaMatch = !storedUa || storedUa === 'unknown' || storedUa === userAgent;
+				if (uaMatch) {
+					skipMfa = true;
+					await getAdminClient()
+						.from('admin_trusted_devices')
+						.update({ last_used_at: new Date().toISOString() })
+						.eq('token', trustedTokenHash);
+				} else {
+					// UA mismatch — possible cookie theft from a different device.
+					// Don't skip MFA; surface for forensics.
+					logError('admin/trusted_device', 'Trusted device UA mismatch — MFA not skipped', new Error('ua_mismatch'), {
+						ipHashPrefix: ipHash.slice(0, 8)
+					});
+					void notify('security', {
+						title: '⚠️ Trusted device UA mismatch',
+						message: 'A trusted device cookie was presented from an unexpected browser. MFA was not skipped.',
+						priority: 0
+					});
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- The trusted device lookup only checked `token` hash, `user_id`, and `expires_at` — the stored `user_agent` was never compared, so a stolen `admin_trusted_device` cookie could skip MFA from any browser or device.
- Now the stored UA must match the current request's UA before MFA is skipped.
- A mismatch falls through to the normal MFA challenge and fires both a Sentry error (`admin/trusted_device`) and a Pushover security alert so the operator knows a suspicious attempt occurred.
- IP is intentionally **not** checked: trusted devices are valid for 30 days and legitimate users regularly change IPs (mobile ↔ WiFi, travel, VPN).

## What changed

**`src/routes/api/admin/auth/login/+server.ts`**
- `select` now fetches `user_agent` alongside `user_id`
- UA match gate added: skip MFA only when stored UA is null/`unknown` or equals the current request UA
- On mismatch: `logError` + `notify('security', ...)` fire-and-forget, then falls through to the normal MFA challenge flow

## Depends on

Rebased on top of #120 (`chore/privacy-observability-bundle`) for `logError` from `$lib/server/observability`. Merge #120 first, then rebase this onto `main`.

## Test plan

- [ ] Log in as an admin with a trusted device cookie present — MFA should be skipped as before
- [ ] Replay the same cookie from a different `User-Agent` (e.g. curl with a custom UA) — MFA challenge should be issued, Pushover alert should fire
- [ ] Cookie with `user_agent = 'unknown'` (old records) — MFA should still be skipped (graceful migration)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)