### PR TITLE
fix(SEC+PRIV): harden audit trail + add PIPEDA TTL purge for admin tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,13 +175,16 @@ Run migrations in this order:
 15. `schema_review_fixes.sql` — RLS hardening; drops public read on `pothole_confirmations`
 16. `schema_rate_limit_cleanup.sql` — pg_cron purge job for `api_rate_limit_events` older than 90 days (PIPEDA data minimization)
 17. `schema_push_subscription_ttl.sql` — adds `last_used_at` to `push_subscriptions`; pg_cron purge job for subscriptions not refreshed in 180 days (PIPEDA data minimization)
+18. `schema_audit_ttl.sql` — pg_cron purge jobs for `admin_auth_attempts` (90 days) and `admin_audit_log` (24 months) (PIPEDA data minimization)
 
-Four `pg_cron` jobs run nightly:
+Six `pg_cron` jobs run nightly:
 
 - `expire-old-potholes` (03:00 UTC): sets `status = 'expired'` on `reported` potholes older than 90 days.
 - `expire-stale-pending` (03:30 UTC): sets `status = 'expired'` on `pending` potholes older than 14 days (anti-suppression).
 - `purge-rate-limit-events` (04:00 UTC): deletes `api_rate_limit_events` rows older than 90 days (PIPEDA data minimization).
 - `purge-stale-push-subscriptions` (04:30 UTC): deletes `push_subscriptions` rows where `last_used_at` is older than 180 days (PIPEDA data minimization).
+- `purge-admin-auth-attempts` (05:00 UTC): deletes `admin_auth_attempts` rows older than 90 days (PIPEDA data minimization).
+- `purge-admin-audit-log` (05:30 UTC): deletes `admin_audit_log` rows older than 24 months (PIPEDA breach investigation minimum).
 
 ## Status Flow
 

--- a/schema_audit_ttl.sql
+++ b/schema_audit_ttl.sql
@@ -1,0 +1,30 @@
+-- schema_audit_ttl.sql
+-- PIPEDA data minimization: add pg_cron purge jobs for admin audit tables.
+-- These tables have no automatic retention policy and accumulate indefinitely.
+--
+-- Retention periods chosen to balance operational needs with PIPEDA minimization:
+--   admin_auth_attempts  — 90 days  (security telemetry; same as api_rate_limit_events)
+--   admin_audit_log      — 24 months (minimum window for breach investigation evidence)
+--
+-- Unschedule by jobid first (safe no-op if job doesn't exist) so the migration
+-- is idempotent across pg_cron versions that lack the text overload.
+
+select cron.unschedule(jobid) from cron.job where jobname = 'purge-admin-auth-attempts';
+select cron.schedule(
+    'purge-admin-auth-attempts',
+    '0 5 * * *',
+    $$
+        delete from admin_auth_attempts
+        where created_at < now() - interval '90 days';
+    $$
+);
+
+select cron.unschedule(jobid) from cron.job where jobname = 'purge-admin-audit-log';
+select cron.schedule(
+    'purge-admin-audit-log',
+    '30 5 * * *',
+    $$
+        delete from admin_audit_log
+        where created_at < now() - interval '24 months';
+    $$
+);

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -297,20 +297,24 @@ export async function recordAuthAttempt(params: {
 	success: boolean;
 	failureReason?: string;
 }): Promise<void> {
-	const { error: insertError } = await getAdminClient().from('admin_auth_attempts').insert({
-		user_id: params.userId ?? null,
-		email: params.email,
-		ip_address: params.ipHash,
-		user_agent: params.userAgent,
-		attempt_type: params.attemptType,
-		success: params.success,
-		failure_reason: params.failureReason ?? null
-	});
-	if (insertError) {
-		logError('admin-auth/record-attempt', 'Failed to record auth attempt — audit trail entry lost', insertError, {
-			attemptType: params.attemptType,
-			success: params.success
+	try {
+		const { error: insertError } = await getAdminClient().from('admin_auth_attempts').insert({
+			user_id: params.userId ?? null,
+			email: params.email,
+			ip_address: params.ipHash,
+			user_agent: params.userAgent,
+			attempt_type: params.attemptType,
+			success: params.success,
+			failure_reason: params.failureReason ?? null
 		});
+		if (insertError) {
+			logError('admin-auth/record-attempt', 'Failed to record auth attempt — audit trail entry lost', insertError, {
+				attemptType: params.attemptType,
+				success: params.success
+			});
+		}
+	} catch (e) {
+		logError('admin-auth/record-attempt', 'Unexpected error recording auth attempt', e);
 	}
 }
 

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -297,7 +297,7 @@ export async function recordAuthAttempt(params: {
 	success: boolean;
 	failureReason?: string;
 }): Promise<void> {
-	await getAdminClient().from('admin_auth_attempts').insert({
+	const { error: insertError } = await getAdminClient().from('admin_auth_attempts').insert({
 		user_id: params.userId ?? null,
 		email: params.email,
 		ip_address: params.ipHash,
@@ -306,6 +306,12 @@ export async function recordAuthAttempt(params: {
 		success: params.success,
 		failure_reason: params.failureReason ?? null
 	});
+	if (insertError) {
+		logError('admin-auth/record-attempt', 'Failed to record auth attempt — audit trail entry lost', insertError, {
+			attemptType: params.attemptType,
+			success: params.success
+		});
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/bluesky.ts
+++ b/src/lib/server/bluesky.ts
@@ -31,7 +31,12 @@ async function createSession(): Promise<Session | null> {
 		return null;
 	}
 
-	return res.json() as Promise<Session>;
+	try {
+		return (await res.json()) as Session;
+	} catch (e) {
+		logError('bluesky/session', 'Failed to parse Bluesky session response', e);
+		return null;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`recordAuthAttempt()` silent failure (C1)**: The Supabase insert result was never checked — every login, MFA, and signup audit entry could silently fail. Now extracts `{ error }` and logs via `logError()` on failure.
- **`bluesky.ts` unhandled rejection (H4)**: `createSession()` returned `res.json()` as a bare `Promise` cast, meaning a malformed response would propagate a rejection to callers. Changed to `await` inside `try/catch`, returning `null` on parse failure like all other error paths.
- **PIPEDA TTL purge — admin audit tables (C4)**: Added `schema_audit_ttl.sql` with two pg_cron jobs: `admin_auth_attempts` purge after 90 days, `admin_audit_log` purge after 24 months. Both tables had no retention policy — a PIPEDA data minimization gap. The 24-month window for the audit log matches the PIPEDA breach record minimum so forensic evidence survives across the full investigation window.

> Note: Agent finding C3 (admin IPs stored as plaintext) was a false positive — both tables already receive HMAC-SHA-256 hashes via the `ipHash` parameter.

## Test plan

- [ ] Trigger a login attempt (success + failure) and verify `admin_auth_attempts` row is inserted
- [ ] Confirm build passes (TypeScript clean: `npx tsc --noEmit`)
- [ ] Run `schema_audit_ttl.sql` in Supabase SQL editor; verify two new cron jobs appear in `cron.job`
- [ ] Confirm no existing functionality regressed (auth flow, Bluesky posting on next confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)