### PR TITLE
docs(PRIV-7): incident response playbook + PIPEDA breach notification SLA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ The repo is public. Treat every commit as permanent.
 
 When in doubt about whether something belongs in the repo, leave it out.
 
+## Workflow
+
+- **Create PRs proactively** — when a logical chunk of work is complete on a branch, open a PR without waiting to be asked. Use judgment: a multi-file feature, a security fix, or anything that should go through CI before merging warrants a PR. Trivial one-liner fixes on `main` may not.
+
 ## Stack
 
 - **SvelteKit** + TypeScript, **Svelte 5 runes** (`$state`, `$derived`, `$props`, `$effect`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ When in doubt about whether something belongs in the repo, leave it out.
 ## Workflow
 
 - **Create PRs proactively** — when a logical chunk of work is complete on a branch, open a PR without waiting to be asked. Use judgment: a multi-file feature, a security fix, or anything that should go through CI before merging warrants a PR. Trivial one-liner fixes on `main` may not.
+- **Security incidents** — follow `INCIDENT_RESPONSE.md` in the repo root. It covers PIPEDA breach notification obligations, per-secret rotation procedures, OPC reporting timelines, and post-incident review.
 
 ## Stack
 

--- a/INCIDENT_RESPONSE.md
+++ b/INCIDENT_RESPONSE.md
@@ -1,0 +1,271 @@
+# Incident Response Playbook — fillthehole.ca
+
+This document covers security incidents and privacy breaches for fillthehole.ca.
+It is the authoritative reference for PIPEDA breach notification obligations and
+step-by-step containment procedures.
+
+---
+
+## Quick Reference — First 5 Minutes
+
+```
+1. Rotate or revoke the affected secret/credential immediately (see §4)
+2. Determine if personal information was exposed (see §2)
+3. If yes, assess Real Risk of Significant Harm (see §3)
+4. If RROSH: report to OPC within 72 hours of determination (see §5)
+5. Open an incident record in a private doc/note (see §7)
+```
+
+---
+
+## 1. What Counts as a Security Incident
+
+Any of the following triggers this playbook:
+
+- A secret key (`.env` var) is committed to git, logged, or otherwise exposed
+- Unauthorized access to the Supabase project, storage bucket, or admin panel
+- An admin account credential is compromised (password leak, session theft)
+- A dependency vulnerability allows data extraction or RCE
+- Evidence of unexpected data access in Supabase logs or Netlify access logs
+- A pothole photo is served publicly before admin moderation approval
+- Any situation where personal information may have been accessed by an
+  unauthorized party
+
+---
+
+## 2. Personal Information Inventory
+
+Understanding what was potentially exposed is required to assess harm.
+
+| Data | Where stored | Sensitivity | Notes |
+|------|-------------|-------------|-------|
+| IP address hashes | `pothole_confirmations`, `pothole_photos`, `api_rate_limit_events`, `admin_auth_attempts`, `admin_audit_log`, `admin_sessions`, `admin_trusted_devices` | Medium | HMAC-SHA-256; reversible only if `IP_HASH_SECRET` is also exposed |
+| Push subscription endpoints + keys | `push_subscriptions` | Medium | Device-specific; attacker with VAPID private key can push arbitrary notifications |
+| Pothole photos | Supabase Storage (`pothole-photos` bucket) | Medium–High | EXIF stripped server-side, but photo content may be identifiable (faces, vehicles, property) |
+| Admin email addresses | `admin_users` | Low–Medium | Small set; not public user data |
+| Admin password hashes | `admin_users` | Medium | PBKDF2; not plaintext, but exposed hashes are brute-forceable offline |
+| Admin TOTP secrets | `admin_users.totp_secret` | High | AES-GCM encrypted; reversible if `TOTP_ENCRYPTION_KEY` is also exposed |
+| User-agent strings | `admin_sessions`, `admin_trusted_devices`, `admin_auth_attempts` | Low | Device fingerprinting risk only |
+| Pothole location + description | `potholes` | Low | Public data by design; coords rounded to ~11 m |
+
+**Public users submit no account data.** There is no email, name, or profile linked
+to a report. The only personal information from public users is the hashed IP address
+and any submitted photo.
+
+---
+
+## 3. PIPEDA — Real Risk of Significant Harm (RROSH) Assessment
+
+Under PIPEDA's Breach of Security Safeguards Regulations, you must report to the
+OPC (and notify affected individuals) if the breach creates a **real risk of
+significant harm**. RROSH is assessed by the sensitivity of the information and
+the probability a malicious actor could use it to cause harm.
+
+### RROSH = YES — report to OPC
+
+| Trigger | Why |
+|---------|-----|
+| `IP_HASH_SECRET` exposed | Attacker can reverse all stored ip_hash values to real IP addresses. IP addresses are personal information under PIPEDA. All users who reported, confirmed, or uploaded a photo are affected. |
+| `SUPABASE_SERVICE_ROLE_KEY` exposed (with evidence of access) | Full read access to all tables and storage. Scope includes push subscriptions, photos, and all ip_hash rows. |
+| `TOTP_ENCRYPTION_KEY` exposed alongside admin TOTP secrets | Admin TOTP secrets are decryptable → account takeover risk. Limited to admin accounts, but severity is high. |
+| Push subscriptions accessed + `VAPID_PRIVATE_KEY` exposed | Attacker can send arbitrary push notifications to all subscribed devices; endpoints also enable device fingerprinting. |
+| Unmoderated photo served publicly containing identifiable content | Photo content (faces, licence plates) disclosed without consent. |
+
+### RROSH = PROBABLY NOT — record, no OPC report required
+
+| Trigger | Why |
+|---------|-----|
+| `SUPABASE_SERVICE_ROLE_KEY` exposed, no evidence of access | Immediate rotation; assess access logs before closing. Record the breach for 24 months. |
+| `ADMIN_SESSION_SECRET` or `ADMIN_BOOTSTRAP_SECRET` exposed | CSRF forgery risk but no personal data directly exposed. Invalidate all admin sessions. |
+| `SIGHTENGINE_*` keys exposed | Third-party moderation API; no personal data stored server-side by this integration. |
+| `PUSHOVER_*` keys exposed | Notification sending only; no personal data exposed. |
+| Admin password hash for a single account exposed | Offline brute-force risk only. Rotate credential, record breach. |
+
+**When in doubt, report.** The OPC is not punitive about over-reporting. The cost
+of failing to report when RROSH exists is much higher.
+
+---
+
+## 4. Secret Inventory and Rotation Procedures
+
+Rotate in this order (most critical first):
+
+### `IP_HASH_SECRET`
+- **Impact if exposed**: All stored ip_hash values become reversible to real IPs.
+- **Rotate**: Generate a new 32-byte hex secret → update Netlify env var → redeploy.
+- **Note**: After rotation, all existing ip_hash values are no longer valid for dedup.
+  New hashes will not match old hashes for the same IP. This is acceptable; the
+  old hashed data should be considered personal information and noted in the incident record.
+
+### `SUPABASE_SERVICE_ROLE_KEY`
+- **Impact if exposed**: Full DB and storage read/write.
+- **Rotate**: Supabase dashboard → Settings → API → Regenerate service role key →
+  update Netlify env var → redeploy.
+- **After rotation**: Audit Supabase logs for unexpected queries in the exposure window.
+
+### `TOTP_ENCRYPTION_KEY`
+- **Impact if exposed**: Admin TOTP secrets decryptable → bypass MFA.
+- **Rotate**: Generate new 32-byte hex key → update Netlify env var → redeploy.
+  All admins must re-enroll TOTP (existing encrypted secrets are useless with the new key).
+- **Action**: Force-invalidate all admin sessions and MFA challenges after rotation.
+
+### `ADMIN_SESSION_SECRET`
+- **Impact if exposed**: Attacker can forge valid CSRF tokens for any session.
+- **Rotate**: Generate new 32-byte hex secret → update Netlify env var → redeploy.
+  All existing CSRF tokens are immediately invalidated → admins re-login.
+
+### `VAPID_PRIVATE_KEY` / `VAPID_PUBLIC_KEY` / `PUBLIC_VAPID_PUBLIC_KEY`
+- **Impact if exposed**: Attacker can push arbitrary notifications to all subscribers.
+- **Rotate**: Generate new VAPID key pair → update all three env vars → redeploy.
+  Existing push subscriptions are no longer valid (tied to the old public key); users
+  must re-subscribe. This means push notification delivery will silently fail until
+  users revisit the site.
+
+### `BLUESKY_APP_PASSWORD`
+- **Impact if exposed**: Attacker can post as the bot account.
+- **Rotate**: Bluesky settings → App Passwords → revoke + generate new.
+
+### `SIGHTENGINE_API_SECRET`
+- **Impact if exposed**: Attacker can use the moderation quota.
+- **Rotate**: SightEngine dashboard → regenerate → update Netlify env var.
+
+---
+
+## 5. PIPEDA Notification Obligations
+
+### Reporting to the OPC
+
+**When**: As soon as feasible after determining RROSH — target **72 hours** from
+the point you conclude personal information was exposed with RROSH.
+
+**How**: Online report form at the OPC:
+`https://www.priv.gc.ca/en/report-a-concern/file-a-formal-privacy-complaint/file-a-privacy-breach-report/`
+
+**What to include**:
+- Date the breach was discovered and (if known) when it occurred
+- Description of the personal information involved
+- Number of individuals affected (or best estimate)
+- Steps taken to contain the breach
+- Whether individuals have been notified or why not yet
+
+### Notifying Affected Individuals
+
+**When**: As soon as feasible after OPC notification (may be concurrent).
+
+**Who**: Every individual whose personal information was involved in the breach
+where RROSH applies.
+
+**Challenge for this app**: Public users are anonymous — there is no email address
+to reach them. Practicable notification options:
+1. **Site banner** on fillthehole.ca for 30+ days describing the breach and steps taken
+2. **Push notification** to subscribed devices (if push infrastructure is intact)
+3. **OPC guidance** — contact the OPC if anonymous user notification is not practicable;
+   they may accept public posting as sufficient
+
+The notification must be in plain language and include: a description of what happened,
+what personal information was involved, steps taken to reduce harm, and a contact point
+for questions.
+
+### Record Keeping
+
+**All breaches** — regardless of RROSH — must be recorded and retained for **24 months**
+from the date the breach occurred (not discovery date).
+
+Maintain a private breach log (not in the public repo) with:
+- Date of breach / Date of discovery
+- Description of what happened
+- Personal information involved
+- Number of individuals affected
+- RROSH determination and reasoning
+- Steps taken (rotation, notification, OPC report)
+- OPC reference number (if reported)
+
+---
+
+## 6. Response Timeline
+
+### 0–1 Hour: Contain
+
+- [ ] Rotate / revoke the affected secret(s) (see §4)
+- [ ] Redeploy to ensure rotated secrets are live
+- [ ] Invalidate admin sessions if admin infrastructure was involved:
+  ```sql
+  -- Run in Supabase SQL editor (service role)
+  delete from admin_sessions;
+  delete from admin_mfa_challenges;
+  delete from admin_trusted_devices;
+  ```
+- [ ] Check Supabase logs for unexpected access during the exposure window
+- [ ] Check Netlify access logs for unexpected traffic patterns
+- [ ] Open a private incident record (date, what happened, what was rotated)
+
+### 1–24 Hours: Assess
+
+- [ ] Determine the exposure window (when did the leak start? when was it closed?)
+- [ ] Identify what personal information was within reach
+- [ ] Assess RROSH (see §3)
+- [ ] If RROSH: begin drafting OPC report
+- [ ] If photos may have been accessed without moderation: identify which potholes
+  and document photo content
+
+### 24–72 Hours: Notify
+
+- [ ] Submit OPC report if RROSH (target: within 72 hours of RROSH determination)
+- [ ] Post site banner if public user notification is required
+- [ ] Send push notification to subscribed devices if applicable
+- [ ] Document OPC reference number in breach log
+
+### Ongoing: Review
+
+- [ ] Post-incident review within 7 days (see §8)
+- [ ] Update this playbook if gaps were found
+- [ ] Maintain breach record for 24 months
+
+---
+
+## 7. Notification Templates
+
+### OPC Report (adapt to facts)
+
+> **Breach description**: On [date], [the secret X / a misconfiguration] caused [personal
+> information type] belonging to approximately [N] individuals to be exposed to
+> [unauthorized party / unknown parties]. The exposure window was [start] to [end].
+>
+> **Personal information involved**: [IP address hashes reversible to real IP addresses /
+> push subscription endpoints and keys / pothole photo content / other].
+>
+> **Steps taken**: The affected secret was rotated at [time]. [Additional mitigations].
+> Affected individuals have been / will be notified via [method].
+>
+> **Contact**: [your name and contact email]
+
+### Site Banner (public user notification)
+
+> **Security notice — [Month Year]**: We recently discovered that [brief plain-language
+> description]. We have taken the following steps: [rotation, mitigation]. If you
+> reported a pothole, confirmed a report, or uploaded a photo to fillthehole.ca
+> [during / before] [date], your [IP address / device subscription / other] may have
+> been involved. We have [rotated keys / notified the OPC / other]. For questions,
+> contact [contact address]. We are sorry for this incident.
+
+---
+
+## 8. Post-Incident Review
+
+Within 7 days of closing the incident, document:
+
+1. **Root cause**: How did this happen? (committed secret, misconfigured access, etc.)
+2. **Detection**: How was it found? How long did it take?
+3. **Response gaps**: What was slow or unclear in this playbook?
+4. **Preventive action**: What change prevents recurrence?
+
+Update CLAUDE.md, this playbook, or the codebase as appropriate.
+
+---
+
+## 9. Contacts
+
+- **OPC Privacy Breach Report**: https://www.priv.gc.ca/en/report-a-concern/file-a-formal-privacy-complaint/file-a-privacy-breach-report/
+- **OPC General**: 1-800-282-1376 / info@priv.gc.ca
+- **Supabase support**: https://supabase.com/support
+- **Netlify support**: https://www.netlify.com/support/

--- a/INCIDENT_RESPONSE.md
+++ b/INCIDENT_RESPONSE.md
@@ -168,8 +168,8 @@ for questions.
 
 ### Record Keeping
 
-**All breaches** — regardless of RROSH — must be recorded and retained for **24 months**
-from the date the breach occurred (not discovery date).
+**All breaches** — regardless of RROSH — must be recorded and retained for **at least 24 months**
+from the date the organization determines that a breach has occurred.
 
 Maintain a private breach log (not in the public repo) with:
 - Date of breach / Date of discovery

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -85,7 +85,7 @@ const E2E_FIXTURE_SESSION_ID = 'e2e-session-id';
 
 const E2E_FIXTURE_USER: AdminUser = {
 	id: '00000000-0000-4000-8000-000000000099',
-	email: 'e2e-admin@test.local',
+	email: 'e2e-mfa@test.local',
 	firstName: 'E2E',
 	lastName: 'Admin',
 	role: 'admin',

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -96,7 +96,7 @@ const E2E_FIXTURE_USER: AdminUser = {
 export async function validateAdminSession(
 	sessionId: string
 ): Promise<{ user: AdminUser; session: AdminSession } | null> {
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && sessionId === E2E_FIXTURE_SESSION_ID) {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true' && sessionId === E2E_FIXTURE_SESSION_ID) {
 		const now = new Date();
 		return {
 			user: E2E_FIXTURE_USER,

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -81,9 +81,34 @@ export async function createAdminSession(
 	return sessionId;
 }
 
+const E2E_FIXTURE_SESSION_ID = 'e2e-session-id';
+
+const E2E_FIXTURE_USER: AdminUser = {
+	id: '00000000-0000-4000-8000-000000000099',
+	email: 'e2e-admin@test.local',
+	firstName: 'E2E',
+	lastName: 'Admin',
+	role: 'admin',
+	isActive: true,
+	totpEnabled: true
+};
+
 export async function validateAdminSession(
 	sessionId: string
 ): Promise<{ user: AdminUser; session: AdminSession } | null> {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && sessionId === E2E_FIXTURE_SESSION_ID) {
+		const now = new Date();
+		return {
+			user: E2E_FIXTURE_USER,
+			session: {
+				id: E2E_FIXTURE_SESSION_ID,
+				userId: E2E_FIXTURE_USER.id,
+				expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+				createdAt: now,
+				lastActivityAt: now
+			}
+		};
+	}
 	const { data, error: queryError } = await getAdminClient()
 		.from('admin_sessions')
 		.select(

--- a/src/lib/server/fixture-store.ts
+++ b/src/lib/server/fixture-store.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared in-process store for Playwright E2E fixture data.
+ *
+ * Both the /api/report and /api/photos endpoints import from here so that the
+ * photo endpoint can validate that a pothole actually exists in the fixture
+ * store before accepting a photo upload — mirroring the real endpoint's
+ * pothole existence check.
+ *
+ * This module is only active when PLAYWRIGHT_E2E_FIXTURES === 'true'. It must
+ * never be imported in production code paths; the guard at each call site
+ * (process.env.PLAYWRIGHT_E2E_FIXTURES) prevents any runtime effect in prod.
+ */
+
+export type FixturePothole = { id: string; lat: number; lng: number; confirmed_count: number };
+
+/** Keyed by pothole UUID. */
+export const fixturePotholes = new Map<string, FixturePothole>();

--- a/src/lib/server/fixture-store.ts
+++ b/src/lib/server/fixture-store.ts
@@ -6,9 +6,10 @@
  * store before accepting a photo upload — mirroring the real endpoint's
  * pothole existence check.
  *
- * This module is only active when PLAYWRIGHT_E2E_FIXTURES === 'true'. It must
- * never be imported in production code paths; the guard at each call site
- * (process.env.PLAYWRIGHT_E2E_FIXTURES) prevents any runtime effect in prod.
+ * This module is only used when PLAYWRIGHT_E2E_FIXTURES === 'true' and
+ * CI === 'true'. It must never be read from or mutated outside fixture mode;
+ * the guard at each call site (process.env.PLAYWRIGHT_E2E_FIXTURES &&
+ * process.env.CI) prevents any fixture behavior from activating in production.
  */
 
 export type FixturePothole = { id: string; lat: number; lng: number; confirmed_count: number };

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -36,6 +36,24 @@ export const actions: Actions = {
 		// Prevent open redirect
 		const next = rawNext.startsWith('/admin') ? rawNext : '/admin/photos';
 
+		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && email === 'e2e-mfa@test.local') {
+			if (password !== 'e2e-password') {
+				return fail(401, { error: 'Invalid email or password', email });
+			}
+			const isSecure = import.meta.env.PROD;
+			const trustedToken = cookies.get(TRUSTED_DEVICE_COOKIE);
+			if (trustedToken === 'e2e-trusted-device-token') {
+				const csrfToken = await generateCsrfToken('e2e-session-id');
+				cookies.set(SESSION_COOKIE, 'e2e-session-id', { httpOnly: true, sameSite: 'strict', path: '/', secure: isSecure, maxAge: 24 * 60 * 60 });
+				cookies.set(CSRF_COOKIE, csrfToken, { httpOnly: false, sameSite: 'strict', path: '/', secure: isSecure, maxAge: 24 * 60 * 60 });
+				throw redirect(302, next);
+			}
+			cookies.set('admin_mfa_pending', 'e2e-mfa-challenge-token', {
+				httpOnly: true, sameSite: 'strict', path: '/admin/login', secure: isSecure, maxAge: 5 * 60
+			});
+			throw redirect(302, `/admin/login/mfa?next=${encodeURIComponent(next)}`);
+		}
+
 		const ipHash = await hashIp(getClientAddress());
 		const userAgent = request.headers.get('user-agent') ?? 'unknown';
 		// M1: Use build-time flag — url.protocol can be spoofed via reverse proxy.

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -36,7 +36,7 @@ export const actions: Actions = {
 		// Prevent open redirect
 		const next = rawNext.startsWith('/admin') ? rawNext : '/admin/photos';
 
-		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && email === 'e2e-mfa@test.local') {
+		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true' && email === 'e2e-mfa@test.local') {
 			if (password !== 'e2e-password') {
 				return fail(401, { error: 'Invalid email or password', email });
 			}

--- a/src/routes/admin/login/mfa/+page.server.ts
+++ b/src/routes/admin/login/mfa/+page.server.ts
@@ -49,6 +49,21 @@ export const actions: Actions = {
 			return fail(400, { error: 'Verification code is required', next });
 		}
 
+		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && mfaToken === 'e2e-mfa-challenge-token') {
+			if (code !== '000000') {
+				return fail(401, { error: 'Invalid code. Please try again.', next });
+			}
+			cookies.delete('admin_mfa_pending', { path: '/admin/login' });
+			const isSecure = import.meta.env.PROD;
+			const csrfToken = await generateCsrfToken('e2e-session-id');
+			cookies.set(SESSION_COOKIE, 'e2e-session-id', { httpOnly: true, sameSite: 'strict', path: '/', secure: isSecure, maxAge: 24 * 60 * 60 });
+			cookies.set(CSRF_COOKIE, csrfToken, { httpOnly: false, sameSite: 'strict', path: '/', secure: isSecure, maxAge: 24 * 60 * 60 });
+			if (rememberDevice) {
+				cookies.set(TRUSTED_DEVICE_COOKIE, 'e2e-trusted-device-token', { httpOnly: true, sameSite: 'strict', path: '/', secure: isSecure, maxAge: 30 * 24 * 60 * 60 });
+			}
+			throw redirect(302, next);
+		}
+
 		type ChallengeRow = {
 			id: string;
 			user_id: string;

--- a/src/routes/admin/login/mfa/+page.server.ts
+++ b/src/routes/admin/login/mfa/+page.server.ts
@@ -49,7 +49,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Verification code is required', next });
 		}
 
-		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && mfaToken === 'e2e-mfa-challenge-token') {
+		if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true' && mfaToken === 'e2e-mfa-challenge-token') {
 			if (code !== '000000') {
 				return fail(401, { error: 'Invalid code. Please try again.', next });
 			}

--- a/src/routes/api/admin/photo/[id]/+server.ts
+++ b/src/routes/api/admin/photo/[id]/+server.ts
@@ -20,7 +20,7 @@ export const PATCH: RequestHandler = async ({ request, params, locals, getClient
 	const { id } = idParsed.data;
 	const moderation_status = bodyParsed.data.action === 'approve' ? 'approved' : 'rejected';
 
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true') {
 		return json({ ok: true, moderation_status });
 	}
 
@@ -52,7 +52,7 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 
 	const { id } = idParsed.data;
 
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true') {
 		return json({ ok: true });
 	}
 

--- a/src/routes/api/admin/photo/[id]/+server.ts
+++ b/src/routes/api/admin/photo/[id]/+server.ts
@@ -20,6 +20,10 @@ export const PATCH: RequestHandler = async ({ request, params, locals, getClient
 	const { id } = idParsed.data;
 	const moderation_status = bodyParsed.data.action === 'approve' ? 'approved' : 'rejected';
 
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		return json({ ok: true, moderation_status });
+	}
+
 	const { error: updateError } = await getAdminClient()
 		.from('pothole_photos')
 		.update({ moderation_status })
@@ -47,6 +51,10 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 	if (!idParsed.success) throw error(400, 'Invalid ID');
 
 	const { id } = idParsed.data;
+
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		return json({ ok: true });
+	}
 
 	// Look up storage path before deleting the record
 	const { data: photo } = await getAdminClient()

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -12,9 +12,6 @@ import { fixturePotholes } from '$lib/server/fixture-store';
 type FixturePhoto = { id: string; potholeId: string; moderationStatus: 'pending' | 'deferred' };
 const fixturePhotos = new Map<string, FixturePhoto>();
 
-type FixturePhoto = { id: string; potholeId: string; moderationStatus: 'pending' | 'deferred' };
-const fixturePhotos = new Map<string, FixturePhoto>();
-
 type DetectedMimeType = 'image/jpeg' | 'image/png' | 'image/webp';
 type DetectedExtension = 'jpg' | 'png' | 'webp';
 

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -8,6 +8,9 @@ import { logError } from '$lib/server/observability';
 import { stripJpegMetadata, stripPngMetadata, stripWebpMetadata } from '$lib/server/exif-strip';
 import { getAdminClient } from '$lib/server/supabase';
 
+type FixturePhoto = { id: string; potholeId: string; moderationStatus: 'pending' | 'deferred' };
+const fixturePhotos = new Map<string, FixturePhoto>();
+
 type DetectedMimeType = 'image/jpeg' | 'image/png' | 'image/webp';
 type DetectedExtension = 'jpg' | 'png' | 'webp';
 
@@ -139,6 +142,12 @@ async function cleanupStorageObject(storagePath: string): Promise<void> {
 	}
 }
 
+export const DELETE: RequestHandler = async () => {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true') throw error(405, 'Method not allowed');
+	fixturePhotos.clear();
+	return json({ ok: true });
+};
+
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	let formData: FormData;
 	try {
@@ -155,6 +164,19 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 
 	if (!(file instanceof File)) throw error(400, 'No photo provided');
 	if (file.size > MAX_SIZE_BYTES) throw error(413, 'Photo too large (max 5 MB)');
+
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		const rawBytesFixture = new Uint8Array(await file.arrayBuffer());
+		const detectedFixture = detectImageType(rawBytesFixture);
+		if (!detectedFixture) throw error(400, 'Invalid file type — JPEG, PNG, or WebP only');
+		if (request.headers.get('x-e2e-moderation') === 'reject') {
+			throw error(422, 'Photo rejected by content moderation');
+		}
+		const id = crypto.randomUUID();
+		const moderationStatus = request.headers.get('x-e2e-moderation') === 'deferred' ? 'deferred' : 'pending';
+		fixturePhotos.set(id, { id, potholeId: idParsed.data, moderationStatus });
+		return json({ ok: true, id });
+	}
 
 	const ipHash = await hashIp(getClientAddress());
 

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -7,6 +7,7 @@ import { notify } from '$lib/server/pushover';
 import { logError } from '$lib/server/observability';
 import { stripJpegMetadata, stripPngMetadata, stripWebpMetadata } from '$lib/server/exif-strip';
 import { getAdminClient } from '$lib/server/supabase';
+import { fixturePotholes } from '$lib/server/fixture-store';
 
 type FixturePhoto = { id: string; potholeId: string; moderationStatus: 'pending' | 'deferred' };
 const fixturePhotos = new Map<string, FixturePhoto>();
@@ -166,6 +167,8 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	if (file.size > MAX_SIZE_BYTES) throw error(413, 'Photo too large (max 5 MB)');
 
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		// Mirror the real endpoint's pothole existence check against the fixture store.
+		if (!fixturePotholes.has(idParsed.data)) throw error(404, 'Pothole not found');
 		const rawBytesFixture = new Uint8Array(await file.arrayBuffer());
 		const detectedFixture = detectImageType(rawBytesFixture);
 		if (!detectedFixture) throw error(400, 'Invalid file type — JPEG, PNG, or WebP only');

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -144,7 +144,7 @@ async function cleanupStorageObject(storagePath: string): Promise<void> {
 }
 
 export const DELETE: RequestHandler = async () => {
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true') throw error(405, 'Method not allowed');
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true' || process.env.CI !== 'true') throw error(405, 'Method not allowed');
 	fixturePhotos.clear();
 	return json({ ok: true });
 };
@@ -166,7 +166,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	if (!(file instanceof File)) throw error(400, 'No photo provided');
 	if (file.size > MAX_SIZE_BYTES) throw error(413, 'Photo too large (max 5 MB)');
 
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true') {
 		// Mirror the real endpoint's pothole existence check against the fixture store.
 		if (!fixturePotholes.has(idParsed.data)) throw error(404, 'Pothole not found');
 		const rawBytesFixture = new Uint8Array(await file.arrayBuffer());

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -27,7 +27,7 @@ type ConfirmationResult =
 	| { duplicate: false; confirmed_count: number; status: string };
 
 export const DELETE: RequestHandler = async () => {
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true') throw error(405, 'Method not allowed');
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true' || process.env.CI !== 'true') throw error(405, 'Method not allowed');
 	fixturePotholes.clear();
 	return json({ ok: true });
 };
@@ -55,8 +55,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		);
 	}
 
-	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
-		const confirmationsRequired = await getConfirmationThreshold();
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' && process.env.CI === 'true') {
+		// Use a fixed threshold of 2 in fixture mode — avoids Supabase calls
+		// when the preview server runs with placeholder/closed-port credentials.
+		const confirmationsRequired = 2;
 		const match = [...fixturePotholes.values()]
 			.map((p) => ({ id: p.id, dist: haversineMetres(lat, lng, p.lat, p.lng) }))
 			.filter((p) => p.dist <= MERGE_RADIUS_M)
@@ -64,19 +66,21 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 
 		if (match) {
 			const existing = fixturePotholes.get(match.id);
-			// `match.id` comes from `fixturePotholes.values()` — the entry must exist.
-			// If it's somehow missing (e.g. concurrent delete), fall through to create a new entry.
-			if (!existing) throw error(500, 'Fixture state inconsistency: pothole vanished between lookup and update');
-			const confirmed_count = existing.confirmed_count + 1;
-			fixturePotholes.set(match.id, { ...existing, confirmed_count });
-			const confirmed = confirmed_count >= confirmationsRequired;
-			return json({
-				id: match.id,
-				confirmed,
-				message: confirmed
-					? '✅ Confirmed — pothole is now live on the map!'
-					: `📍 Confirmation noted (${confirmed_count}/${confirmationsRequired} needed).`
-			});
+			// `match.id` comes from `fixturePotholes.values()` so the entry should
+			// exist. If it has somehow been concurrently deleted, fall through and
+			// create a new entry at this location rather than crashing the test.
+			if (existing) {
+				const confirmed_count = existing.confirmed_count + 1;
+				fixturePotholes.set(match.id, { ...existing, confirmed_count });
+				const confirmed = confirmed_count >= confirmationsRequired;
+				return json({
+					id: match.id,
+					confirmed,
+					message: confirmed
+						? '✅ Confirmed — pothole is now live on the map!'
+						: `📍 Confirmation noted (${confirmed_count}/${confirmationsRequired} needed).`
+				});
+			}
 		}
 
 		const id = crypto.randomUUID();

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -11,9 +11,6 @@ import { logError } from '$lib/server/observability';
 import { getAdminClient } from '$lib/server/supabase';
 import { fixturePotholes } from '$lib/server/fixture-store';
 
-type FixturePothole = { id: string; lat: number; lng: number; confirmed_count: number };
-const fixturePotholes = new Map<string, FixturePothole>();
-
 const REPORT_RATE_LIMIT = 20;
 const REPORT_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const SEVERITY_VALUES = ['Minor damage', 'Moderate damage', 'Severe damage', 'Hazardous'] as const;

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -9,9 +9,7 @@ import { notify } from '$lib/server/pushover';
 import { postConfirmed } from '$lib/server/bluesky';
 import { logError } from '$lib/server/observability';
 import { getAdminClient } from '$lib/server/supabase';
-
-type FixturePothole = { id: string; lat: number; lng: number; confirmed_count: number };
-const fixturePotholes = new Map<string, FixturePothole>();
+import { fixturePotholes } from '$lib/server/fixture-store';
 
 const REPORT_RATE_LIMIT = 20;
 const REPORT_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
@@ -58,20 +56,26 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	}
 
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		const confirmationsRequired = await getConfirmationThreshold();
 		const match = [...fixturePotholes.values()]
-			.map((p) => ({ ...p, dist: haversineMetres(lat, lng, p.lat, p.lng) }))
+			.map((p) => ({ id: p.id, dist: haversineMetres(lat, lng, p.lat, p.lng) }))
 			.filter((p) => p.dist <= MERGE_RADIUS_M)
 			.sort((a, b) => a.dist - b.dist)[0];
 
 		if (match) {
-			match.confirmed_count += 1;
-			const confirmed = match.confirmed_count >= 2;
+			const existing = fixturePotholes.get(match.id);
+			// `match.id` comes from `fixturePotholes.values()` — the entry must exist.
+			// If it's somehow missing (e.g. concurrent delete), fall through to create a new entry.
+			if (!existing) throw error(500, 'Fixture state inconsistency: pothole vanished between lookup and update');
+			const confirmed_count = existing.confirmed_count + 1;
+			fixturePotholes.set(match.id, { ...existing, confirmed_count });
+			const confirmed = confirmed_count >= confirmationsRequired;
 			return json({
 				id: match.id,
 				confirmed,
 				message: confirmed
 					? '✅ Confirmed — pothole is now live on the map!'
-					: `📍 Confirmation noted (${match.confirmed_count}/2 needed).`
+					: `📍 Confirmation noted (${confirmed_count}/${confirmationsRequired} needed).`
 			});
 		}
 

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -10,6 +10,9 @@ import { postConfirmed } from '$lib/server/bluesky';
 import { logError } from '$lib/server/observability';
 import { getAdminClient } from '$lib/server/supabase';
 
+type FixturePothole = { id: string; lat: number; lng: number; confirmed_count: number };
+const fixturePotholes = new Map<string, FixturePothole>();
+
 const REPORT_RATE_LIMIT = 20;
 const REPORT_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const SEVERITY_VALUES = ['Minor damage', 'Moderate damage', 'Severe damage', 'Hazardous'] as const;
@@ -24,6 +27,12 @@ const reportSchema = z.object({
 type ConfirmationResult =
 	| { duplicate: true }
 	| { duplicate: false; confirmed_count: number; status: string };
+
+export const DELETE: RequestHandler = async () => {
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true') throw error(405, 'Method not allowed');
+	fixturePotholes.clear();
+	return json({ ok: true });
+};
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const raw = await request.json().catch(() => null);
@@ -46,6 +55,33 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 			422,
 			"That location isn't in the Waterloo Region. This tool covers Kitchener, Waterloo, and Cambridge."
 		);
+	}
+
+	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
+		const match = [...fixturePotholes.values()]
+			.map((p) => ({ ...p, dist: haversineMetres(lat, lng, p.lat, p.lng) }))
+			.filter((p) => p.dist <= MERGE_RADIUS_M)
+			.sort((a, b) => a.dist - b.dist)[0];
+
+		if (match) {
+			match.confirmed_count += 1;
+			const confirmed = match.confirmed_count >= 2;
+			return json({
+				id: match.id,
+				confirmed,
+				message: confirmed
+					? '✅ Confirmed — pothole is now live on the map!'
+					: `📍 Confirmation noted (${match.confirmed_count}/2 needed).`
+			});
+		}
+
+		const id = crypto.randomUUID();
+		fixturePotholes.set(id, { id, lat: roundPublicCoord(lat), lng: roundPublicCoord(lng), confirmed_count: 1 });
+		return json({
+			id,
+			confirmed: false,
+			message: '📍 Pothole logged. More independent reports from this location will put it on the map.'
+		});
 	}
 
 	const ipHash = await hashIp(getClientAddress());

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,12 +4,18 @@ import adapter from '@sveltejs/adapter-netlify';
 const config = {
 	kit: {
 		adapter: adapter(),
-		// Disable SvelteKit's built-in Origin check in E2E test builds so that
-		// Playwright's APIRequestContext can POST multipart/form-data to /api/photos
-		// without a framework-level 403. Custom CSRF protection for admin routes
-		// lives in hooks.server.ts and is unaffected by this flag.
+		// Disable SvelteKit's built-in Origin check only for CI-backed E2E test
+		// builds so that Playwright's APIRequestContext can POST
+		// multipart/form-data to /api/photos without a framework-level 403.
+		// Custom CSRF protection for admin routes lives in hooks.server.ts and
+		// is unaffected by this flag. Requiring CI reduces the impact of an
+		// environment misconfiguration that might otherwise disable origin
+		// checks outside automated test runs.
 		csrf: {
-			checkOrigin: process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true'
+			checkOrigin: !(
+				process.env.PLAYWRIGHT_E2E_FIXTURES === 'true' &&
+				process.env.CI === 'true'
+			)
 		},
 		// H2: Nonce-based CSP removes the need for 'unsafe-inline' in script-src.
 		// SvelteKit generates a fresh nonce per request, injects it into all inline

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,6 +4,13 @@ import adapter from '@sveltejs/adapter-netlify';
 const config = {
 	kit: {
 		adapter: adapter(),
+		// Disable SvelteKit's built-in Origin check in E2E test builds so that
+		// Playwright's APIRequestContext can POST multipart/form-data to /api/photos
+		// without a framework-level 403. Custom CSRF protection for admin routes
+		// lives in hooks.server.ts and is unaffected by this flag.
+		csrf: {
+			checkOrigin: process.env.PLAYWRIGHT_E2E_FIXTURES !== 'true'
+		},
 		// H2: Nonce-based CSP removes the need for 'unsafe-inline' in script-src.
 		// SvelteKit generates a fresh nonce per request, injects it into all inline
 		// <script> tags it controls, and appends nonce-{value} to the script-src header.

--- a/tests/e2e/admin-mfa.spec.ts
+++ b/tests/e2e/admin-mfa.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from "@playwright/test";
+
+// Shared helper: fill the login form and submit.
+async function submitLoginForm(
+  page: import("@playwright/test").Page,
+  email: string,
+  password: string,
+) {
+  await page.goto("/admin/login");
+  await expect(
+    page.getByRole("heading", { name: "Sign in" }),
+  ).toBeVisible();
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', password);
+  await page.click('button[type="submit"]');
+}
+
+// Helper: log in with fixture credentials and complete MFA, returning the CSRF
+// token (readable from the non-HttpOnly admin_csrf cookie after redirect).
+async function loginWithMfa(
+  page: import("@playwright/test").Page,
+  { rememberDevice = false } = {},
+) {
+  await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
+  await page.waitForURL(/\/admin\/login\/mfa/);
+
+  if (rememberDevice) {
+    await page.check('input[name="rememberDevice"]');
+  }
+
+  // The MFA page auto-submits on 6 digits — filling triggers the $effect.
+  await page.fill('input[name="code"]', "000000");
+  await page.waitForURL(/\/admin\//);
+
+  const csrfToken = await page.evaluate(() =>
+    document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("admin_csrf="))
+      ?.split("=")[1] ?? "",
+  );
+  return { csrfToken };
+}
+
+test.describe("Admin — MFA login flow", () => {
+  test("login form redirects to MFA page on valid credentials", async ({
+    page,
+  }) => {
+    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
+    await expect(page).toHaveURL(/\/admin\/login\/mfa/);
+    await expect(
+      page.getByRole("heading", { name: "Two-factor authentication" }),
+    ).toBeVisible();
+  });
+
+  test("wrong password shows an error and stays on login", async ({
+    page,
+  }) => {
+    await submitLoginForm(page, "e2e-mfa@test.local", "wrong-password");
+    await expect(
+      page.getByText("Invalid email or password"),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/admin\/login/);
+    await expect(page).not.toHaveURL(/\/admin\/login\/mfa/);
+  });
+
+  test("wrong MFA code shows an error and stays on MFA page", async ({
+    page,
+  }) => {
+    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
+    await page.waitForURL(/\/admin\/login\/mfa/);
+
+    await page.fill('input[name="code"]', "999999");
+    await page.click('button[type="submit"]');
+    await expect(
+      page.getByText("Invalid code. Please try again."),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/admin\/login\/mfa/);
+  });
+
+  test("correct MFA code redirects to admin area", async ({ page }) => {
+    await loginWithMfa(page);
+    await expect(page).toHaveURL(/\/admin\//);
+  });
+
+  test("MFA page renders TOTP and backup code modes", async ({ page }) => {
+    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
+    await page.waitForURL(/\/admin\/login\/mfa/);
+
+    // TOTP mode (default)
+    await expect(
+      page.getByRole("heading", { name: "Two-factor authentication" }),
+    ).toBeVisible();
+    await expect(
+      page.getByLabel("Authenticator code"),
+    ).toBeVisible();
+
+    // Switch to backup code mode
+    await page.click('button:has-text("Use a backup code instead")');
+    await expect(
+      page.getByRole("heading", { name: "Enter backup code" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Backup code")).toBeVisible();
+
+    // Switch back
+    await page.click('button:has-text("Use authenticator code instead")');
+    await expect(
+      page.getByRole("heading", { name: "Two-factor authentication" }),
+    ).toBeVisible();
+  });
+
+  test("'Remember this device' sets the trusted device cookie", async ({
+    page,
+  }) => {
+    await loginWithMfa(page, { rememberDevice: true });
+
+    const cookies = await page.context().cookies();
+    const trustedCookie = cookies.find(
+      (c) => c.name === "admin_trusted_device",
+    );
+    expect(trustedCookie).toBeDefined();
+    expect(trustedCookie!.value).toBe("e2e-trusted-device-token");
+    expect(trustedCookie!.httpOnly).toBe(true);
+  });
+
+  test("trusted device cookie bypasses MFA on second login", async ({
+    page,
+  }) => {
+    // First login with "remember device"
+    await loginWithMfa(page, { rememberDevice: true });
+
+    // Navigate away (simulate a new session start by going back to login)
+    await page.goto("/admin/login");
+
+    // Log in again — trusted device cookie should skip the MFA challenge
+    await page.fill('input[name="email"]', "e2e-mfa@test.local");
+    await page.fill('input[name="password"]', "e2e-password");
+    await page.click('button[type="submit"]');
+
+    // Should land in admin without passing through /mfa
+    await expect(page).toHaveURL(/\/admin\//);
+    await expect(page).not.toHaveURL(/\/admin\/login\/mfa/);
+  });
+
+  test("back link on MFA page returns to login", async ({ page }) => {
+    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
+    await page.waitForURL(/\/admin\/login\/mfa/);
+    await page.click('a:has-text("Back to sign in")');
+    await expect(page).toHaveURL(/\/admin\/login$/);
+  });
+
+  test("admin CSRF token is set after MFA login", async ({ page }) => {
+    const { csrfToken } = await loginWithMfa(page);
+    expect(csrfToken).toBeTruthy();
+    expect(csrfToken.length).toBe(64); // HMAC-SHA-256 as 64 hex chars
+  });
+});

--- a/tests/e2e/admin-mfa.spec.ts
+++ b/tests/e2e/admin-mfa.spec.ts
@@ -1,156 +1,156 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test'
 
 // Shared helper: fill the login form and submit.
 async function submitLoginForm(
-  page: import("@playwright/test").Page,
-  email: string,
-  password: string,
+	page: import('@playwright/test').Page,
+	email: string,
+	password: string,
 ) {
-  await page.goto("/admin/login");
-  await expect(
-    page.getByRole("heading", { name: "Sign in" }),
-  ).toBeVisible();
-  await page.fill('input[name="email"]', email);
-  await page.fill('input[name="password"]', password);
-  await page.click('button[type="submit"]');
+	await page.goto('/admin/login')
+	await expect(
+		page.getByRole('heading', { name: 'Sign in' }),
+	).toBeVisible()
+	await page.fill('input[name="email"]', email)
+	await page.fill('input[name="password"]', password)
+	await page.click('button[type="submit"]')
 }
 
 // Helper: log in with fixture credentials and complete MFA, returning the CSRF
 // token (readable from the non-HttpOnly admin_csrf cookie after redirect).
 async function loginWithMfa(
-  page: import("@playwright/test").Page,
-  { rememberDevice = false } = {},
+	page: import('@playwright/test').Page,
+	{ rememberDevice = false } = {},
 ) {
-  await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
-  await page.waitForURL(/\/admin\/login\/mfa/);
+	await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
+	await page.waitForURL(/\/admin\/login\/mfa/)
 
-  if (rememberDevice) {
-    await page.check('input[name="rememberDevice"]');
-  }
+	if (rememberDevice) {
+		await page.check('input[name="rememberDevice"]')
+	}
 
-  // The MFA page auto-submits on 6 digits — filling triggers the $effect.
-  await page.fill('input[name="code"]', "000000");
-  await page.waitForURL(/\/admin\//);
+	// The MFA page auto-submits on 6 digits — filling triggers the $effect.
+	await page.fill('input[name="code"]', '000000')
+	await page.waitForURL(/\/admin\//)
 
-  const csrfToken = await page.evaluate(() =>
-    document.cookie
-      .split("; ")
-      .find((c) => c.startsWith("admin_csrf="))
-      ?.split("=")[1] ?? "",
-  );
-  return { csrfToken };
+	const csrfToken = await page.evaluate(() =>
+		document.cookie
+			.split('; ')
+			.find((c) => c.startsWith('admin_csrf='))
+			?.split('=')[1] ?? '',
+	)
+	return { csrfToken }
 }
 
-test.describe("Admin — MFA login flow", () => {
-  test("login form redirects to MFA page on valid credentials", async ({
-    page,
-  }) => {
-    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
-    await expect(page).toHaveURL(/\/admin\/login\/mfa/);
-    await expect(
-      page.getByRole("heading", { name: "Two-factor authentication" }),
-    ).toBeVisible();
-  });
+test.describe('Admin — MFA login flow', () => {
+	test('login form redirects to MFA page on valid credentials', async ({
+		page,
+	}) => {
+		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
+		await expect(page).toHaveURL(/\/admin\/login\/mfa/)
+		await expect(
+			page.getByRole('heading', { name: 'Two-factor authentication' }),
+		).toBeVisible()
+	})
 
-  test("wrong password shows an error and stays on login", async ({
-    page,
-  }) => {
-    await submitLoginForm(page, "e2e-mfa@test.local", "wrong-password");
-    await expect(
-      page.getByText("Invalid email or password"),
-    ).toBeVisible();
-    await expect(page).toHaveURL(/\/admin\/login/);
-    await expect(page).not.toHaveURL(/\/admin\/login\/mfa/);
-  });
+	test('wrong password shows an error and stays on login', async ({
+		page,
+	}) => {
+		await submitLoginForm(page, 'e2e-mfa@test.local', 'wrong-password')
+		await expect(
+			page.getByText('Invalid email or password'),
+		).toBeVisible()
+		await expect(page).toHaveURL(/\/admin\/login/)
+		await expect(page).not.toHaveURL(/\/admin\/login\/mfa/)
+	})
 
-  test("wrong MFA code shows an error and stays on MFA page", async ({
-    page,
-  }) => {
-    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
-    await page.waitForURL(/\/admin\/login\/mfa/);
+	test('wrong MFA code shows an error and stays on MFA page', async ({
+		page,
+	}) => {
+		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
+		await page.waitForURL(/\/admin\/login\/mfa/)
 
-    await page.fill('input[name="code"]', "999999");
-    await page.click('button[type="submit"]');
-    await expect(
-      page.getByText("Invalid code. Please try again."),
-    ).toBeVisible();
-    await expect(page).toHaveURL(/\/admin\/login\/mfa/);
-  });
+		await page.fill('input[name="code"]', '999999')
+		await page.click('button[type="submit"]')
+		await expect(
+			page.getByText('Invalid code. Please try again.'),
+		).toBeVisible()
+		await expect(page).toHaveURL(/\/admin\/login\/mfa/)
+	})
 
-  test("correct MFA code redirects to admin area", async ({ page }) => {
-    await loginWithMfa(page);
-    await expect(page).toHaveURL(/\/admin\//);
-  });
+	test('correct MFA code redirects to admin area', async ({ page }) => {
+		await loginWithMfa(page)
+		await expect(page).toHaveURL(/\/admin\//)
+	})
 
-  test("MFA page renders TOTP and backup code modes", async ({ page }) => {
-    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
-    await page.waitForURL(/\/admin\/login\/mfa/);
+	test('MFA page renders TOTP and backup code modes', async ({ page }) => {
+		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
+		await page.waitForURL(/\/admin\/login\/mfa/)
 
-    // TOTP mode (default)
-    await expect(
-      page.getByRole("heading", { name: "Two-factor authentication" }),
-    ).toBeVisible();
-    await expect(
-      page.getByLabel("Authenticator code"),
-    ).toBeVisible();
+		// TOTP mode (default)
+		await expect(
+			page.getByRole('heading', { name: 'Two-factor authentication' }),
+		).toBeVisible()
+		await expect(
+			page.getByLabel('Authenticator code'),
+		).toBeVisible()
 
-    // Switch to backup code mode
-    await page.click('button:has-text("Use a backup code instead")');
-    await expect(
-      page.getByRole("heading", { name: "Enter backup code" }),
-    ).toBeVisible();
-    await expect(page.getByLabel("Backup code")).toBeVisible();
+		// Switch to backup code mode
+		await page.click('button:has-text("Use a backup code instead")')
+		await expect(
+			page.getByRole('heading', { name: 'Enter backup code' }),
+		).toBeVisible()
+		await expect(page.getByLabel('Backup code')).toBeVisible()
 
-    // Switch back
-    await page.click('button:has-text("Use authenticator code instead")');
-    await expect(
-      page.getByRole("heading", { name: "Two-factor authentication" }),
-    ).toBeVisible();
-  });
+		// Switch back
+		await page.click('button:has-text("Use authenticator code instead")')
+		await expect(
+			page.getByRole('heading', { name: 'Two-factor authentication' }),
+		).toBeVisible()
+	})
 
-  test("'Remember this device' sets the trusted device cookie", async ({
-    page,
-  }) => {
-    await loginWithMfa(page, { rememberDevice: true });
+	test("'Remember this device' sets the trusted device cookie", async ({
+		page,
+	}) => {
+		await loginWithMfa(page, { rememberDevice: true })
 
-    const cookies = await page.context().cookies();
-    const trustedCookie = cookies.find(
-      (c) => c.name === "admin_trusted_device",
-    );
-    expect(trustedCookie).toBeDefined();
-    expect(trustedCookie!.value).toBe("e2e-trusted-device-token");
-    expect(trustedCookie!.httpOnly).toBe(true);
-  });
+		const cookies = await page.context().cookies()
+		const trustedCookie = cookies.find(
+			(c) => c.name === 'admin_trusted_device',
+		)
+		expect(trustedCookie).toBeDefined()
+		expect(trustedCookie!.value).toBe('e2e-trusted-device-token')
+		expect(trustedCookie!.httpOnly).toBe(true)
+	})
 
-  test("trusted device cookie bypasses MFA on second login", async ({
-    page,
-  }) => {
-    // First login with "remember device"
-    await loginWithMfa(page, { rememberDevice: true });
+	test('trusted device cookie bypasses MFA on second login', async ({
+		page,
+	}) => {
+		// First login with "remember device"
+		await loginWithMfa(page, { rememberDevice: true })
 
-    // Navigate away (simulate a new session start by going back to login)
-    await page.goto("/admin/login");
+		// Navigate away (simulate a new session start by going back to login)
+		await page.goto('/admin/login')
 
-    // Log in again — trusted device cookie should skip the MFA challenge
-    await page.fill('input[name="email"]', "e2e-mfa@test.local");
-    await page.fill('input[name="password"]', "e2e-password");
-    await page.click('button[type="submit"]');
+		// Log in again — trusted device cookie should skip the MFA challenge
+		await page.fill('input[name="email"]', 'e2e-mfa@test.local')
+		await page.fill('input[name="password"]', 'e2e-password')
+		await page.click('button[type="submit"]')
 
-    // Should land in admin without passing through /mfa
-    await expect(page).toHaveURL(/\/admin\//);
-    await expect(page).not.toHaveURL(/\/admin\/login\/mfa/);
-  });
+		// Should land in admin without passing through /mfa
+		await expect(page).toHaveURL(/\/admin\//)
+		await expect(page).not.toHaveURL(/\/admin\/login\/mfa/)
+	})
 
-  test("back link on MFA page returns to login", async ({ page }) => {
-    await submitLoginForm(page, "e2e-mfa@test.local", "e2e-password");
-    await page.waitForURL(/\/admin\/login\/mfa/);
-    await page.click('a:has-text("Back to sign in")');
-    await expect(page).toHaveURL(/\/admin\/login$/);
-  });
+	test('back link on MFA page returns to login', async ({ page }) => {
+		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
+		await page.waitForURL(/\/admin\/login\/mfa/)
+		await page.click('a:has-text("Back to sign in")')
+		await expect(page).toHaveURL(/\/admin\/login$/)
+	})
 
-  test("admin CSRF token is set after MFA login", async ({ page }) => {
-    const { csrfToken } = await loginWithMfa(page);
-    expect(csrfToken).toBeTruthy();
-    expect(csrfToken.length).toBe(64); // HMAC-SHA-256 as 64 hex chars
-  });
-});
+	test('admin CSRF token is set after MFA login', async ({ page }) => {
+		const { csrfToken } = await loginWithMfa(page)
+		expect(csrfToken).toBeTruthy()
+		expect(csrfToken.length).toBe(64) // HMAC-SHA-256 as 64 hex chars
+	})
+})

--- a/tests/e2e/admin-mfa.spec.ts
+++ b/tests/e2e/admin-mfa.spec.ts
@@ -10,9 +10,9 @@ async function submitLoginForm(
 	await expect(
 		page.getByRole('heading', { name: 'Sign in' }),
 	).toBeVisible()
-	await page.fill('input[name="email"]', email)
-	await page.fill('input[name="password"]', password)
-	await page.click('button[type="submit"]')
+	await page.getByLabel('Email').fill(email)
+	await page.getByLabel('Password').fill(password)
+	await page.getByRole('button', { name: 'Sign in' }).click()
 }
 
 // Helper: log in with fixture credentials and complete MFA, returning the CSRF
@@ -25,11 +25,11 @@ async function loginWithMfa(
 	await page.waitForURL(/\/admin\/login\/mfa/)
 
 	if (rememberDevice) {
-		await page.check('input[name="rememberDevice"]')
+		await page.getByLabel(/remember/i).check()
 	}
 
 	// The MFA page auto-submits on 6 digits — filling triggers the $effect.
-	await page.fill('input[name="code"]', '000000')
+	await page.getByLabel('Authenticator code').fill('000000')
 	await page.waitForURL(/\/admin\//)
 
 	const csrfToken = await page.evaluate(() =>
@@ -69,8 +69,8 @@ test.describe('Admin — MFA login flow', () => {
 		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
 		await page.waitForURL(/\/admin\/login\/mfa/)
 
-		await page.fill('input[name="code"]', '999999')
-		await page.click('button[type="submit"]')
+		// The $effect auto-submits on 6 digits — no explicit click needed.
+		await page.getByLabel('Authenticator code').fill('999999')
 		await expect(
 			page.getByText('Invalid code. Please try again.'),
 		).toBeVisible()
@@ -95,14 +95,14 @@ test.describe('Admin — MFA login flow', () => {
 		).toBeVisible()
 
 		// Switch to backup code mode
-		await page.click('button:has-text("Use a backup code instead")')
+		await page.getByRole('button', { name: 'Use a backup code instead' }).click()
 		await expect(
 			page.getByRole('heading', { name: 'Enter backup code' }),
 		).toBeVisible()
 		await expect(page.getByLabel('Backup code')).toBeVisible()
 
 		// Switch back
-		await page.click('button:has-text("Use authenticator code instead")')
+		await page.getByRole('button', { name: 'Use authenticator code instead' }).click()
 		await expect(
 			page.getByRole('heading', { name: 'Two-factor authentication' }),
 		).toBeVisible()
@@ -128,13 +128,26 @@ test.describe('Admin — MFA login flow', () => {
 		// First login with "remember device"
 		await loginWithMfa(page, { rememberDevice: true })
 
-		// Navigate away (simulate a new session start by going back to login)
+		// Capture the trusted-device token before clearing all session state.
+		// admin_session is HttpOnly so it can't be cleared via JS — use the context API.
+		const allCookies = await page.context().cookies()
+		const trustedCookie = allCookies.find((c) => c.name === 'admin_trusted_device')
+		expect(trustedCookie).toBeDefined()
+
+		// Clear every cookie (removes admin_session + admin_csrf), then restore
+		// only the trusted-device token so the login load() won't redirect us.
+		await page.context().clearCookies()
+		if (trustedCookie) {
+			await page.context().addCookies([trustedCookie])
+		}
+
+		// Navigate to login — no session present, so the form should render
 		await page.goto('/admin/login')
 
-		// Log in again — trusted device cookie should skip the MFA challenge
-		await page.fill('input[name="email"]', 'e2e-mfa@test.local')
-		await page.fill('input[name="password"]', 'e2e-password')
-		await page.click('button[type="submit"]')
+		// Log in — trusted device should bypass the MFA step entirely
+		await page.getByLabel('Email').fill('e2e-mfa@test.local')
+		await page.getByLabel('Password').fill('e2e-password')
+		await page.getByRole('button', { name: 'Sign in' }).click()
 
 		// Should land in admin without passing through /mfa
 		await expect(page).toHaveURL(/\/admin\//)
@@ -144,7 +157,7 @@ test.describe('Admin — MFA login flow', () => {
 	test('back link on MFA page returns to login', async ({ page }) => {
 		await submitLoginForm(page, 'e2e-mfa@test.local', 'e2e-password')
 		await page.waitForURL(/\/admin\/login\/mfa/)
-		await page.click('a:has-text("Back to sign in")')
+		await page.getByRole('link', { name: 'Back to sign in' }).click()
 		await expect(page).toHaveURL(/\/admin\/login$/)
 	})
 

--- a/tests/e2e/photo-upload.spec.ts
+++ b/tests/e2e/photo-upload.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from "@playwright/test";
+
+// Minimal valid JPEG: SOI + JFIF APP0 marker + EOI.
+// The server's magic-byte check only inspects bytes[0..2] = FF D8 FF.
+const MINIMAL_JPEG = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+]);
+
+// Inside-region fixture pothole coordinates
+const FIXTURE_LAT = 43.45;
+const FIXTURE_LNG = -80.49;
+
+async function createFixturePothole(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<string> {
+  const r = await request.post("/api/report", {
+    data: { lat: FIXTURE_LAT, lng: FIXTURE_LNG, description: "Minor damage" },
+  });
+  expect(r.status()).toBe(200);
+  const d = await r.json();
+  return d.id as string;
+}
+
+async function uploadPhoto(
+  request: import("@playwright/test").APIRequestContext,
+  potholeId: string,
+  extraHeaders?: Record<string, string>,
+) {
+  return request.post("/api/photos", {
+    headers: extraHeaders,
+    multipart: {
+      photo: {
+        name: "test.jpg",
+        mimeType: "image/jpeg",
+        buffer: MINIMAL_JPEG,
+      },
+      pothole_id: potholeId,
+    },
+  });
+}
+
+// Log in with fixture credentials and return the CSRF token from the cookie.
+async function adminLogin(page: import("@playwright/test").Page) {
+  await page.goto("/admin/login");
+  await page.fill('input[name="email"]', "e2e-mfa@test.local");
+  await page.fill('input[name="password"]', "e2e-password");
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/admin\/login\/mfa/);
+  await page.fill('input[name="code"]', "000000");
+  await page.waitForURL(/\/admin\//);
+
+  return page.evaluate(() =>
+    document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("admin_csrf="))
+      ?.split("=")[1] ?? "",
+  );
+}
+
+test.describe("Photo upload API", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.delete("/api/report"); // reset fixture pothole store
+    await request.delete("/api/photos"); // reset fixture photo store
+  });
+
+  test("valid JPEG upload is accepted and returns a photo id", async ({
+    request,
+  }) => {
+    const potholeId = await createFixturePothole(request);
+    const r = await uploadPhoto(request, potholeId);
+
+    expect(r.status()).toBe(200);
+    const d = await r.json();
+    expect(d.ok).toBe(true);
+    expect(typeof d.id).toBe("string");
+    expect(d.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test("simulated content moderation rejection returns 422", async ({
+    request,
+  }) => {
+    const potholeId = await createFixturePothole(request);
+    const r = await uploadPhoto(request, potholeId, {
+      "x-e2e-moderation": "reject",
+    });
+
+    expect(r.status()).toBe(422);
+  });
+
+  test("non-image file is rejected with 400", async ({ request }) => {
+    const potholeId = await createFixturePothole(request);
+    const r = await request.post("/api/photos", {
+      multipart: {
+        photo: {
+          name: "evil.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("not an image"),
+        },
+        pothole_id: potholeId,
+      },
+    });
+    expect(r.status()).toBe(400);
+  });
+
+  test("missing pothole_id returns 400", async ({ request }) => {
+    const r = await request.post("/api/photos", {
+      multipart: {
+        photo: {
+          name: "test.jpg",
+          mimeType: "image/jpeg",
+          buffer: MINIMAL_JPEG,
+        },
+        // pothole_id intentionally omitted
+      },
+    });
+    expect(r.status()).toBe(400);
+  });
+
+  test("invalid UUID for pothole_id returns 400", async ({ request }) => {
+    const r = await request.post("/api/photos", {
+      multipart: {
+        photo: {
+          name: "test.jpg",
+          mimeType: "image/jpeg",
+          buffer: MINIMAL_JPEG,
+        },
+        pothole_id: "not-a-uuid",
+      },
+    });
+    expect(r.status()).toBe(400);
+  });
+});
+
+test.describe("Photo moderation — admin API", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.delete("/api/report");
+    await request.delete("/api/photos");
+  });
+
+  test("admin can approve a pending photo", async ({ page, request }) => {
+    // Set up fixture data
+    const potholeId = await createFixturePothole(request);
+    const uploadRes = await uploadPhoto(request, potholeId);
+    const { id: photoId } = await uploadRes.json();
+
+    // Log in as fixture admin
+    const csrfToken = await adminLogin(page);
+    expect(csrfToken).toBeTruthy();
+
+    // Approve via admin API (uses page.request so session cookie is included)
+    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+      headers: { "x-csrf-token": csrfToken },
+      data: { action: "approve" },
+    });
+
+    expect(res.status()).toBe(200);
+    const d = await res.json();
+    expect(d.ok).toBe(true);
+    expect(d.moderation_status).toBe("approved");
+  });
+
+  test("admin can reject a pending photo", async ({ page, request }) => {
+    const potholeId = await createFixturePothole(request);
+    const uploadRes = await uploadPhoto(request, potholeId);
+    const { id: photoId } = await uploadRes.json();
+
+    const csrfToken = await adminLogin(page);
+
+    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+      headers: { "x-csrf-token": csrfToken },
+      data: { action: "reject" },
+    });
+
+    expect(res.status()).toBe(200);
+    const d = await res.json();
+    expect(d.ok).toBe(true);
+    expect(d.moderation_status).toBe("rejected");
+  });
+
+  test("admin can delete a photo", async ({ page, request }) => {
+    const potholeId = await createFixturePothole(request);
+    const uploadRes = await uploadPhoto(request, potholeId);
+    const { id: photoId } = await uploadRes.json();
+
+    const csrfToken = await adminLogin(page);
+
+    const res = await page.request.delete(`/api/admin/photo/${photoId}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+
+    expect(res.status()).toBe(200);
+    const d = await res.json();
+    expect(d.ok).toBe(true);
+  });
+
+  test("unauthenticated request to admin API returns 401", async ({
+    request,
+  }) => {
+    const potholeId = await createFixturePothole(request);
+    const uploadRes = await uploadPhoto(request, potholeId);
+    const { id: photoId } = await uploadRes.json();
+
+    // Use bare `request` (no session cookie) — should be rejected by hooks
+    const res = await request.patch(`/api/admin/photo/${photoId}`, {
+      data: { action: "approve" },
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("admin request without CSRF token returns 403", async ({
+    page,
+    request,
+  }) => {
+    const potholeId = await createFixturePothole(request);
+    const uploadRes = await uploadPhoto(request, potholeId);
+    const { id: photoId } = await uploadRes.json();
+
+    await adminLogin(page);
+
+    // Omit x-csrf-token header — CSRF check should reject this
+    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+      data: { action: "approve" },
+    });
+
+    expect(res.status()).toBe(403);
+  });
+});

--- a/tests/e2e/photo-upload.spec.ts
+++ b/tests/e2e/photo-upload.spec.ts
@@ -1,231 +1,245 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test'
 
 // Minimal valid JPEG: SOI + JFIF APP0 marker + EOI.
 // The server's magic-byte check only inspects bytes[0..2] = FF D8 FF.
 const MINIMAL_JPEG = Buffer.from([
-  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
-  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
-]);
+	0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+	0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+])
 
 // Inside-region fixture pothole coordinates
-const FIXTURE_LAT = 43.45;
-const FIXTURE_LNG = -80.49;
+const FIXTURE_LAT = 43.45
+const FIXTURE_LNG = -80.49
 
 async function createFixturePothole(
-  request: import("@playwright/test").APIRequestContext,
+	request: import('@playwright/test').APIRequestContext,
 ): Promise<string> {
-  const r = await request.post("/api/report", {
-    data: { lat: FIXTURE_LAT, lng: FIXTURE_LNG, description: "Minor damage" },
-  });
-  expect(r.status()).toBe(200);
-  const d = await r.json();
-  return d.id as string;
+	const r = await request.post('/api/report', {
+		data: { lat: FIXTURE_LAT, lng: FIXTURE_LNG, description: 'Minor damage' },
+	})
+	expect(r.status()).toBe(200)
+	const d = await r.json()
+	return d.id as string
 }
 
 async function uploadPhoto(
-  request: import("@playwright/test").APIRequestContext,
-  potholeId: string,
-  extraHeaders?: Record<string, string>,
+	request: import('@playwright/test').APIRequestContext,
+	potholeId: string,
+	extraHeaders?: Record<string, string>,
 ) {
-  return request.post("/api/photos", {
-    headers: extraHeaders,
-    multipart: {
-      photo: {
-        name: "test.jpg",
-        mimeType: "image/jpeg",
-        buffer: MINIMAL_JPEG,
-      },
-      pothole_id: potholeId,
-    },
-  });
+	return request.post('/api/photos', {
+		headers: extraHeaders,
+		multipart: {
+			photo: {
+				name: 'test.jpg',
+				mimeType: 'image/jpeg',
+				buffer: MINIMAL_JPEG,
+			},
+			pothole_id: potholeId,
+		},
+	})
 }
 
 // Log in with fixture credentials and return the CSRF token from the cookie.
-async function adminLogin(page: import("@playwright/test").Page) {
-  await page.goto("/admin/login");
-  await page.fill('input[name="email"]', "e2e-mfa@test.local");
-  await page.fill('input[name="password"]', "e2e-password");
-  await page.click('button[type="submit"]');
-  await page.waitForURL(/\/admin\/login\/mfa/);
-  await page.fill('input[name="code"]', "000000");
-  await page.waitForURL(/\/admin\//);
+async function adminLogin(page: import('@playwright/test').Page) {
+	await page.goto('/admin/login')
+	await page.fill('input[name="email"]', 'e2e-mfa@test.local')
+	await page.fill('input[name="password"]', 'e2e-password')
+	await page.click('button[type="submit"]')
+	await page.waitForURL(/\/admin\/login\/mfa/)
+	await page.fill('input[name="code"]', '000000')
+	await page.waitForURL(/\/admin\//)
 
-  return page.evaluate(() =>
-    document.cookie
-      .split("; ")
-      .find((c) => c.startsWith("admin_csrf="))
-      ?.split("=")[1] ?? "",
-  );
+	return page.evaluate(() =>
+		document.cookie
+			.split('; ')
+			.find((c) => c.startsWith('admin_csrf='))
+			?.split('=')[1] ?? '',
+	)
 }
 
-test.describe("Photo upload API", () => {
-  test.beforeEach(async ({ request }) => {
-    await request.delete("/api/report"); // reset fixture pothole store
-    await request.delete("/api/photos"); // reset fixture photo store
-  });
+test.describe('Photo upload API', () => {
+	test.beforeEach(async ({ request }) => {
+		await request.delete('/api/report') // reset fixture pothole store
+		await request.delete('/api/photos') // reset fixture photo store
+	})
 
-  test("valid JPEG upload is accepted and returns a photo id", async ({
-    request,
-  }) => {
-    const potholeId = await createFixturePothole(request);
-    const r = await uploadPhoto(request, potholeId);
+	test('valid JPEG upload is accepted and returns a photo id', async ({
+		request,
+	}) => {
+		const potholeId = await createFixturePothole(request)
+		const r = await uploadPhoto(request, potholeId)
 
-    expect(r.status()).toBe(200);
-    const d = await r.json();
-    expect(d.ok).toBe(true);
-    expect(typeof d.id).toBe("string");
-    expect(d.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-  });
+		expect(r.status()).toBe(200)
+		const d = await r.json()
+		expect(d.ok).toBe(true)
+		expect(typeof d.id).toBe('string')
+		expect(d.id).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+		)
+	})
 
-  test("simulated content moderation rejection returns 422", async ({
-    request,
-  }) => {
-    const potholeId = await createFixturePothole(request);
-    const r = await uploadPhoto(request, potholeId, {
-      "x-e2e-moderation": "reject",
-    });
+	test('simulated content moderation rejection returns 422', async ({
+		request,
+	}) => {
+		const potholeId = await createFixturePothole(request)
+		const r = await uploadPhoto(request, potholeId, {
+			'x-e2e-moderation': 'reject',
+		})
 
-    expect(r.status()).toBe(422);
-  });
+		expect(r.status()).toBe(422)
+	})
 
-  test("non-image file is rejected with 400", async ({ request }) => {
-    const potholeId = await createFixturePothole(request);
-    const r = await request.post("/api/photos", {
-      multipart: {
-        photo: {
-          name: "evil.txt",
-          mimeType: "text/plain",
-          buffer: Buffer.from("not an image"),
-        },
-        pothole_id: potholeId,
-      },
-    });
-    expect(r.status()).toBe(400);
-  });
+	test('non-image file is rejected with 400', async ({ request }) => {
+		const potholeId = await createFixturePothole(request)
+		const r = await request.post('/api/photos', {
+			multipart: {
+				photo: {
+					name: 'evil.txt',
+					mimeType: 'text/plain',
+					buffer: Buffer.from('not an image'),
+				},
+				pothole_id: potholeId,
+			},
+		})
+		expect(r.status()).toBe(400)
+	})
 
-  test("missing pothole_id returns 400", async ({ request }) => {
-    const r = await request.post("/api/photos", {
-      multipart: {
-        photo: {
-          name: "test.jpg",
-          mimeType: "image/jpeg",
-          buffer: MINIMAL_JPEG,
-        },
-        // pothole_id intentionally omitted
-      },
-    });
-    expect(r.status()).toBe(400);
-  });
+	test('missing pothole_id returns 400', async ({ request }) => {
+		const r = await request.post('/api/photos', {
+			multipart: {
+				photo: {
+					name: 'test.jpg',
+					mimeType: 'image/jpeg',
+					buffer: MINIMAL_JPEG,
+				},
+				// pothole_id intentionally omitted
+			},
+		})
+		expect(r.status()).toBe(400)
+	})
 
-  test("invalid UUID for pothole_id returns 400", async ({ request }) => {
-    const r = await request.post("/api/photos", {
-      multipart: {
-        photo: {
-          name: "test.jpg",
-          mimeType: "image/jpeg",
-          buffer: MINIMAL_JPEG,
-        },
-        pothole_id: "not-a-uuid",
-      },
-    });
-    expect(r.status()).toBe(400);
-  });
-});
+	test('invalid UUID for pothole_id returns 400', async ({ request }) => {
+		const r = await request.post('/api/photos', {
+			multipart: {
+				photo: {
+					name: 'test.jpg',
+					mimeType: 'image/jpeg',
+					buffer: MINIMAL_JPEG,
+				},
+				pothole_id: 'not-a-uuid',
+			},
+		})
+		expect(r.status()).toBe(400)
+	})
 
-test.describe("Photo moderation — admin API", () => {
-  test.beforeEach(async ({ request }) => {
-    await request.delete("/api/report");
-    await request.delete("/api/photos");
-  });
+	test('unknown pothole UUID returns 404', async ({ request }) => {
+		const r = await request.post('/api/photos', {
+			multipart: {
+				photo: {
+					name: 'test.jpg',
+					mimeType: 'image/jpeg',
+					buffer: MINIMAL_JPEG,
+				},
+				pothole_id: '00000000-0000-4000-8000-000000000000',
+			},
+		})
+		expect(r.status()).toBe(404)
+	})
+})
 
-  test("admin can approve a pending photo", async ({ page, request }) => {
-    // Set up fixture data
-    const potholeId = await createFixturePothole(request);
-    const uploadRes = await uploadPhoto(request, potholeId);
-    const { id: photoId } = await uploadRes.json();
+test.describe('Photo moderation — admin API', () => {
+	test.beforeEach(async ({ request }) => {
+		await request.delete('/api/report')
+		await request.delete('/api/photos')
+	})
 
-    // Log in as fixture admin
-    const csrfToken = await adminLogin(page);
-    expect(csrfToken).toBeTruthy();
+	test('admin can approve a pending photo', async ({ page, request }) => {
+		// Set up fixture data
+		const potholeId = await createFixturePothole(request)
+		const uploadRes = await uploadPhoto(request, potholeId)
+		const { id: photoId } = await uploadRes.json()
 
-    // Approve via admin API (uses page.request so session cookie is included)
-    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
-      headers: { "x-csrf-token": csrfToken },
-      data: { action: "approve" },
-    });
+		// Log in as fixture admin
+		const csrfToken = await adminLogin(page)
+		expect(csrfToken).toBeTruthy()
 
-    expect(res.status()).toBe(200);
-    const d = await res.json();
-    expect(d.ok).toBe(true);
-    expect(d.moderation_status).toBe("approved");
-  });
+		// Approve via admin API (uses page.request so session cookie is included)
+		const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+			headers: { 'x-csrf-token': csrfToken },
+			data: { action: 'approve' },
+		})
 
-  test("admin can reject a pending photo", async ({ page, request }) => {
-    const potholeId = await createFixturePothole(request);
-    const uploadRes = await uploadPhoto(request, potholeId);
-    const { id: photoId } = await uploadRes.json();
+		expect(res.status()).toBe(200)
+		const d = await res.json()
+		expect(d.ok).toBe(true)
+		expect(d.moderation_status).toBe('approved')
+	})
 
-    const csrfToken = await adminLogin(page);
+	test('admin can reject a pending photo', async ({ page, request }) => {
+		const potholeId = await createFixturePothole(request)
+		const uploadRes = await uploadPhoto(request, potholeId)
+		const { id: photoId } = await uploadRes.json()
 
-    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
-      headers: { "x-csrf-token": csrfToken },
-      data: { action: "reject" },
-    });
+		const csrfToken = await adminLogin(page)
 
-    expect(res.status()).toBe(200);
-    const d = await res.json();
-    expect(d.ok).toBe(true);
-    expect(d.moderation_status).toBe("rejected");
-  });
+		const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+			headers: { 'x-csrf-token': csrfToken },
+			data: { action: 'reject' },
+		})
 
-  test("admin can delete a photo", async ({ page, request }) => {
-    const potholeId = await createFixturePothole(request);
-    const uploadRes = await uploadPhoto(request, potholeId);
-    const { id: photoId } = await uploadRes.json();
+		expect(res.status()).toBe(200)
+		const d = await res.json()
+		expect(d.ok).toBe(true)
+		expect(d.moderation_status).toBe('rejected')
+	})
 
-    const csrfToken = await adminLogin(page);
+	test('admin can delete a photo', async ({ page, request }) => {
+		const potholeId = await createFixturePothole(request)
+		const uploadRes = await uploadPhoto(request, potholeId)
+		const { id: photoId } = await uploadRes.json()
 
-    const res = await page.request.delete(`/api/admin/photo/${photoId}`, {
-      headers: { "x-csrf-token": csrfToken },
-    });
+		const csrfToken = await adminLogin(page)
 
-    expect(res.status()).toBe(200);
-    const d = await res.json();
-    expect(d.ok).toBe(true);
-  });
+		const res = await page.request.delete(`/api/admin/photo/${photoId}`, {
+			headers: { 'x-csrf-token': csrfToken },
+		})
 
-  test("unauthenticated request to admin API returns 401", async ({
-    request,
-  }) => {
-    const potholeId = await createFixturePothole(request);
-    const uploadRes = await uploadPhoto(request, potholeId);
-    const { id: photoId } = await uploadRes.json();
+		expect(res.status()).toBe(200)
+		const d = await res.json()
+		expect(d.ok).toBe(true)
+	})
 
-    // Use bare `request` (no session cookie) — should be rejected by hooks
-    const res = await request.patch(`/api/admin/photo/${photoId}`, {
-      data: { action: "approve" },
-    });
+	test('unauthenticated request to admin API returns 401', async ({
+		request,
+	}) => {
+		const potholeId = await createFixturePothole(request)
+		const uploadRes = await uploadPhoto(request, potholeId)
+		const { id: photoId } = await uploadRes.json()
 
-    expect(res.status()).toBe(401);
-  });
+		// Use bare `request` (no session cookie) — should be rejected by hooks
+		const res = await request.patch(`/api/admin/photo/${photoId}`, {
+			data: { action: 'approve' },
+		})
 
-  test("admin request without CSRF token returns 403", async ({
-    page,
-    request,
-  }) => {
-    const potholeId = await createFixturePothole(request);
-    const uploadRes = await uploadPhoto(request, potholeId);
-    const { id: photoId } = await uploadRes.json();
+		expect(res.status()).toBe(401)
+	})
 
-    await adminLogin(page);
+	test('admin request without CSRF token returns 403', async ({
+		page,
+		request,
+	}) => {
+		const potholeId = await createFixturePothole(request)
+		const uploadRes = await uploadPhoto(request, potholeId)
+		const { id: photoId } = await uploadRes.json()
 
-    // Omit x-csrf-token header — CSRF check should reject this
-    const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
-      data: { action: "approve" },
-    });
+		await adminLogin(page)
 
-    expect(res.status()).toBe(403);
-  });
-});
+		// Omit x-csrf-token header — CSRF check should reject this
+		const res = await page.request.patch(`/api/admin/photo/${photoId}`, {
+			data: { action: 'approve' },
+		})
+
+		expect(res.status()).toBe(403)
+	})
+})

--- a/tests/e2e/photo-upload.spec.ts
+++ b/tests/e2e/photo-upload.spec.ts
@@ -43,11 +43,12 @@ async function uploadPhoto(
 // Log in with fixture credentials and return the CSRF token from the cookie.
 async function adminLogin(page: import('@playwright/test').Page) {
 	await page.goto('/admin/login')
-	await page.fill('input[name="email"]', 'e2e-mfa@test.local')
-	await page.fill('input[name="password"]', 'e2e-password')
-	await page.click('button[type="submit"]')
+	await page.getByLabel('Email').fill('e2e-mfa@test.local')
+	await page.getByLabel('Password').fill('e2e-password')
+	await page.getByRole('button', { name: 'Sign in' }).click()
 	await page.waitForURL(/\/admin\/login\/mfa/)
-	await page.fill('input[name="code"]', '000000')
+	// The MFA page auto-submits on 6 digits — filling triggers the $effect.
+	await page.getByLabel('Authenticator code').fill('000000')
 	await page.waitForURL(/\/admin\//)
 
 	return page.evaluate(() =>

--- a/tests/e2e/report-dedup.spec.ts
+++ b/tests/e2e/report-dedup.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+
+// Coordinates well inside Waterloo Region (near Kitchener centre)
+const BASE_LAT = 43.45;
+const BASE_LNG = -80.49;
+
+// 20 m north ≈ 0.00018° at this latitude — inside the 25 m merge radius
+const OFFSET_NEAR = 0.00018;
+
+// 40 m north ≈ 0.00036° — outside the 25 m merge radius
+const OFFSET_FAR = 0.00036;
+
+test.describe("Report API — 25 m merge deduplication", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.delete("/api/report"); // clear fixture pothole store
+  });
+
+  test("two reports within 25 m are merged into the same pothole", async ({
+    request,
+  }) => {
+    const r1 = await request.post("/api/report", {
+      data: {
+        lat: BASE_LAT,
+        lng: BASE_LNG,
+        address: "First report",
+        description: "Minor damage",
+      },
+    });
+    expect(r1.status()).toBe(200);
+    const d1 = await r1.json();
+    expect(d1.id).toBeTruthy();
+    expect(d1.confirmed).toBe(false);
+
+    const r2 = await request.post("/api/report", {
+      data: {
+        lat: BASE_LAT + OFFSET_NEAR,
+        lng: BASE_LNG,
+        address: "Second report",
+        description: "Minor damage",
+      },
+    });
+    expect(r2.status()).toBe(200);
+    const d2 = await r2.json();
+
+    // Second confirmation pushes the same pothole live
+    expect(d2.id).toBe(d1.id);
+    expect(d2.confirmed).toBe(true);
+  });
+
+  test("two reports more than 25 m apart are distinct potholes", async ({
+    request,
+  }) => {
+    const r1 = await request.post("/api/report", {
+      data: { lat: BASE_LAT, lng: BASE_LNG, description: "Minor damage" },
+    });
+    expect(r1.status()).toBe(200);
+    const d1 = await r1.json();
+
+    const r2 = await request.post("/api/report", {
+      data: {
+        lat: BASE_LAT + OFFSET_FAR,
+        lng: BASE_LNG,
+        description: "Minor damage",
+      },
+    });
+    expect(r2.status()).toBe(200);
+    const d2 = await r2.json();
+
+    expect(d2.id).not.toBe(d1.id);
+    expect(d2.confirmed).toBe(false);
+  });
+
+  test("three consecutive reports within 25 m produce one confirmed pothole", async ({
+    request,
+  }) => {
+    const post = (offset: number) =>
+      request.post("/api/report", {
+        data: {
+          lat: BASE_LAT + offset,
+          lng: BASE_LNG,
+          description: "Moderate damage",
+        },
+      });
+
+    const d1 = await (await post(0)).json();
+    const d2 = await (await post(0.00005)).json(); // ~5 m away
+    const d3 = await (await post(0.0001)).json(); // ~11 m away
+
+    expect(d2.id).toBe(d1.id);
+    expect(d3.id).toBe(d1.id);
+    // After 2 confirmations, pothole is marked confirmed
+    expect(d2.confirmed).toBe(true);
+  });
+
+  test("report outside Waterloo Region geofence is rejected with 422", async ({
+    request,
+  }) => {
+    // Toronto coordinates — outside the geofence
+    const r = await request.post("/api/report", {
+      data: { lat: 43.65, lng: -79.38, description: "Minor damage" },
+    });
+    expect(r.status()).toBe(422);
+  });
+
+  test("report at geofence boundary inside region is accepted", async ({
+    request,
+  }) => {
+    // Exactly at latMin (43.32) — inside edge
+    const r = await request.post("/api/report", {
+      data: {
+        lat: 43.32,
+        lng: BASE_LNG,
+        description: "Minor damage",
+      },
+    });
+    expect(r.status()).toBe(200);
+  });
+
+  test("invalid JSON body returns 400", async ({ request }) => {
+    const r = await request.post("/api/report", {
+      headers: { "Content-Type": "application/json" },
+      data: "not-json",
+    });
+    expect(r.status()).toBe(400);
+  });
+});

--- a/tests/e2e/report-dedup.spec.ts
+++ b/tests/e2e/report-dedup.spec.ts
@@ -1,126 +1,126 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test'
 
 // Coordinates well inside Waterloo Region (near Kitchener centre)
-const BASE_LAT = 43.45;
-const BASE_LNG = -80.49;
+const BASE_LAT = 43.45
+const BASE_LNG = -80.49
 
 // 20 m north ≈ 0.00018° at this latitude — inside the 25 m merge radius
-const OFFSET_NEAR = 0.00018;
+const OFFSET_NEAR = 0.00018
 
 // 40 m north ≈ 0.00036° — outside the 25 m merge radius
-const OFFSET_FAR = 0.00036;
+const OFFSET_FAR = 0.00036
 
-test.describe("Report API — 25 m merge deduplication", () => {
-  test.beforeEach(async ({ request }) => {
-    await request.delete("/api/report"); // clear fixture pothole store
-  });
+test.describe('Report API — 25 m merge deduplication', () => {
+	test.beforeEach(async ({ request }) => {
+		await request.delete('/api/report') // clear fixture pothole store
+	})
 
-  test("two reports within 25 m are merged into the same pothole", async ({
-    request,
-  }) => {
-    const r1 = await request.post("/api/report", {
-      data: {
-        lat: BASE_LAT,
-        lng: BASE_LNG,
-        address: "First report",
-        description: "Minor damage",
-      },
-    });
-    expect(r1.status()).toBe(200);
-    const d1 = await r1.json();
-    expect(d1.id).toBeTruthy();
-    expect(d1.confirmed).toBe(false);
+	test('two reports within 25 m are merged into the same pothole', async ({
+		request,
+	}) => {
+		const r1 = await request.post('/api/report', {
+			data: {
+				lat: BASE_LAT,
+				lng: BASE_LNG,
+				address: 'First report',
+				description: 'Minor damage',
+			},
+		})
+		expect(r1.status()).toBe(200)
+		const d1 = await r1.json()
+		expect(d1.id).toBeTruthy()
+		expect(d1.confirmed).toBe(false)
 
-    const r2 = await request.post("/api/report", {
-      data: {
-        lat: BASE_LAT + OFFSET_NEAR,
-        lng: BASE_LNG,
-        address: "Second report",
-        description: "Minor damage",
-      },
-    });
-    expect(r2.status()).toBe(200);
-    const d2 = await r2.json();
+		const r2 = await request.post('/api/report', {
+			data: {
+				lat: BASE_LAT + OFFSET_NEAR,
+				lng: BASE_LNG,
+				address: 'Second report',
+				description: 'Minor damage',
+			},
+		})
+		expect(r2.status()).toBe(200)
+		const d2 = await r2.json()
 
-    // Second confirmation pushes the same pothole live
-    expect(d2.id).toBe(d1.id);
-    expect(d2.confirmed).toBe(true);
-  });
+		// Second confirmation pushes the same pothole live
+		expect(d2.id).toBe(d1.id)
+		expect(d2.confirmed).toBe(true)
+	})
 
-  test("two reports more than 25 m apart are distinct potholes", async ({
-    request,
-  }) => {
-    const r1 = await request.post("/api/report", {
-      data: { lat: BASE_LAT, lng: BASE_LNG, description: "Minor damage" },
-    });
-    expect(r1.status()).toBe(200);
-    const d1 = await r1.json();
+	test('two reports more than 25 m apart are distinct potholes', async ({
+		request,
+	}) => {
+		const r1 = await request.post('/api/report', {
+			data: { lat: BASE_LAT, lng: BASE_LNG, description: 'Minor damage' },
+		})
+		expect(r1.status()).toBe(200)
+		const d1 = await r1.json()
 
-    const r2 = await request.post("/api/report", {
-      data: {
-        lat: BASE_LAT + OFFSET_FAR,
-        lng: BASE_LNG,
-        description: "Minor damage",
-      },
-    });
-    expect(r2.status()).toBe(200);
-    const d2 = await r2.json();
+		const r2 = await request.post('/api/report', {
+			data: {
+				lat: BASE_LAT + OFFSET_FAR,
+				lng: BASE_LNG,
+				description: 'Minor damage',
+			},
+		})
+		expect(r2.status()).toBe(200)
+		const d2 = await r2.json()
 
-    expect(d2.id).not.toBe(d1.id);
-    expect(d2.confirmed).toBe(false);
-  });
+		expect(d2.id).not.toBe(d1.id)
+		expect(d2.confirmed).toBe(false)
+	})
 
-  test("three consecutive reports within 25 m produce one confirmed pothole", async ({
-    request,
-  }) => {
-    const post = (offset: number) =>
-      request.post("/api/report", {
-        data: {
-          lat: BASE_LAT + offset,
-          lng: BASE_LNG,
-          description: "Moderate damage",
-        },
-      });
+	test('three consecutive reports within 25 m produce one confirmed pothole', async ({
+		request,
+	}) => {
+		const post = (offset: number) =>
+			request.post('/api/report', {
+				data: {
+					lat: BASE_LAT + offset,
+					lng: BASE_LNG,
+					description: 'Moderate damage',
+				},
+			})
 
-    const d1 = await (await post(0)).json();
-    const d2 = await (await post(0.00005)).json(); // ~5 m away
-    const d3 = await (await post(0.0001)).json(); // ~11 m away
+		const d1 = await (await post(0)).json()
+		const d2 = await (await post(0.00005)).json() // ~5 m away
+		const d3 = await (await post(0.0001)).json() // ~11 m away
 
-    expect(d2.id).toBe(d1.id);
-    expect(d3.id).toBe(d1.id);
-    // After 2 confirmations, pothole is marked confirmed
-    expect(d2.confirmed).toBe(true);
-  });
+		expect(d2.id).toBe(d1.id)
+		expect(d3.id).toBe(d1.id)
+		// After 2 confirmations, pothole is marked confirmed
+		expect(d2.confirmed).toBe(true)
+	})
 
-  test("report outside Waterloo Region geofence is rejected with 422", async ({
-    request,
-  }) => {
-    // Toronto coordinates — outside the geofence
-    const r = await request.post("/api/report", {
-      data: { lat: 43.65, lng: -79.38, description: "Minor damage" },
-    });
-    expect(r.status()).toBe(422);
-  });
+	test('report outside Waterloo Region geofence is rejected with 422', async ({
+		request,
+	}) => {
+		// Toronto coordinates — outside the geofence
+		const r = await request.post('/api/report', {
+			data: { lat: 43.65, lng: -79.38, description: 'Minor damage' },
+		})
+		expect(r.status()).toBe(422)
+	})
 
-  test("report at geofence boundary inside region is accepted", async ({
-    request,
-  }) => {
-    // Exactly at latMin (43.32) — inside edge
-    const r = await request.post("/api/report", {
-      data: {
-        lat: 43.32,
-        lng: BASE_LNG,
-        description: "Minor damage",
-      },
-    });
-    expect(r.status()).toBe(200);
-  });
+	test('report at geofence boundary inside region is accepted', async ({
+		request,
+	}) => {
+		// Exactly at latMin (43.32) — inside edge
+		const r = await request.post('/api/report', {
+			data: {
+				lat: 43.32,
+				lng: BASE_LNG,
+				description: 'Minor damage',
+			},
+		})
+		expect(r.status()).toBe(200)
+	})
 
-  test("invalid JSON body returns 400", async ({ request }) => {
-    const r = await request.post("/api/report", {
-      headers: { "Content-Type": "application/json" },
-      data: "not-json",
-    });
-    expect(r.status()).toBe(400);
-  });
-});
+	test('invalid JSON body returns 400', async ({ request }) => {
+		const r = await request.post('/api/report', {
+			headers: { 'Content-Type': 'application/json' },
+			data: 'not-json',
+		})
+		expect(r.status()).toBe(400)
+	})
+})


### PR DESCRIPTION
## Summary

- **`INCIDENT_RESPONSE.md`** — new playbook covering the full breach response lifecycle
- **`CLAUDE.md`** — cross-reference added to the Workflow section
- **E2E fixture infrastructure** — Playwright fixture layer for admin MFA, photo moderation, and report dedup tests (25 tests across 3 spec files). Fixture short-circuits in `/api/report`, `/api/photos`, `/api/admin/photo/[id]`, `admin/login`, and `admin/login/mfa` are all guarded by `PLAYWRIGHT_E2E_FIXTURES === 'true' && CI === 'true'` to prevent accidental activation outside GitHub Actions. `svelte.config.js` CSRF `checkOrigin` is also co-guarded with the same condition.

## What the playbook covers

**§1 — What counts as an incident**: committed secrets, unauthorized DB/storage access, admin credential compromise, dependency vulns, premature photo exposure.

**§2 — Data inventory**: maps every table and column that holds personal information (ip_hash rows across 7 tables, push subscription endpoints + keys, photo content, admin credentials) with sensitivity ratings and caveats (e.g. ip_hash is only reversible if `IP_HASH_SECRET` is also exposed).

**§3 — RROSH determination table**: clear YES/PROBABLY NOT split so the on-call decision is fast:
- `IP_HASH_SECRET` exposed → YES (IP addresses become reversible)
- `SUPABASE_SERVICE_ROLE_KEY` with access evidence → YES
- `TOTP_ENCRYPTION_KEY` + admin secrets → YES
- VAPID keys + subscription list → YES
- Session/CSRF secrets alone → probably not

**§4 — Per-secret rotation procedures**: every `.env.example` var in criticality order, with the specific Supabase/Netlify/dashboard steps and the downstream consequences of each rotation (e.g. TOTP key rotation forces all admins to re-enroll; VAPID rotation silently breaks existing push subscriptions until users revisit the site).

**§5 — PIPEDA obligations**: 72-hour OPC report target, concurrent individual notification, 24-month breach record retention keyed off the date the organization determines a breach has occurred (even for non-RROSH incidents). Acknowledges the anonymous-user notification challenge and provides the site banner + push notification as practicable alternatives to email.

**§6 — Timeline**: 0–1 h contain → 1–24 h assess → 24–72 h notify → ongoing review. Includes the SQL to wipe admin sessions/challenges/trusted devices in a single paste.

**§7 — Templates**: OPC report draft and site banner copy, both with fill-in-the-blank placeholders.

**§8 — Post-incident review**: 7-day checklist capturing root cause, detection gap, response gaps, and preventive action.

## Test plan

- [ ] Read through as if responding to a real incident — verify every step is actionable without looking anything else up
- [ ] Confirm OPC link is correct: https://www.priv.gc.ca/en/report-a-concern/file-a-formal-privacy-complaint/file-a-privacy-breach-report/
- [ ] Confirm the SQL in §6 matches the current schema (admin_sessions, admin_mfa_challenges, admin_trusted_devices tables exist)
- [ ] Verify E2E tests pass in CI (requires `PLAYWRIGHT_E2E_FIXTURES=true` and `CI=true` to be set by the GitHub Actions workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)