### PR TITLE
Code review 2026-04-20: 30/60/90-day improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,12 +169,14 @@ Run migrations in this order:
 14. `schema_push_unsubscribe_ratelimit.sql` — adds `push_unsubscribe` scope to `api_rate_limit_events` constraint
 15. `schema_review_fixes.sql` — RLS hardening; drops public read on `pothole_confirmations`
 16. `schema_rate_limit_cleanup.sql` — pg_cron purge job for `api_rate_limit_events` older than 90 days (PIPEDA data minimization)
+17. `schema_push_subscription_ttl.sql` — adds `last_used_at` to `push_subscriptions`; pg_cron purge job for subscriptions not refreshed in 180 days (PIPEDA data minimization)
 
-Three `pg_cron` jobs run nightly:
+Four `pg_cron` jobs run nightly:
 
 - `expire-old-potholes` (03:00 UTC): sets `status = 'expired'` on `reported` potholes older than 90 days.
 - `expire-stale-pending` (03:30 UTC): sets `status = 'expired'` on `pending` potholes older than 14 days (anti-suppression).
 - `purge-rate-limit-events` (04:00 UTC): deletes `api_rate_limit_events` rows older than 90 days (PIPEDA data minimization).
+- `purge-stale-push-subscriptions` (04:30 UTC): deletes `push_subscriptions` rows where `last_used_at` is older than 180 days (PIPEDA data minimization).
 
 ## Status Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ pending → reported → filled
 - **photos_published**: admin-only toggle per pothole; a live pothole does NOT mean its photos are shown — admin must explicitly publish them
 - **IP hashing**: HMAC-SHA-256 with `IP_HASH_SECRET`, never store raw IPs
 - **Coord privacy**: reporter lat/lng is rounded to 4 decimal places (≈11m at Waterloo latitude) at write-time via `roundPublicCoord()` in `$lib/geo` — the precision is a hard-coded constant, not an env var. Geofence + merge-radius logic runs on the raw input so decisions aren't shifted by rounding. Serialization paths (feed.json, feed.xml, export.csv, embed, OG) re-apply `roundPublicCoord` as defense-in-depth for any historical rows stored at full precision.
-- **Photo EXIF**: server-side strip in `stripJpegMetadata` (`$lib/server/exif-strip`) runs before moderation and storage upload. Drops APP1 (EXIF/GPS/XMP), APP2–APP15, and COM segments from JPEGs losslessly. PNG/WebP pass through untouched; they rarely carry camera EXIF from mobile uploads.
+- **Photo EXIF**: server-side strip in `$lib/server/exif-strip` runs before SightEngine moderation and storage upload. `stripJpegMetadata` drops APP1–APP15 and COM segments from JPEGs. `stripPngMetadata` drops the `eXIf` chunk from PNGs. `stripWebpMetadata` drops EXIF/XMP chunks from VP8X-extended WebPs (simple VP8/VP8L files carry no metadata by spec). All three return the input unchanged on malformed input.
 - **Auto-expiry**: `reported` potholes expire after 90 days; `pending` potholes expire after 14 days (both via pg_cron)
 
 ## Svelte 5 Patterns (important — don't use Svelte 4 syntax)

--- a/schema_push_subscription_ttl.sql
+++ b/schema_push_subscription_ttl.sql
@@ -18,6 +18,8 @@ alter table push_subscriptions
     alter column last_used_at set not null;
 
 -- Nightly job: delete push subscriptions not refreshed in 180 days.
+-- Unschedule first (safe no-op if job doesn't exist) to keep the migration idempotent.
+select cron.unschedule(jobid) from cron.job where jobname = 'purge-stale-push-subscriptions';
 select cron.schedule(
     'purge-stale-push-subscriptions',
     '30 4 * * *',

--- a/schema_push_subscription_ttl.sql
+++ b/schema_push_subscription_ttl.sql
@@ -1,0 +1,19 @@
+-- schema_push_subscription_ttl.sql
+-- Adds last_used_at tracking to push_subscriptions and a pg_cron cleanup job
+-- that purges subscriptions not refreshed in 180 days (PRIV-5 / PIPEDA data minimization).
+
+alter table push_subscriptions
+    add column if not exists last_used_at timestamptz not null default now();
+
+-- Back-fill: treat existing rows as last used at creation time.
+update push_subscriptions set last_used_at = created_at where last_used_at = now();
+
+-- Nightly job: delete push subscriptions not refreshed in 180 days.
+select cron.schedule(
+    'purge-stale-push-subscriptions',
+    '30 4 * * *',
+    $$
+        delete from push_subscriptions
+        where last_used_at < now() - interval '180 days';
+    $$
+);

--- a/schema_push_subscription_ttl.sql
+++ b/schema_push_subscription_ttl.sql
@@ -2,11 +2,20 @@
 -- Adds last_used_at tracking to push_subscriptions and a pg_cron cleanup job
 -- that purges subscriptions not refreshed in 180 days (PRIV-5 / PIPEDA data minimization).
 
+-- Add as nullable first so the backfill can run before the NOT NULL constraint is applied.
 alter table push_subscriptions
-    add column if not exists last_used_at timestamptz not null default now();
+    add column if not exists last_used_at timestamptz;
 
 -- Back-fill: treat existing rows as last used at creation time.
-update push_subscriptions set last_used_at = created_at where last_used_at = now();
+update push_subscriptions
+set last_used_at = created_at
+where last_used_at is null;
+
+-- Now lock in the default and NOT NULL constraint.
+alter table push_subscriptions
+    alter column last_used_at set default now();
+alter table push_subscriptions
+    alter column last_used_at set not null;
 
 -- Nightly job: delete push subscriptions not refreshed in 180 days.
 select cron.schedule(

--- a/src/lib/components/SocialShare.svelte
+++ b/src/lib/components/SocialShare.svelte
@@ -109,7 +109,7 @@
 			</a>
 		{/each}
 		<!-- aria-live announces the "Copied!" state change to screen readers -->
-		<span class="sr-only" aria-live="polite">{copied ? 'Link copied to clipboard' : ''}</span>
+		<span class="sr-only" role="status" aria-live="polite">{copied ? 'Link copied to clipboard' : ''}</span>
 		<button
 			type="button"
 			onclick={copyLink}

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -15,12 +15,16 @@
 		photos_published: boolean;
 	};
 
+	const PAGE_SIZE = 6;
+
 	let { count = $bindable(0) }: { count?: number } = $props();
 
 	let ids = $state<string[]>([]);
 	let potholes = $state<WatchedPothole[]>([]);
 	let loading = $state(false);
 	let fetchError = $state(false);
+	let showAll = $state(false);
+	let visiblePotholes = $derived(showAll ? potholes : potholes.slice(0, PAGE_SIZE));
 
 	// Keep the bound count in sync whenever ids changes
 	$effect(() => {
@@ -85,15 +89,24 @@
 			</div>
 
 			{#if loading}
-				<div class="flex items-center gap-2 text-zinc-500 text-sm py-2">
-					<Icon name="loader" size={14} class="animate-spin shrink-0" />
-					Loading…
+				<!-- Skeleton cards — match expected layout to prevent CLS -->
+				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+					{#each { length: Math.min(ids.length, PAGE_SIZE) } as _}
+						<div class="relative bg-zinc-900 rounded-xl overflow-hidden border border-zinc-800 h-[100px] animate-pulse">
+							<div class="absolute inset-y-0 left-0 w-[3px] bg-zinc-700"></div>
+							<div class="pl-5 pr-3 pt-3.5 pb-3.5 flex flex-col gap-2.5">
+								<div class="h-4 bg-zinc-700 rounded w-3/4"></div>
+								<div class="h-3 bg-zinc-800 rounded w-1/2"></div>
+								<div class="h-3 bg-zinc-800 rounded w-1/3"></div>
+							</div>
+						</div>
+					{/each}
 				</div>
 			{:else if fetchError}
 				<p class="text-zinc-500 text-sm">Couldn't load watchlist status. Try refreshing.</p>
 			{:else if potholes.length > 0}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-					{#each potholes as pothole (pothole.id)}
+					{#each visiblePotholes as pothole (pothole.id)}
 						{@const info =
 							STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ??
 							STATUS_CONFIG.reported}
@@ -157,6 +170,16 @@
 						</div>
 					{/each}
 				</div>
+				{#if potholes.length > PAGE_SIZE}
+					<div class="mt-4 text-center">
+						<button
+							onclick={() => (showAll = !showAll)}
+							class="text-xs font-medium text-zinc-500 hover:text-sky-400 transition-colors"
+						>
+							{showAll ? 'Show fewer' : `Show ${potholes.length - PAGE_SIZE} more`}
+						</button>
+					</div>
+				{/if}
 			{/if}
 		</div>
 	</section>

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -173,6 +173,7 @@
 				{#if potholes.length > PAGE_SIZE}
 					<div class="mt-4 text-center">
 						<button
+							type="button"
 							onclick={() => (showAll = !showAll)}
 							class="text-xs font-medium text-zinc-500 hover:text-sky-400 transition-colors"
 						>

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -91,7 +91,7 @@
 			{#if loading}
 				<!-- Skeleton cards — match expected layout to prevent CLS -->
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-					{#each { length: Math.min(ids.length, PAGE_SIZE) } as _}
+					{#each [...Array(Math.min(ids.length, PAGE_SIZE)).keys()] as i (i)}
 						<div class="relative bg-zinc-900 rounded-xl overflow-hidden border border-zinc-800 h-[100px] animate-pulse">
 							<div class="absolute inset-y-0 left-0 w-[3px] bg-zinc-700"></div>
 							<div class="pl-5 pr-3 pt-3.5 pb-3.5 flex flex-col gap-2.5">

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -1,5 +1,4 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import { logError } from '$lib/server/observability';
 import { getAdminClient } from '$lib/server/supabase';
 

--- a/src/lib/server/exif-strip.ts
+++ b/src/lib/server/exif-strip.ts
@@ -1,22 +1,20 @@
 /**
- * Strip EXIF / XMP / ICC / comment segments from a JPEG, preserving scan data.
+ * Strip embedded metadata (EXIF / XMP / ICC / comments) from JPEG, PNG, and
+ * WebP uploads. Mobile cameras embed GPS lat/lng, device serial numbers, and
+ * timestamps in these segments — stripping them prevents sub-metre location
+ * disclosure even when the DB row only stores rounded coords.
  *
- * Mobile cameras embed GPS lat/lng (sub-metre precision), device make/model,
- * serial numbers, and timestamps in the APP1 (EXIF) and APP2 (ICC/MPF) segments.
- * Rounding the DB-stored coords is useless if the bytes we store next to the
- * row still reveal where the reporter was standing.
+ * All three functions follow the same contract: return the input unchanged when
+ * the format signature is absent or the stream is malformed, so a corrupt upload
+ * is rejected at the content-type validation step rather than silently mangled.
+ */
+
+/**
+ * Strip EXIF/XMP/ICC from a JPEG.
  *
- * JPEG layout:
- *   SOI (FF D8) → segments (FF XX [len_hi] [len_lo] payload…) → SOS (FF DA)
- *   followed by compressed scan data → EOI (FF D9).
- *   Segment length is big-endian and includes the two length bytes themselves.
- *
- * We keep APP0 (FF E0 / JFIF header — some decoders require it), DQT/DHT/SOF,
- * and the SOS segment + scan data. We drop APP1–APP15 (FF E1–EF) and COM
- * (FF FE), which carry EXIF/XMP/ICC/FPXR/comments.
- *
- * Returns the input unchanged for anything that isn't a well-formed JPEG so
- * PNG/WebP pass through for their own handlers.
+ * JPEG layout: SOI → segments (FF XX len payload) → SOS → scan data → EOI.
+ * We keep APP0 (JFIF), DQT/DHT/SOF, and SOS + scan data.
+ * We drop APP1–APP15 (FF E1–EF) and COM (FF FE).
  */
 export function stripJpegMetadata(input: Uint8Array): Uint8Array {
 	// SOI check: JPEG must start with FF D8.
@@ -93,4 +91,97 @@ export function stripJpegMetadata(input: Uint8Array): Uint8Array {
 	// Per the function contract, return the original bytes unchanged rather
 	// than a structurally incomplete stripped copy.
 	return input;
+}
+
+/**
+ * Strip the `eXIf` chunk from a PNG.
+ *
+ * PNG layout: 8-byte signature → chunks (4-byte length, 4-byte type,
+ * data, 4-byte CRC). We drop only the `eXIf` chunk (the official EXIF
+ * container for PNG defined in PNG spec 1.6). All other chunks — including
+ * image data (IDAT), colour info (gAMA/cHRM/sRGB), and transparency (tRNS)
+ * — are kept intact.
+ */
+export function stripPngMetadata(input: Uint8Array): Uint8Array {
+	const PNG_SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	if (input.length < 8) return input;
+	for (let j = 0; j < 8; j++) if (input[j] !== PNG_SIG[j]) return input;
+
+	const out = new Uint8Array(input.length);
+	out.set(input.subarray(0, 8), 0);
+	let w = 8;
+	let i = 8;
+
+	while (i + 12 <= input.length) {
+		const chunkLen = ((input[i] << 24) | (input[i + 1] << 16) | (input[i + 2] << 8) | input[i + 3]) >>> 0;
+		if (i + 12 + chunkLen > input.length) return input;
+		const type = String.fromCharCode(input[i + 4], input[i + 5], input[i + 6], input[i + 7]);
+		const total = 12 + chunkLen; // 4 (len) + 4 (type) + chunkLen (data) + 4 (CRC)
+
+		if (type !== 'eXIf') {
+			out.set(input.subarray(i, i + total), w);
+			w += total;
+		}
+
+		i += total;
+		if (type === 'IEND') break;
+	}
+
+	return out.slice(0, w);
+}
+
+/**
+ * Strip EXIF and XMP chunks from an extended (VP8X) WebP.
+ *
+ * WebP layout: RIFF header (12 bytes) → chunks (4-byte FourCC, 4-byte
+ * little-endian size, data, optional pad byte). Only VP8X (extended) files
+ * can carry standalone EXIF/XMP chunks; simple VP8 and lossless VP8L files
+ * cannot and are returned unchanged. When chunks are removed we also clear
+ * the corresponding flag bits in the VP8X flags byte and update the RIFF
+ * file-size field so the result parses correctly.
+ */
+export function stripWebpMetadata(input: Uint8Array): Uint8Array {
+	// RIFF + WEBP signature
+	if (
+		input.length < 30 ||
+		input[0] !== 0x52 || input[1] !== 0x49 || input[2] !== 0x46 || input[3] !== 0x46 ||
+		input[8] !== 0x57 || input[9] !== 0x45 || input[10] !== 0x42 || input[11] !== 0x50
+	) return input;
+
+	// Only VP8X (0x56 0x50 0x38 0x58 = "VP8X") carries metadata chunks.
+	if (input[12] !== 0x56 || input[13] !== 0x50 || input[14] !== 0x38 || input[15] !== 0x58) return input;
+
+	const vp8xDataSize = (input[16] | (input[17] << 8) | (input[18] << 16) | (input[19] << 24)) >>> 0;
+	if (vp8xDataSize < 1 || 20 + vp8xDataSize > input.length) return input;
+
+	const out = new Uint8Array(input.length);
+	// Copy RIFF/WEBP header (12) + VP8X chunk header + data
+	out.set(input.subarray(0, 20 + vp8xDataSize), 0);
+	// Clear Exif (bit 3 = 0x08) and XMP (bit 4 = 0x10) flag bits in VP8X flags byte
+	out[20] = input[20] & ~0x18;
+	let w = 20 + vp8xDataSize;
+	if (vp8xDataSize & 1) out[w++] = 0; // pad to even boundary
+
+	let i = 20 + vp8xDataSize + (vp8xDataSize & 1);
+	while (i + 8 <= input.length) {
+		const type = String.fromCharCode(input[i], input[i + 1], input[i + 2], input[i + 3]);
+		const chunkSize = (input[i + 4] | (input[i + 5] << 8) | (input[i + 6] << 16) | (input[i + 7] << 24)) >>> 0;
+		const paddedSize = chunkSize + (chunkSize & 1);
+		if (i + 8 + paddedSize > input.length) return input;
+
+		if (type !== 'EXIF' && type !== 'XMP ') {
+			out.set(input.subarray(i, i + 8 + paddedSize), w);
+			w += 8 + paddedSize;
+		}
+		i += 8 + paddedSize;
+	}
+
+	const result = out.slice(0, w);
+	// Fix RIFF file size (bytes 4–7, little-endian) = total size − 8
+	const fileSize = w - 8;
+	result[4] = fileSize & 0xff;
+	result[5] = (fileSize >> 8) & 0xff;
+	result[6] = (fileSize >> 16) & 0xff;
+	result[7] = (fileSize >> 24) & 0xff;
+	return result;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export interface PotholePhoto {
 	created_at: string;
 	/** Full-resolution public URL, constructed server-side from storage_path. */
 	url: string;
-	/** Resized thumbnail URL via Supabase Image Transformation (800 px wide). Falls back to url if the feature is not enabled. */
+	/** Resized thumbnail URL via Supabase Image Transformation (800 px wide). The img element should onerror-fallback to url. */
 	thumbnailUrl: string;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,8 +10,10 @@ export interface PotholePhoto {
 	moderation_status: PhotoModerationStatus;
 	moderation_score: number | null;
 	created_at: string;
-	/** Constructed server-side from storage_path. */
+	/** Full-resolution public URL, constructed server-side from storage_path. */
 	url: string;
+	/** Resized thumbnail URL via Supabase Image Transformation (800 px wide). Falls back to url if the feature is not enabled. */
+	thumbnailUrl: string;
 }
 
 export interface Pothole {

--- a/src/lib/wards.ts
+++ b/src/lib/wards.ts
@@ -71,6 +71,9 @@ export interface GeoJSONFeature {
 }
 
 const wardCache: Partial<Record<City, GeoJSONFeature[]>> = {};
+// Timestamp of the last fetch failure per city. Successful fetches clear this.
+const wardCacheFailedAt: Partial<Record<City, number>> = {};
+const WARD_FAILURE_RETRY_MS = 5 * 60 * 1000; // retry failed fetches after 5 minutes
 
 // ── Geometry helpers ──────────────────────────────────────────────────────────
 
@@ -99,20 +102,29 @@ function pointInPolygon(lng: number, lat: number, geometry: GeoJSONFeature['geom
 // ── Ward lookup ───────────────────────────────────────────────────────────────
 
 export async function fetchWards(city: City): Promise<GeoJSONFeature[]> {
-	// Cache hit (success or previously failed) — return without a network call.
-	if (city in wardCache) return wardCache[city]!;
+	if (city in wardCache) {
+		// Success cache — features are permanent; never re-fetch.
+		if (wardCache[city]!.length > 0) return wardCache[city]!;
+		// Failure cache — hold for 5 min to prevent thundering herd, then retry.
+		if (Date.now() - (wardCacheFailedAt[city] ?? 0) < WARD_FAILURE_RETRY_MS) {
+			return wardCache[city]!;
+		}
+	}
 	try {
 		const { url } = WARD_SOURCES[city];
 		const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
 		if (!res.ok) {
-			wardCache[city] = []; // Cache failure to prevent thundering herd on retry
+			wardCache[city] = [];
+			wardCacheFailedAt[city] = Date.now();
 			return [];
 		}
 		const geojson = await res.json();
 		wardCache[city] = geojson.features ?? [];
+		delete wardCacheFailedAt[city];
 		return wardCache[city]!;
 	} catch {
-		wardCache[city] = []; // Network error — cache empty to avoid repeated fetches
+		wardCache[city] = [];
+		wardCacheFailedAt[city] = Date.now();
 		return [];
 	}
 }

--- a/src/lib/wards.ts
+++ b/src/lib/wards.ts
@@ -99,13 +99,22 @@ function pointInPolygon(lng: number, lat: number, geometry: GeoJSONFeature['geom
 // ── Ward lookup ───────────────────────────────────────────────────────────────
 
 export async function fetchWards(city: City): Promise<GeoJSONFeature[]> {
-	if (wardCache[city]) return wardCache[city]!;
-	const { url } = WARD_SOURCES[city];
-	const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
-	if (!res.ok) return [];
-	const geojson = await res.json();
-	wardCache[city] = geojson.features ?? [];
-	return wardCache[city]!;
+	// Cache hit (success or previously failed) — return without a network call.
+	if (city in wardCache) return wardCache[city]!;
+	try {
+		const { url } = WARD_SOURCES[city];
+		const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+		if (!res.ok) {
+			wardCache[city] = []; // Cache failure to prevent thundering herd on retry
+			return [];
+		}
+		const geojson = await res.json();
+		wardCache[city] = geojson.features ?? [];
+		return wardCache[city]!;
+	} catch {
+		wardCache[city] = []; // Network error — cache empty to avoid repeated fetches
+		return [];
+	}
 }
 
 export async function lookupWard(lat: number, lng: number): Promise<Councillor | null> {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,9 +1,21 @@
 import { supabase } from '$lib/supabase';
+import { logError } from '$lib/server/observability';
 import type { LayoutServerLoad } from './$types';
+
+type Counts = { reported: number; filled: number };
+
+let cachedCounts: Counts | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 60_000;
 
 export const load: LayoutServerLoad = async () => {
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
 		return { counts: { reported: 0, filled: 0 } };
+	}
+
+	const now = Date.now();
+	if (cachedCounts && now - cacheTimestamp < CACHE_TTL_MS) {
+		return { counts: cachedCounts };
 	}
 
 	try {
@@ -20,17 +32,18 @@ export const load: LayoutServerLoad = async () => {
 				.eq('status', 'filled')
 		]);
 
-		if (reportedResult.error) console.error('Supabase load error (reported count):', reportedResult.error);
-		if (filledResult.error) console.error('Supabase load error (filled count):', filledResult.error);
+		if (reportedResult.error) logError('layout', 'Supabase load error (reported count)', reportedResult.error);
+		if (filledResult.error) logError('layout', 'Supabase load error (filled count)', filledResult.error);
 
-		return {
-			counts: {
-				reported: reportedResult.count ?? 0,
-				filled: filledResult.count ?? 0
-			}
+		const counts: Counts = {
+			reported: reportedResult.count ?? 0,
+			filled: filledResult.count ?? 0
 		};
+		cachedCounts = counts;
+		cacheTimestamp = now;
+		return { counts };
 	} catch (e) {
-		console.error('Supabase load exception:', e);
-		return { counts: { reported: 0, filled: 0 } };
+		logError('layout', 'Supabase load exception', e instanceof Error ? e : new Error(String(e)));
+		return { counts: cachedCounts ?? { reported: 0, filled: 0 } };
 	}
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as Sentry from '@sentry/sveltekit';
 	import { goto } from '$app/navigation';
 	import HomeIntroCard from '$lib/components/HomeIntroCard.svelte';
 	import Icon from '$lib/components/Icon.svelte';
@@ -243,7 +244,7 @@
 			layers.wards = true;
 		} catch (err) {
 			toastError('Could not load ward boundaries. Try again later.');
-			console.error('[ward heatmap]', err);
+			Sentry.captureException(err, { tags: { area: 'ward-heatmap' } });
 		} finally {
 			wardLoading = false;
 		}
@@ -397,9 +398,13 @@
 
 					// Move marker from reported layer to filled layer.
 					if (result.ok) {
-						clientPotholes = potholes.map((pothole) =>
-							pothole.id === id ? { ...pothole, status: 'filled', filled_at: new Date().toISOString() } : pothole
-						);
+						// Targeted delta: mutate only the changed element so $derived consumers
+						// don't recalculate the full array on every fill action.
+						if (!clientPotholes) clientPotholes = (potholes as Pothole[]).slice();
+						const idx = clientPotholes.findIndex((p) => p.id === id);
+						if (idx !== -1) {
+							clientPotholes[idx] = { ...clientPotholes[idx], status: 'filled', filled_at: new Date().toISOString() };
+						}
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const marker = (e as any).popup._source;
 						clusterGroups['reported']?.removeLayer(marker);
@@ -473,6 +478,24 @@
 </svelte:head>
 
 <h1 class="sr-only">Waterloo Region Pothole Map</h1>
+
+<aside class="sr-only" aria-label="Pothole list">
+	<h2>Active potholes ({liveReportedCount})</h2>
+	{#if liveReportedCount === 0}
+		<p>No active potholes reported.</p>
+	{:else}
+		<ul>
+			{#each potholes.filter(p => p.status === 'reported').sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)) as pothole (pothole.id)}
+				<li>
+					<a href="/hole/{pothole.id}">
+						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
+						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</aside>
 
 <div class="relative w-full isolate" style="height: calc(100dvh - 57px - env(safe-area-inset-top))">
 	<div bind:this={mapEl} class="w-full h-full bg-zinc-900"></div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -492,7 +492,7 @@
 			<div
 				class="absolute top-4 left-4 right-4 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 z-[1001] flex flex-wrap items-center gap-2 sm:gap-3 bg-zinc-950 border border-sky-600 rounded-xl px-4 py-3 shadow-xl"
 			>
-				<span class="text-sm text-white grow" aria-live="polite" aria-atomic="true">
+				<span class="text-sm text-white grow" role="status" aria-live="polite" aria-atomic="true">
 					Tap the map where the pothole is
 				</span>
 				{#if reportLatLng}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,6 +42,13 @@
 			.slice(0, 4)
 	);
 
+	// Pre-sorted list for the sr-only aside — avoids inline sort on every render.
+	let reportedPotholesSorted = $derived(
+		potholes
+			.filter((p) => p.status === 'reported')
+			.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+	);
+
 	// Report-here pin-drop mode
 	let reportMode = $state(false);
 	let reportLatLng = $state<{ lat: number; lng: number } | null>(null);
@@ -485,9 +492,14 @@
 		<p>No active potholes reported.</p>
 	{:else}
 		<ul>
-			{#each potholes.filter(p => p.status === 'reported').sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)) as pothole (pothole.id)}
+			{#each reportedPotholesSorted as pothole (pothole.id)}
 				<li>
-					<a href="/hole/{pothole.id}">
+					<!-- Skip-link pattern: the link becomes a fixed overlay on keyboard focus
+					     so sighted keyboard users see where focus is. -->
+					<a
+						href="/hole/{pothole.id}"
+						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-zinc-950 focus:text-sky-400 focus:px-4 focus:py-2 focus:rounded-lg focus:border focus:border-zinc-700 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-sky-500"
+					>
 						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'}
 					</a>

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -14,6 +14,7 @@ import {
 import { generateCsrfToken, CSRF_COOKIE } from '$lib/server/admin-csrf';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 export const load: PageServerLoad = async ({ cookies, url }) => {
 	// Redirect logged-in users away from login page
 	const sessionId = cookies.get(SESSION_COOKIE);
@@ -176,12 +177,17 @@ export const actions: Actions = {
 			// multiple simultaneously valid tokens that collectively expand the
 			// attacker's TOTP-guess window.
 			const now = new Date().toISOString();
-			await getAdminClient()
+			const { error: invalidateError } = await getAdminClient()
 				.from('admin_mfa_challenges')
 				.update({ used: true, used_at: now })
 				.eq('user_id', user.id)
 				.eq('used', false)
 				.gt('expires_at', now);
+
+			if (invalidateError) {
+				logError('admin/login', 'Failed to invalidate prior MFA challenges', invalidateError, { userId: user.id });
+				return fail(500, { error: 'Login failed. Please try again.', email });
+			}
 
 			// M2 fix: token is stored in an HttpOnly cookie rather than the URL query string.
 			// A URL token leaks into browser history, server logs, and Referer headers.

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -171,6 +171,18 @@ export const actions: Actions = {
 			}
 
 			// MFA required — create challenge.
+			// SEC-1 fix: invalidate any existing valid challenges for this user before
+			// inserting a new one. Without this, rapid repeat submissions accumulate
+			// multiple simultaneously valid tokens that collectively expand the
+			// attacker's TOTP-guess window.
+			const now = new Date().toISOString();
+			await getAdminClient()
+				.from('admin_mfa_challenges')
+				.update({ used: true, used_at: now })
+				.eq('user_id', user.id)
+				.eq('used', false)
+				.gt('expires_at', now);
+
 			// M2 fix: token is stored in an HttpOnly cookie rather than the URL query string.
 			// A URL token leaks into browser history, server logs, and Referer headers.
 			const mfaToken = crypto.randomUUID();

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { env } from '$env/dynamic/private';
 import { z } from 'zod';
 import { verifyPassword, hashToken } from '$lib/server/admin-crypto';
 import {

--- a/src/routes/admin/login/mfa/+page.server.ts
+++ b/src/routes/admin/login/mfa/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { env } from '$env/dynamic/private';
 import { verifyTotpCode } from '$lib/server/admin-totp';
 import { decryptTotpSecret, verifyBackupCode, hashToken } from '$lib/server/admin-crypto';
 import {

--- a/src/routes/api/admin/auth/mfa/verify/+server.ts
+++ b/src/routes/api/admin/auth/mfa/verify/+server.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { env } from '$env/dynamic/private';
 import { z } from 'zod';
 import { verifyTotpCode } from '$lib/server/admin-totp';
 import {

--- a/src/routes/api/export.csv/+server.ts
+++ b/src/routes/api/export.csv/+server.ts
@@ -88,7 +88,8 @@ export const GET: RequestHandler = async ({ request }) => {
 		);
 		return t > max ? t : max;
 	}, 0);
-	const lastModified = new Date(lastModifiedMs || Date.now()).toUTCString();
+	// Use epoch (not Date.now()) when empty so the value is stable across requests.
+	const lastModified = new Date(lastModifiedMs).toUTCString();
 
 	// 304 Not Modified: skip sending the body if the CDN/client has current data.
 	const ifModifiedSince = request.headers.get('if-modified-since');
@@ -98,7 +99,8 @@ export const GET: RequestHandler = async ({ request }) => {
 			headers: {
 				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
 				'Last-Modified': lastModified,
-				'Access-Control-Allow-Origin': '*'
+				'Access-Control-Allow-Origin': '*',
+				'Cross-Origin-Resource-Policy': 'cross-origin'
 			}
 		});
 	}

--- a/src/routes/api/export.csv/+server.ts
+++ b/src/routes/api/export.csv/+server.ts
@@ -64,7 +64,7 @@ function toRow(p: Row): string {
 	}).join(',');
 }
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
 	// Export all publicly visible potholes — pending suppressed (not confirmed).
 	// The anon key SELECT policy on `potholes` already excludes no rows beyond RLS,
 	// so we filter status explicitly to match the public intent.
@@ -78,6 +78,31 @@ export const GET: RequestHandler = async () => {
 	if (dbError) throw error(500, 'Failed to load data');
 
 	const rows = data ?? [];
+
+	// Compute Last-Modified from the most recent event in this export.
+	const lastModifiedMs = rows.reduce((max, p) => {
+		const t = Math.max(
+			new Date(p.created_at).getTime(),
+			p.filled_at ? new Date(p.filled_at).getTime() : 0,
+			p.expired_at ? new Date(p.expired_at).getTime() : 0
+		);
+		return t > max ? t : max;
+	}, 0);
+	const lastModified = new Date(lastModifiedMs || Date.now()).toUTCString();
+
+	// 304 Not Modified: skip sending the body if the CDN/client has current data.
+	const ifModifiedSince = request.headers.get('if-modified-since');
+	if (ifModifiedSince && new Date(ifModifiedSince) >= new Date(lastModified)) {
+		return new Response(null, {
+			status: 304,
+			headers: {
+				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+				'Last-Modified': lastModified,
+				'Access-Control-Allow-Origin': '*'
+			}
+		});
+	}
+
 	const header = COLUMNS.join(',');
 	const csv = [header, ...rows.map((p) => toRow(p as Row))].join('\r\n');
 
@@ -85,7 +110,8 @@ export const GET: RequestHandler = async () => {
 		headers: {
 			'Content-Type': 'text/csv; charset=utf-8',
 			'Content-Disposition': 'attachment; filename="fillthehole-potholes.csv"',
-			'Cache-Control': 'public, max-age=300',
+			'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+			'Last-Modified': lastModified,
 			'Access-Control-Allow-Origin': '*',
 			'Cross-Origin-Resource-Policy': 'cross-origin',
 			'X-Row-Limit': String(ROW_LIMIT),

--- a/src/routes/api/feed.json/+server.ts
+++ b/src/routes/api/feed.json/+server.ts
@@ -12,7 +12,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	// M7: Capped at 500 records to prevent unbounded response growth.
 	const { data, error } = await supabase
 		.from('potholes')
-		.select('id, created_at, lat, lng, address, description, status, filled_at')
+		.select('id, created_at, lat, lng, address, description, status, filled_at, expired_at')
 		.neq('status', 'pending')
 		.order('created_at', { ascending: false })
 		.limit(500);
@@ -32,14 +32,18 @@ export const GET: RequestHandler = async ({ request }) => {
 	}));
 
 	// Compute Last-Modified from the most-recent event in this response.
+	// Include expired_at so expiry transitions (reported → expired) bust the cache.
+	// Fall back to the epoch rather than Date.now() so empty feeds return a stable
+	// Last-Modified and clients can receive 304s on subsequent requests.
 	const lastModifiedMs = potholes.reduce((max, p) => {
 		const t = Math.max(
 			new Date(p.created_at).getTime(),
-			p.filled_at ? new Date(p.filled_at).getTime() : 0
+			p.filled_at   ? new Date(p.filled_at).getTime()   : 0,
+			p.expired_at  ? new Date(p.expired_at).getTime()  : 0
 		);
 		return t > max ? t : max;
 	}, 0);
-	const lastModified = new Date(lastModifiedMs || Date.now()).toUTCString();
+	const lastModified = new Date(lastModifiedMs).toUTCString();
 
 	// 304 Not Modified: skip sending the body if the CDN/client has current data.
 	const ifModifiedSince = request.headers.get('if-modified-since');
@@ -49,7 +53,8 @@ export const GET: RequestHandler = async ({ request }) => {
 			headers: {
 				'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
 				'Last-Modified': lastModified,
-				'Access-Control-Allow-Origin': '*'
+				'Access-Control-Allow-Origin': '*',
+				'Cross-Origin-Resource-Policy': 'cross-origin'
 			}
 		});
 	}

--- a/src/routes/api/feed.json/+server.ts
+++ b/src/routes/api/feed.json/+server.ts
@@ -7,7 +7,7 @@ import { roundPublicCoord } from '$lib/geo';
 
 const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
 	// M2: Removed wanksy_at (internal legacy field not for public consumption).
 	// M7: Capped at 500 records to prevent unbounded response growth.
 	const { data, error } = await supabase
@@ -31,6 +31,29 @@ export const GET: RequestHandler = async () => {
 		description: p.description ? decodeHtmlEntities(p.description) : null
 	}));
 
+	// Compute Last-Modified from the most-recent event in this response.
+	const lastModifiedMs = potholes.reduce((max, p) => {
+		const t = Math.max(
+			new Date(p.created_at).getTime(),
+			p.filled_at ? new Date(p.filled_at).getTime() : 0
+		);
+		return t > max ? t : max;
+	}, 0);
+	const lastModified = new Date(lastModifiedMs || Date.now()).toUTCString();
+
+	// 304 Not Modified: skip sending the body if the CDN/client has current data.
+	const ifModifiedSince = request.headers.get('if-modified-since');
+	if (ifModifiedSince && new Date(ifModifiedSince) >= new Date(lastModified)) {
+		return new Response(null, {
+			status: 304,
+			headers: {
+				'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
+				'Last-Modified': lastModified,
+				'Access-Control-Allow-Origin': '*'
+			}
+		});
+	}
+
 	return json(
 		{
 			generated: new Date().toISOString(),
@@ -39,7 +62,8 @@ export const GET: RequestHandler = async () => {
 		},
 		{
 			headers: {
-				'Cache-Control': 'public, max-age=60',
+				'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
+				'Last-Modified': lastModified,
 				'Access-Control-Allow-Origin': '*',
 				// L8: This feed is intentionally public/cross-origin (CORS * above).
 				// Opt out of the same-site default set in hooks.server.ts.

--- a/src/routes/api/feed.xml/+server.ts
+++ b/src/routes/api/feed.xml/+server.ts
@@ -96,8 +96,8 @@ export const GET: RequestHandler = async ({ request }) => {
 	);
 
 	const potholes = merged.slice(0, 100);
-	const now = new Date().toUTCString();
-	const lastBuild = potholes[0] ? new Date(eventTime(potholes[0])).toUTCString() : now;
+	// Use epoch when empty so Last-Modified is stable and 304s remain effective.
+	const lastBuild = potholes[0] ? new Date(eventTime(potholes[0])).toUTCString() : new Date(0).toUTCString();
 
 	const items = potholes
 		.map((p) => {
@@ -139,7 +139,8 @@ ${items}
 			headers: {
 				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
 				'Last-Modified': lastBuild,
-				'Access-Control-Allow-Origin': '*'
+				'Access-Control-Allow-Origin': '*',
+				'Cross-Origin-Resource-Policy': 'cross-origin'
 			}
 		});
 	}

--- a/src/routes/api/feed.xml/+server.ts
+++ b/src/routes/api/feed.xml/+server.ts
@@ -60,7 +60,7 @@ function eventTime(p: { status: string; created_at: string; filled_at: string | 
 	return p.filled_at ?? p.created_at;
 }
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
 	// Fetch the 50 most-recently-reported (by created_at) and 50 most-recently-filled
 	// potholes separately so a fill today isn't buried by older reports. Merge and
 	// re-sort by event time (created_at for reported, filled_at for filled).
@@ -130,10 +130,25 @@ ${items}
   </channel>
 </rss>`;
 
+	// 304 Not Modified: skip sending the body if the CDN/client has current data.
+	// lastBuild is already the most recent event time in this feed.
+	const ifModifiedSince = request.headers.get('if-modified-since');
+	if (ifModifiedSince && new Date(ifModifiedSince) >= new Date(lastBuild)) {
+		return new Response(null, {
+			status: 304,
+			headers: {
+				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+				'Last-Modified': lastBuild,
+				'Access-Control-Allow-Origin': '*'
+			}
+		});
+	}
+
 	return new Response(xml, {
 		headers: {
 			'Content-Type': 'application/rss+xml; charset=utf-8',
-			'Cache-Control': 'public, max-age=300',
+			'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+			'Last-Modified': lastBuild,
 			'Access-Control-Allow-Origin': '*',
 			'Cross-Origin-Resource-Policy': 'cross-origin'
 		}

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { notify } from '$lib/server/pushover';
 import { logError } from '$lib/server/observability';
-import { stripJpegMetadata } from '$lib/server/exif-strip';
+import { stripJpegMetadata, stripPngMetadata, stripWebpMetadata } from '$lib/server/exif-strip';
 import { getAdminClient } from '$lib/server/supabase';
 
 type DetectedMimeType = 'image/jpeg' | 'image/png' | 'image/webp';
@@ -208,11 +208,14 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	}
 	const { mimeType, ext } = detectedType;
 
-	// Strip EXIF/XMP/ICC from JPEGs before the bytes are stored or moderated.
-	// Mobile cameras embed GPS coords, device serials, and timestamps that
-	// defeat the write-time coord rounding applied to the DB row. PNG/WebP
-	// rarely carry camera EXIF from mobile uploads and pass through untouched.
-	const cleanBytes = mimeType === 'image/jpeg' ? stripJpegMetadata(rawBytes) : rawBytes;
+	// Strip embedded metadata before storage and before sending bytes to
+	// SightEngine. Mobile cameras embed GPS coords (sub-metre precision),
+	// device serials, and timestamps — removing them ensures stored files
+	// don't reveal reporter locations beyond the rounded DB coords.
+	let cleanBytes: Uint8Array;
+	if (mimeType === 'image/jpeg') cleanBytes = stripJpegMetadata(rawBytes);
+	else if (mimeType === 'image/png') cleanBytes = stripPngMetadata(rawBytes);
+	else cleanBytes = stripWebpMetadata(rawBytes);
 
 	const photoId = crypto.randomUUID();
 	const storagePath = `${idParsed.data}/${photoId}.${ext}`;

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -46,7 +46,8 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		{
 			endpoint: parsed.data.endpoint,
 			p256dh: parsed.data.keys.p256dh,
-			auth: parsed.data.keys.auth
+			auth: parsed.data.keys.auth,
+			last_used_at: new Date().toISOString()
 		},
 		{ onConflict: 'endpoint' }
 	);

--- a/src/routes/hole/[id]/+page.server.ts
+++ b/src/routes/hole/[id]/+page.server.ts
@@ -232,15 +232,22 @@ export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
   // Only expose photos publicly when admin has explicitly published them for this pothole.
   // A reported (live) pothole does not imply its photos are visible.
   const photos: PotholePhoto[] = pothole.photos_published
-    ? (photosResult.data ?? []).map((p) => ({
-        ...p,
-        pothole_id: params.id,
-        moderation_status: "approved" as const,
-        moderation_score: null,
-        url: supabase.storage
-          .from("pothole-photos")
-          .getPublicUrl(p.storage_path).data.publicUrl,
-      }))
+    ? (photosResult.data ?? []).map((p) => {
+        const storage = supabase.storage.from("pothole-photos");
+        return {
+          ...p,
+          pothole_id: params.id,
+          moderation_status: "approved" as const,
+          moderation_score: null,
+          url: storage.getPublicUrl(p.storage_path).data.publicUrl,
+          // Supabase Image Transformation (Pro feature): serve an 800px-wide
+          // JPEG for the thumbnail strip to avoid loading multi-megapixel originals.
+          // Falls back to the original URL if Image Transformation is not enabled.
+          thumbnailUrl: storage.getPublicUrl(p.storage_path, {
+            transform: { width: 800, quality: 80, resize: 'contain' }
+          }).data.publicUrl,
+        };
+      })
     : [];
 
   const hitCount = hitCountResult.count ?? 0;

--- a/src/routes/hole/[id]/+page.server.ts
+++ b/src/routes/hole/[id]/+page.server.ts
@@ -241,8 +241,8 @@ export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
           moderation_score: null,
           url: storage.getPublicUrl(p.storage_path).data.publicUrl,
           // Supabase Image Transformation (Pro feature): serve an 800px-wide
-          // JPEG for the thumbnail strip to avoid loading multi-megapixel originals.
-          // Falls back to the original URL if Image Transformation is not enabled.
+          // resized image for the thumbnail strip. The img onerror handler falls
+          // back to url if transformation is unavailable.
           thumbnailUrl: storage.getPublicUrl(p.storage_path, {
             transform: { width: 800, quality: 80, resize: 'contain' }
           }).data.publicUrl,

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -72,6 +72,28 @@
 			: `Unfilled pothole at ${pothole.address || 'this location'} in Waterloo Region. Help get it filled.`
 	);
 
+	let jsonLd = $derived(
+		JSON.stringify({
+			'@context': 'https://schema.org',
+			'@type': 'Place',
+			name: `Pothole at ${pothole.address || 'unknown location'}`,
+			description: ogDescription,
+			geo: {
+				'@type': 'GeoCoordinates',
+				latitude: pothole.lat,
+				longitude: pothole.lng
+			},
+			url: `${origin}/hole/${pothole.id}`,
+			dateCreated: pothole.created_at,
+			...(pothole.filled_at ? { dateModified: pothole.filled_at } : {}),
+			additionalProperty: [
+				{ '@type': 'PropertyValue', name: 'status', value: pothole.status },
+				{ '@type': 'PropertyValue', name: 'confirmedBy', value: pothole.confirmed_count }
+			]
+		// Prevent closing-tag sequences from ending this inline script prematurely.
+		}).replace(new RegExp('<' + '/script', 'gi'), '<\\/script')
+	);
+
 	let submitting = $state(false);
 	let showFilledForm = $state(false);
 
@@ -257,6 +279,7 @@
 	<meta property="og:image:height" content="630" />
 	<meta property="og:url" content="{origin}/hole/{pothole.id}" />
 	<meta property="og:type" content="website" />
+	{@html `<script type="application/ld+json">${jsonLd}</script>`}
 </svelte:head>
 
 <div class="max-w-2xl mx-auto px-4 py-8 space-y-6" inert={lightboxIndex !== null}>
@@ -770,13 +793,19 @@
 			</button>
 		{/if}
 
-		<!-- Image -->
+		<!-- Image — render current + ±1 adjacent so prev/next navigate instantly -->
 		<div role="presentation" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
-			<img
-				src={photos[lightboxIndex].url}
-				alt="Pothole at {pothole.address || 'this location'} — photo {lightboxIndex + 1} of {photos.length}"
-				class="max-w-full max-h-[90vh] object-contain rounded-lg shadow-2xl"
-			/>
+			{#each photos as photo, i (photo.id)}
+				{#if Math.abs(i - lightboxIndex) <= 1}
+					<img
+						src={photo.url}
+						alt="Pothole at {pothole.address || 'this location'} — photo {i + 1} of {photos.length}"
+						class="max-w-full max-h-[90vh] object-contain rounded-lg shadow-2xl"
+						class:hidden={i !== lightboxIndex}
+						aria-hidden={i !== lightboxIndex}
+					/>
+				{/if}
+			{/each}
 		</div>
 
 		<!-- Next -->

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -504,7 +504,7 @@
 						aria-label="View photo {i + 1} of {photos.length}"
 					>
 						<img
-							src={photo.url}
+							src={photo.thumbnailUrl}
 							alt="Pothole at {pothole.address || 'this location'}"
 							class="w-full object-cover aspect-video"
 							loading="lazy"

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -72,7 +72,13 @@
 			: `Unfilled pothole at ${pothole.address || 'this location'} in Waterloo Region. Help get it filled.`
 	);
 
-	let jsonLd = $derived(
+	// Build the full JSON-LD <script> block as a plain string in TypeScript context.
+	// {@html jsonLdScript} then takes a simple identifier — svelte-eslint-parser handles
+	// that without issue. Embedding the template literal directly in {@html} caused the
+	// parser to enter "script element" mode on seeing "<script type=..." and then fail
+	// on the ${} expression inside it.
+	let jsonLdScript = $derived(
+		'<script type="application/ld+json">' +
 		JSON.stringify({
 			'@context': 'https://schema.org',
 			'@type': 'Place',
@@ -90,8 +96,8 @@
 				{ '@type': 'PropertyValue', name: 'status', value: pothole.status },
 				{ '@type': 'PropertyValue', name: 'confirmedBy', value: pothole.confirmed_count }
 			]
-		// Prevent closing-tag sequences from ending this inline script prematurely.
-		}).replace(new RegExp('<' + '/script', 'gi'), '<\\/script')
+		}).replace(new RegExp('<' + '/script', 'gi'), '<\\/script') +
+		'<' + '/script>'
 	);
 
 	let submitting = $state(false);
@@ -279,7 +285,8 @@
 	<meta property="og:image:height" content="630" />
 	<meta property="og:url" content="{origin}/hole/{pothole.id}" />
 	<meta property="og:type" content="website" />
-	{@html `<script type="application/ld+json">${jsonLd}</script>`}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html jsonLdScript}
 </svelte:head>
 
 <div class="max-w-2xl mx-auto px-4 py-8 space-y-6" inert={lightboxIndex !== null}>

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -531,6 +531,7 @@
 							alt="Pothole at {pothole.address || 'this location'}"
 							class="w-full object-cover aspect-video"
 							loading="lazy"
+							onerror={(e) => { (e.currentTarget as HTMLImageElement).src = photo.url; }}
 						/>
 					</button>
 				{/each}

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -538,7 +538,7 @@
 							alt="Pothole at {pothole.address || 'this location'}"
 							class="w-full object-cover aspect-video"
 							loading="lazy"
-							onerror={(e) => { (e.currentTarget as HTMLImageElement).src = photo.url; }}
+							onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.onerror = null; img.src = photo.url; }}
 						/>
 					</button>
 				{/each}

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -435,7 +435,7 @@
 						type="button"
 						onclick={() => (locationMode = tab.mode)}
 						onkeydown={(event) => handleLocationTabKeydown(event, tab.mode)}
-						class="flex-1 py-1.5 px-2 rounded-md text-xs font-semibold transition-colors
+						class="flex-1 min-h-[44px] py-1.5 px-2 rounded-md text-xs font-semibold transition-colors
 							{locationMode === tab.mode
 								? 'bg-zinc-700 text-white'
 								: 'text-zinc-400 hover:text-zinc-200'}"
@@ -531,7 +531,7 @@
 								<li>
 									<button
 										type="button"
-										class="w-full text-left px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-700"
+										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-zinc-200 hover:bg-zinc-700"
 										onclick={() => selectSuggestion(s)}
 									>
 										{s.display_name}
@@ -650,7 +650,7 @@
 			<p class="text-xs text-zinc-400">Photos are reviewed before appearing publicly. Only take one if you're safely off the road.</p>
 		</div>
 
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3" aria-live="polite" aria-atomic="true">
+		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3" role="status" aria-live="polite" aria-atomic="true">
 			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
 				<Icon name="check-circle" size={14} class={hasLocation ? 'text-green-400' : 'text-zinc-400'} />
 				Ready to submit

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -499,7 +499,7 @@
 					<p class="flex items-center gap-1.5 text-xs text-zinc-400">
 						<Icon name="map-pin" size={11} class="shrink-0 text-zinc-400" />
 						{address}
-						<span aria-hidden="true">· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" tabindex="-1" class="underline hover:text-zinc-300">OpenStreetMap</a></span>
+						<span>· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="underline hover:text-zinc-300">OpenStreetMap</a></span>
 					</p>
 				{:else if gpsStatus === 'got'}
 					<p class="text-xs text-zinc-400">Looking up address via OpenStreetMap…</p>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -120,6 +120,10 @@
 
 	function onAddressInput() {
 		if (addressDebounce) clearTimeout(addressDebounce);
+		// Clear any previously selected location — user is searching for a new one.
+		lat = null;
+		lng = null;
+		address = null;
 		addressDebounce = setTimeout(() => searchAddress(addressQuery), 300);
 	}
 
@@ -523,7 +527,7 @@
 					/>
 					{#if addressSearching}
 						<p class="text-xs text-zinc-400 mt-1">Searching…</p>
-					{:else if !addressSearching && addressQuery.length > 2 && addressSuggestions.length === 0 && lat === null}
+					{:else if addressQuery.length > 2 && addressSuggestions.length === 0 && lat === null}
 						<p class="text-xs text-zinc-400 mt-1" role="status" aria-live="polite">No results found — try a different address or street name.</p>
 					{/if}
 					{#if addressSuggestions.length > 0}

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -499,7 +499,7 @@
 					<p class="flex items-center gap-1.5 text-xs text-zinc-400">
 						<Icon name="map-pin" size={11} class="shrink-0 text-zinc-400" />
 						{address}
-						<span class="text-zinc-600" aria-hidden="true">· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="underline hover:text-zinc-400">OpenStreetMap</a></span>
+						<span aria-hidden="true">· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" tabindex="-1" class="underline hover:text-zinc-300">OpenStreetMap</a></span>
 					</p>
 				{:else if gpsStatus === 'got'}
 					<p class="text-xs text-zinc-400">Looking up address via OpenStreetMap…</p>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -21,6 +21,7 @@
 	let lat = $state<number | null>(null);
 	let lng = $state<number | null>(null);
 	let gpsStatus = $state<'idle' | 'loading' | 'got' | 'error'>('idle');
+	let gpsAccuracy = $state<number | null>(null);
 	let address = $state<string | null>(null);
 	let severity = $state<string | null>(null);
 	let submitting = $state(false);
@@ -314,6 +315,7 @@
 		function onSuccess(pos: GeolocationPosition) {
 			lat = pos.coords.latitude;
 			lng = pos.coords.longitude;
+			gpsAccuracy = pos.coords.accuracy ?? null;
 			gpsStatus = 'got';
 			toast.success('Location locked in');
 			reverseGeocode(pos.coords.latitude, pos.coords.longitude);
@@ -469,7 +471,7 @@
 						Getting your location…
 					{:else if gpsStatus === 'got'}
 						<Icon name="check" size={15} strokeWidth={2.5} class="shrink-0" />
-						GPS locked
+						GPS locked{gpsAccuracy !== null ? ` · ±${Math.round(gpsAccuracy)}m` : ''}
 					{:else if gpsStatus === 'error'}
 						<Icon name="alert-triangle" size={15} class="shrink-0" />
 						GPS failed — retry
@@ -521,6 +523,8 @@
 					/>
 					{#if addressSearching}
 						<p class="text-xs text-zinc-400 mt-1">Searching…</p>
+					{:else if !addressSearching && addressQuery.length > 2 && addressSuggestions.length === 0 && lat === null}
+						<p class="text-xs text-zinc-400 mt-1" role="status" aria-live="polite">No results found — try a different address or street name.</p>
 					{/if}
 					{#if addressSuggestions.length > 0}
 						<ul

--- a/src/routes/stats/+page.server.ts
+++ b/src/routes/stats/+page.server.ts
@@ -44,16 +44,17 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	setHeaders({ 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' });
 
 	// Fetch potholes and pre-warm the ward boundary cache in parallel.
-	// lookupWard() re-uses these cached results for every per-pothole PIP call.
+	// fetchWards() now never rejects (errors are caught and cached as []) so
+	// Promise.all is safe here, but ward failures must not break the pothole query.
 	const [{ data, error }] = await Promise.all([
 		supabase
 			.from('potholes')
 			.select('id, created_at, lat, lng, status, filled_at, expired_at, address, confirmed_count')
 			.neq('status', 'pending')
 			.order('created_at', { ascending: false }),
-		fetchWards('kitchener'),
-		fetchWards('waterloo'),
-		fetchWards('cambridge')
+		fetchWards('kitchener').catch(() => []),
+		fetchWards('waterloo').catch(() => []),
+		fetchWards('cambridge').catch(() => [])
 	]);
 
 	if (error) {

--- a/src/routes/stats/+page.server.ts
+++ b/src/routes/stats/+page.server.ts
@@ -2,12 +2,23 @@ import { supabase } from '$lib/supabase';
 import { decodeHtmlEntities } from '$lib/escape';
 import type { PageServerLoad } from './$types';
 import type { Pothole } from '$lib/types';
+import { lookupWard, fetchWards, COUNCILLORS } from '$lib/wards';
 import { logError } from '$lib/server/observability';
 
-// Fixture pothole for E2E tests. Coordinates fall inside the polygon used in
-// ward-profile.spec.ts (43.40–43.45 lat, -80.55 to -80.50 lng) so ward rows
-// render and the link-to-ward-profile test can find an <a href="/stats/ward/…">.
-const E2E_STATS_FIXTURE: Pothole[] = [
+// Stable ward definitions derived from the councillors list — no network call needed.
+export type WardDef = {
+	city: string; ward: number; key: string;
+	councillorName: string; councillorUrl: string;
+};
+
+const ALL_WARDS: WardDef[] = COUNCILLORS.map(c => ({
+	city: c.city, ward: c.ward, key: `${c.city}-${c.ward}`,
+	councillorName: c.name, councillorUrl: c.url
+}));
+
+// Fixture pothole for E2E tests. Coordinates fall inside Kitchener Ward 6;
+// ward_key is hardcoded so tests don't hit real ArcGIS endpoints.
+const E2E_STATS_FIXTURE: Array<Pothole & { ward_key: string | null }> = [
 	{
 		id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
 		created_at: '2026-01-15T10:00:00.000Z',
@@ -19,26 +30,35 @@ const E2E_STATS_FIXTURE: Pothole[] = [
 		confirmed_count: 3,
 		filled_at: null,
 		expired_at: null,
-		photos_published: false
+		photos_published: false,
+		ward_key: 'kitchener-6'
 	}
 ];
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
-		return { potholes: url.searchParams.get('__fixture') === '1' ? E2E_STATS_FIXTURE : ([] as Pothole[]) };
+		const fixture = url.searchParams.get('__fixture') === '1' ? E2E_STATS_FIXTURE : [];
+		return { potholes: fixture, wards: ALL_WARDS };
 	}
 
 	setHeaders({ 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' });
 
-	const { data, error } = await supabase
-		.from('potholes')
-		.select('id, created_at, lat, lng, status, filled_at, expired_at, address, confirmed_count')
-		.neq('status', 'pending')
-		.order('created_at', { ascending: false });
+	// Fetch potholes and pre-warm the ward boundary cache in parallel.
+	// lookupWard() re-uses these cached results for every per-pothole PIP call.
+	const [{ data, error }] = await Promise.all([
+		supabase
+			.from('potholes')
+			.select('id, created_at, lat, lng, status, filled_at, expired_at, address, confirmed_count')
+			.neq('status', 'pending')
+			.order('created_at', { ascending: false }),
+		fetchWards('kitchener'),
+		fetchWards('waterloo'),
+		fetchWards('cambridge')
+	]);
 
 	if (error) {
 		logError('stats/load', 'Failed to load stats potholes', error);
-		return { potholes: [] as Pothole[] };
+		return { potholes: [] as Array<Pothole & { ward_key: string | null }>, wards: ALL_WARDS };
 	}
 
 	const potholes = (data ?? []).map((p) => ({
@@ -46,5 +66,13 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		address: p.address ? decodeHtmlEntities(p.address) : null
 	})) as Pothole[];
 
-	return { potholes };
+	// Assign ward keys for all potholes in parallel.
+	// Ward boundary data is now cached, so each call is synchronous PIP only.
+	const councillors = await Promise.all(potholes.map((p) => lookupWard(p.lat, p.lng)));
+	const potholesWithWards = potholes.map((p, i) => ({
+		...p,
+		ward_key: councillors[i] ? `${councillors[i]!.city}-${councillors[i]!.ward}` : null
+	}));
+
+	return { potholes: potholesWithWards, wards: ALL_WARDS };
 };

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -285,24 +285,24 @@
 		<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
 				<p class="text-xs text-zinc-500 uppercase tracking-wide">Total reported</p>
-				<p class="text-3xl font-bold text-white" aria-live="polite">{totalConfirmed}</p>
+				<p class="text-3xl font-bold text-white" role="status" aria-live="polite">{totalConfirmed}</p>
 				<p class="text-xs text-zinc-500">confirmed potholes</p>
 			</div>
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
 				<p class="text-xs text-zinc-500 uppercase tracking-wide">Currently open</p>
-				<p class="text-3xl font-bold text-orange-400" aria-live="polite">{totalOpen}</p>
+				<p class="text-3xl font-bold text-orange-400" role="status" aria-live="polite">{totalOpen}</p>
 				<p class="text-xs text-zinc-500">unfilled, on the map</p>
 			</div>
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
 				<p class="text-xs text-zinc-500 uppercase tracking-wide">Fill rate</p>
-				<p class="text-3xl font-bold text-sky-400" aria-live="polite">
+				<p class="text-3xl font-bold text-sky-400" role="status" aria-live="polite">
 					{fillRate === null ? '—' : `${fmt(fillRate, 0)}%`}
 				</p>
 				<p class="text-xs text-zinc-500">{totalFilled} of {totalConfirmed} filled</p>
 			</div>
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
 				<p class="text-xs text-zinc-500 uppercase tracking-wide">Avg days to fill</p>
-				<p class="text-3xl font-bold {avgDaysToFill === null ? 'text-zinc-500' : 'text-green-400'}" aria-live="polite">
+				<p class="text-3xl font-bold {avgDaysToFill === null ? 'text-zinc-500' : 'text-green-400'}" role="status" aria-live="polite">
 					{avgDaysToFill === null ? '—' : fmt(avgDaysToFill, 1)}
 				</p>
 				<p class="text-xs text-zinc-500">from report to fixed</p>
@@ -401,7 +401,7 @@
 		<div class="flex items-center justify-between mb-4 flex-wrap gap-2">
 			<h2 id="ward-heading" class="section-title text-lg text-white">By ward</h2>
 			{#if wardLoading}
-				<span class="text-xs text-zinc-500 animate-pulse" aria-live="polite">Loading ward boundaries…</span>
+				<span class="text-xs text-zinc-500 animate-pulse" role="status" aria-live="polite">Loading ward boundaries…</span>
 			{/if}
 		</div>
 

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -33,6 +33,12 @@
 	let totalOpen      = $derived(filtered.filter(p => p.status === 'reported' || p.status === 'expired').length);
 	let fillRate       = $derived(totalConfirmed === 0 ? null : (totalFilled / totalConfirmed) * 100);
 
+	// True when potholes exist in the window but none could be assigned a ward —
+	// indicates an ArcGIS/ward-boundary fetch failure rather than "no data".
+	let wardLookupFailed = $derived(
+		filtered.length > 0 && filtered.every((p) => (p as { ward_key: string | null }).ward_key === null)
+	);
+
 	let avgDaysToFill = $derived.by(() => {
 		const done = filtered.filter(p => p.status === 'filled' && p.filled_at);
 		if (!done.length) return null;
@@ -368,7 +374,11 @@
 			<h2 id="ward-heading" class="section-title text-lg text-white">By ward</h2>
 		</div>
 
-		{#if wardRows.length === 0}
+		{#if wardLookupFailed}
+			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm" role="status">
+				Ward boundary data is temporarily unavailable. City-level totals above are unaffected.
+			</div>
+		{:else if wardRows.length === 0}
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
 				No ward data available for the selected window.
 			</div>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { format } from 'date-fns';
 	import type { PageData } from './$types';
-	import type { Pothole } from '$lib/types';
-	import { COUNCILLORS } from '$lib/wards';
-	import { inWardFeature } from '$lib/geo';
 	import Icon from '$lib/components/Icon.svelte';
 	import { wardGrade } from '$lib/ward-grade';
 
 	let { data }: { data: PageData } = $props();
-	let allPotholes = $derived(data.potholes as Pothole[]);
+	let allPotholes = $derived(data.potholes);
 
 	// ── Time filter ────────────────────────────────────────────────────────────
 	type WindowDays = 30 | 90 | 365 | null;
@@ -74,23 +70,6 @@
 	);
 
 	// ── Ward leaderboard ───────────────────────────────────────────────────────
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let wardGeojson = $state<any>(null);
-	let wardLoading = $state(false);
-	let wardError   = $state(false);
-
-	onMount(async () => {
-		wardLoading = true;
-		try {
-			const res = await fetch('/api/wards.geojson');
-			if (!res.ok) throw new Error(`${res.status}`);
-			wardGeojson = await res.json();
-		} catch {
-			wardError = true;
-		} finally {
-			wardLoading = false;
-		}
-	});
 
 	interface WardRow {
 		city: string; ward: number; key: string;
@@ -107,45 +86,32 @@
 		if (sortCol === col) { sortAsc = !sortAsc; } else { sortCol = col; sortAsc = false; }
 	}
 
+	// Ward keys were assigned server-side via point-in-polygon on load.
+	// Aggregation here is O(n) over filtered potholes with no GeoJSON fetch needed.
 	let wardRows = $derived.by((): WardRow[] => {
-		if (!wardGeojson?.features?.length) return [];
-
 		const stats: Record<string, WardRow> = {};
 		const filledTimes: Record<string, number[]> = {};
 
-		for (const f of wardGeojson.features) {
-			const city = String(f.properties?.CITY ?? '');
-			const ward = Number(f.properties?.WARDID_NORM ?? 0);
-			if (!city || !ward) continue;
-			const key = `${city}-${ward}`;
-			if (key in stats) continue;
-			const councillor = COUNCILLORS.find(c => c.city === city && c.ward === ward);
-			stats[key] = {
-				city, ward, key,
-				councillorName: councillor?.name ?? '—',
-				councillorUrl:  councillor?.url  ?? '',
+		for (const w of data.wards) {
+			stats[w.key] = {
+				city: w.city, ward: w.ward, key: w.key,
+				councillorName: w.councillorName, councillorUrl: w.councillorUrl,
 				open: 0, filled: 0, total: 0, fillRate: 0, avgDays: null
 			};
 		}
 
 		for (const p of filtered) {
-			for (const f of wardGeojson.features) {
-				if (!inWardFeature(p.lng, p.lat, f.geometry)) continue;
-				const city = String(f.properties?.CITY ?? '');
-				const ward = Number(f.properties?.WARDID_NORM ?? 0);
-				const key  = `${city}-${ward}`;
-				if (!(key in stats)) break;
-				stats[key].total++;
-				if (p.status === 'filled') {
-					stats[key].filled++;
-					if (p.filled_at) {
-						const days = (new Date(p.filled_at).getTime() - new Date(p.created_at).getTime()) / 86_400_000;
-						(filledTimes[key] ??= []).push(days);
-					}
-				} else if (p.status === 'reported' || p.status === 'expired') {
-					stats[key].open++;
+			const key = p.ward_key;
+			if (!key || !(key in stats)) continue;
+			stats[key].total++;
+			if (p.status === 'filled') {
+				stats[key].filled++;
+				if (p.filled_at) {
+					const days = (new Date(p.filled_at).getTime() - new Date(p.created_at).getTime()) / 86_400_000;
+					(filledTimes[key] ??= []).push(days);
 				}
-				break;
+			} else if (p.status === 'reported' || p.status === 'expired') {
+				stats[key].open++;
 			}
 		}
 
@@ -400,20 +366,9 @@
 	<section aria-labelledby="ward-heading">
 		<div class="flex items-center justify-between mb-4 flex-wrap gap-2">
 			<h2 id="ward-heading" class="section-title text-lg text-white">By ward</h2>
-			{#if wardLoading}
-				<span class="text-xs text-zinc-500 animate-pulse" role="status" aria-live="polite">Loading ward boundaries…</span>
-			{/if}
 		</div>
 
-		{#if wardError}
-			<div role="alert" class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
-				Could not load ward boundaries. Try refreshing the page.
-			</div>
-		{:else if wardLoading}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm animate-pulse" aria-busy="true">
-				Assigning wards…
-			</div>
-		{:else if wardRows.length === 0}
+		{#if wardRows.length === 0}
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
 				No ward data available for the selected window.
 			</div>

--- a/tests/e2e/map-page.spec.ts
+++ b/tests/e2e/map-page.spec.ts
@@ -293,7 +293,7 @@ test.describe("Map page smoke test", () => {
     await expect(marker).toBeVisible({ timeout: 10000 });
     await marker.click();
 
-    await expect(page.getByText("123 Test Street")).toBeVisible();
+    await expect(page.getByText("123 Test Street", { exact: true })).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Open details" }),
     ).toHaveAttribute("href", `/hole/${seededReportedPothole.id}`);


### PR DESCRIPTION
## Summary

Implements all items from the April 20 code review across 8 commits. Spans security fixes, performance improvements, accessibility compliance, and UX polish.

### Security
- **SEC-1**: Invalidate prior MFA challenges before issuing a new one — prevents token accumulation that widens the TOTP guess window

### Privacy
- **PRIV-3**: Disclose Nominatim use in the report form
- **PRIV-4**: Strip EXIF/GPS metadata from PNG and WebP uploads (JPEG was already covered)
- **PRIV-5**: Add `last_used_at` to push subscriptions + pg_cron purge after 180 days (PIPEDA data minimization)

### Performance
- **PERF-P1-2**: Cache layout COUNT queries for 60 s with in-memory TTL; replace bare `console.error` with `logError()`
- **PERF-P1-4/P2-2**: Move ward assignment server-side in the stats page — eliminates O(n×m) client-side PIP loop
- **PERF-P1-5**: Use Supabase Image Transformation for photo thumbnails (800px JPEG) instead of full-res originals
- **PERF-P1-6**: Add `Last-Modified` + 304 Not Modified handling to all three open-data feeds (`feed.json`, `feed.xml`, `export.csv`)
- **PERF-P2-1**: Replace full `.map()` reassignment with targeted in-place mutation when a pothole is marked filled
- **PERF-P2-3**: Lightbox pre-renders current ±1 adjacent photos so navigation is instant
- **PERF-P2-6**: Watchlist panel shows skeleton cards during load (prevents CLS); adds 6-item pagination

### Accessibility
- **A11Y-5**: Add `role="status"` to all `aria-live="polite"` regions (WCAG 4.1.3)
- **A11Y-7**: Fix ward toggle button aria-pressed semantics
- **A11Y-1**: Add `<aside class="sr-only">` on the map page listing all active potholes as navigable links — AODA screen reader compliance
- **UX-5**: Enforce 44×44 px minimum touch targets on location tabs and address suggestions (WCAG 2.5.8)

### UX
- **UX-3**: Show GPS accuracy (`±Xm`) inline after lock; "No results found" message for empty address searches
- **UX-4**: Replace `console.error` with `Sentry.captureException` for the ward heatmap failure path
- **UX-6**: Add schema.org `Place` JSON-LD to pothole detail pages (coordinates, status, confirmation count, dates)

### Code quality
- **CODE-1**: Centralize `getAdminClient()` in `$lib/server/supabase.ts`
- **CODE-4**: Fix geo utility types

## Not included (tracked separately)
- **CODE-5**: E2E tests for admin MFA flow, photo moderation chain, 25 m merge dedup
- **PRIV-7**: Breach notification SLA / incident response playbook
- **SEC-4**: CSRF token rotation per request (explicitly deferred — one-way-door)

## Test plan
- [ ] `npm run check` passes (0 errors, 0 warnings across 1605 files) ✅
- [ ] Report form: use GPS — button shows `GPS locked · ±Xm` after lock
- [ ] Report form: search an address with no Waterloo Region results — "No results found" appears
- [ ] Pothole detail page: view source, confirm `<script type="application/ld+json">` present with correct lat/lng
- [ ] Map page: use a screen reader, confirm the `<aside>` pothole list is reachable before the map
- [ ] Fill a pothole from the map popup — marker moves to filled layer; no full-page reactivity flash
- [ ] Open lightbox with 2+ photos — navigate prev/next, confirm instant transitions (adjacent photos preloaded)
- [ ] Add 7+ items to watchlist — confirm skeleton during load, "Show X more" pagination appears
- [ ] Ward heatmap: force a fetch error (DevTools → block `/api/wards.geojson`) — Sentry event fires (check Sentry dashboard)
- [ ] Open data feeds: `curl -I https://fillthehole.ca/api/feed.json` — `Last-Modified` header present; second request with `If-Modified-Since` returns 304

🤖 Generated with [Claude Code](https://claude.com/claude-code)