### PR TITLE
perf/fix: cache headers, layout TTL, webpush cleanup error handling

### DIFF
--- a/src/lib/server/webpush.ts
+++ b/src/lib/server/webpush.ts
@@ -65,6 +65,7 @@ export async function broadcastPush(payload: PushPayload): Promise<void> {
 	);
 
 	if (expired.length > 0) {
-		await db.from('push_subscriptions').delete().in('endpoint', expired);
+		const { error: deleteError } = await db.from('push_subscriptions').delete().in('endpoint', expired);
+		if (deleteError) logError('webpush', 'Failed to remove expired push subscriptions', deleteError);
 	}
 }

--- a/src/lib/server/webpush.ts
+++ b/src/lib/server/webpush.ts
@@ -66,6 +66,6 @@ export async function broadcastPush(payload: PushPayload): Promise<void> {
 
 	if (expired.length > 0) {
 		const { error: deleteError } = await db.from('push_subscriptions').delete().in('endpoint', expired);
-		if (deleteError) logError('webpush', 'Failed to remove expired push subscriptions', deleteError);
+		if (deleteError) logError('webpush', 'failed to remove expired push subscriptions', deleteError);
 	}
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,7 +6,7 @@ type Counts = { reported: number; filled: number };
 
 let cachedCounts: Counts | null = null;
 let cacheTimestamp = 0;
-const CACHE_TTL_MS = 60_000;
+const CACHE_TTL_MS = 5 * 60_000;
 
 export const load: LayoutServerLoad = async () => {
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {

--- a/src/routes/report/+page.server.ts
+++ b/src/routes/report/+page.server.ts
@@ -1,10 +1,11 @@
 import { getConfirmationThreshold } from '$lib/server/settings';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ setHeaders }) => {
 	if (process.env.PLAYWRIGHT_E2E_FIXTURES === 'true') {
 		return { confirmationThreshold: 2 };
 	}
+	setHeaders({ 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' });
 	return {
 		confirmationThreshold: await getConfirmationThreshold(),
 	};


### PR DESCRIPTION
## Summary

- **Report page cache headers (H3)**: `report/+page.server.ts` had no `Cache-Control` — CDN behaviour was undefined. Added `public, s-maxage=300, stale-while-revalidate=600` matching the home page pattern. The only dynamic value (`confirmationThreshold`) changes at most when an admin updates a setting.

- **Layout COUNT query TTL (H7)**: In-memory cache TTL was 60s. Reported/filled counts change slowly — a new confirmation every few minutes at best. Raised to 5 minutes, cutting Supabase queries on the layout load by 5×.

- **Webpush stale endpoint cleanup (M17)**: `broadcastPush()` deleted expired subscriptions via a bare Supabase delete with no error check. Accumulated stale endpoints silently on failure. Now checks `{ error }` and logs via `logError()`.

> Note: M9 (void notify/postConfirmed `.catch()`) was a false positive — both `notify()` and `postConfirmed()`/`postFilled()` already have internal try/catch and are documented as fire-and-forget safe. No change needed.

## Test plan

- [ ] Load `/report` — verify `Cache-Control: public, s-maxage=300` header appears in response
- [ ] Reload the app twice within 5 minutes — verify layout counts don't trigger new Supabase queries (check server logs)
- [ ] TypeScript clean: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)