### PR TITLE
a11y: combobox ARIA for address autocomplete + zinc-500 contrast fixes

### DIFF
--- a/src/lib/components/PushNotifications.svelte
+++ b/src/lib/components/PushNotifications.svelte
@@ -105,7 +105,7 @@
 		Blocked
 	</span>
 {:else if notifState === 'pending'}
-	<span class="inline-flex items-center gap-1.5 text-xs text-zinc-500 animate-pulse">
+	<span class="inline-flex items-center gap-1.5 text-xs text-zinc-400 animate-pulse">
 		<Icon name="bell" size={13} />
 		…
 	</span>

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -103,7 +103,7 @@
 					{/each}
 				</div>
 			{:else if fetchError}
-				<p class="text-zinc-500 text-sm">Couldn't load watchlist status. Try refreshing.</p>
+				<p class="text-zinc-400 text-sm">Couldn't load watchlist status. Try refreshing.</p>
 			{:else if potholes.length > 0}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each visiblePotholes as pothole (pothole.id)}
@@ -117,7 +117,7 @@
 						{@const pillColor =
 							pothole.status === 'reported' ? 'bg-orange-500/10 text-orange-400' :
 							pothole.status === 'filled'   ? 'bg-green-500/10 text-green-400' :
-							'bg-zinc-700/60 text-zinc-500'}
+							'bg-zinc-700/60 text-zinc-400'}
 						<div class="relative bg-zinc-900 rounded-xl overflow-hidden border border-zinc-800 hover:border-zinc-700 transition-colors">
 							<!-- Status accent strip -->
 							<div class="absolute inset-y-0 left-0 w-[3px] {accentColor}"></div>
@@ -154,7 +154,7 @@
 								<div class="flex items-center justify-between gap-2 pt-0.5">
 									<a
 										href="/hole/{pothole.id}"
-										class="text-xs font-medium text-zinc-500 hover:text-sky-400 transition-colors"
+										class="text-xs font-medium text-zinc-400 hover:text-sky-400 transition-colors"
 										aria-label="View details for {pothole.address || 'this pothole'}"
 									>
 										View details →
@@ -175,7 +175,7 @@
 						<button
 							type="button"
 							onclick={() => (showAll = !showAll)}
-							class="text-xs font-medium text-zinc-500 hover:text-sky-400 transition-colors"
+							class="text-xs font-medium text-zinc-400 hover:text-sky-400 transition-colors"
 						>
 							{showAll ? 'Show fewer' : `Show ${potholes.length - PAGE_SIZE} more`}
 						</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -700,7 +700,7 @@
 														{pothole.description || 'Jump to this marker to review details, share it, or mark it fixed.'}
 													</p>
 													{#if pothole.photos_published}
-														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-zinc-500">
+														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-zinc-400">
 															<Icon name="camera" size={11} />
 															Photo
 														</span>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -66,9 +66,29 @@
 	let addressQuery = $state('');
 	let addressSuggestions = $state<Array<{ lat: string; lon: string; display_name: string }>>([]);
 	let addressSearching = $state(false);
+	let addressActiveIndex = $state(-1);
 	let addressDebounce: ReturnType<typeof setTimeout> | null = null;
 	let addressAbortController: AbortController | null = null;
 	let reverseGeocodeAbortController: AbortController | null = null;
+
+	// Reset keyboard-active option whenever the suggestion list changes.
+	$effect(() => { void addressSuggestions; addressActiveIndex = -1; });
+
+	function onAddressKeydown(e: KeyboardEvent) {
+		if (addressSuggestions.length === 0) return;
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			addressActiveIndex = (addressActiveIndex + 1) % addressSuggestions.length;
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			addressActiveIndex = (addressActiveIndex - 1 + addressSuggestions.length) % addressSuggestions.length;
+		} else if (e.key === 'Enter' && addressActiveIndex >= 0) {
+			e.preventDefault();
+			selectSuggestion(addressSuggestions[addressActiveIndex]);
+		} else if (e.key === 'Escape') {
+			addressSuggestions = [];
+		}
+	}
 
 	// Waterloo Region bounding box for Nominatim: minLon,minLat,maxLon,maxLat
 	const WR_VIEWBOX = '-80.59,43.32,-80.22,43.53';
@@ -522,11 +542,19 @@
 						role="combobox"
 						aria-autocomplete="list"
 						aria-expanded={addressSuggestions.length > 0}
-						aria-controls="address-suggestions-list"
+						aria-controls={addressSuggestions.length > 0 ? 'address-suggestions-list' : undefined}
+						aria-activedescendant={addressActiveIndex >= 0 ? `address-suggestion-${addressActiveIndex}` : undefined}
 						aria-haspopup="listbox"
 						placeholder="Enter an address or intersection…"
 						bind:value={addressQuery}
 						oninput={onAddressInput}
+						onkeydown={onAddressKeydown}
+						onblur={(e: FocusEvent) => {
+							const related = e.relatedTarget as HTMLElement | null;
+							if (!related?.closest('#address-suggestions-list')) {
+								addressSuggestions = [];
+							}
+						}}
 						class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-white placeholder-zinc-500 focus:outline-none focus:border-sky-500"
 						autocomplete="off"
 					/>
@@ -543,12 +571,12 @@
 							data-testid="address-suggestions"
 							class="absolute z-10 w-full mt-1 bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl overflow-hidden"
 						>
-							{#each addressSuggestions as s (s.display_name)}
-								<li role="option" aria-selected="false">
+							{#each addressSuggestions as s, i (s.display_name)}
+								<li id="address-suggestion-{i}" role="option" aria-selected={i === addressActiveIndex}>
 									<button
 										type="button"
 										tabindex="-1"
-										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-zinc-200 hover:bg-zinc-700"
+										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-zinc-200 hover:bg-zinc-700 {i === addressActiveIndex ? 'bg-zinc-700' : ''}"
 										onclick={() => selectSuggestion(s)}
 									>
 										{s.display_name}

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -519,6 +519,11 @@
 					<input
 						id="address-search-input"
 						type="text"
+						role="combobox"
+						aria-autocomplete="list"
+						aria-expanded={addressSuggestions.length > 0}
+						aria-controls="address-suggestions-list"
+						aria-haspopup="listbox"
 						placeholder="Enter an address or intersection…"
 						bind:value={addressQuery}
 						oninput={onAddressInput}
@@ -532,13 +537,17 @@
 					{/if}
 					{#if addressSuggestions.length > 0}
 						<ul
+							id="address-suggestions-list"
+							role="listbox"
+							aria-label="Address suggestions"
 							data-testid="address-suggestions"
 							class="absolute z-10 w-full mt-1 bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl overflow-hidden"
 						>
 							{#each addressSuggestions as s (s.display_name)}
-								<li>
+								<li role="option" aria-selected="false">
 									<button
 										type="button"
+										tabindex="-1"
 										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-zinc-200 hover:bg-zinc-700"
 										onclick={() => selectSuggestion(s)}
 									>


### PR DESCRIPTION
## Summary

- **Address autocomplete ARIA (M3, WCAG AA)**: The address search was a plain text input with an unlabelled `<ul>` beside it. Screen readers couldn't discover available suggestions or navigate them. Added the standard ARIA combobox pattern:
  - Input: `role="combobox"`, `aria-autocomplete="list"`, `aria-expanded`, `aria-controls="address-suggestions-list"`, `aria-haspopup="listbox"`
  - List: `role="listbox"`, `id="address-suggestions-list"`, `aria-label`
  - Items: `role="option"`, `aria-selected="false"` on each `<li>`
  - Suggestion buttons get `tabindex="-1"` — keyboard focus stays on the input; screen readers navigate via `role="option"`

- **Contrast ratio fixes (M2, WCAG AA)**: `text-zinc-500` on `bg-zinc-900`/`bg-zinc-950` produces ~4.3:1 contrast, just below the 4.5:1 WCAG AA minimum for normal text. Changed to `text-zinc-400` (~7.2:1) in five public-facing locations:
  - `WatchlistPanel` error message, expired-status pill, "View details →" link, "Show more" button
  - `PushNotifications` pending/loading state
  - Map popup "Photo" badge

> Note: M1 (lightbox `aria-modal`) and C5 (toast `aria-live`) were confirmed already implemented — `role="dialog" aria-modal="true"` is on the lightbox, and svelte-sonner ships its own `aria-live="polite"` region.

## Test plan

- [ ] Tab to address search input, type 3+ characters — verify screen reader announces "N suggestions available" and items are navigable
- [ ] Verify `aria-expanded` toggles between `false` (no results) and `true` (results visible)
- [ ] Run aXe or browser accessibility checker on `/report` — no combobox violations
- [ ] Visual check: zinc-400 secondary text is readable on dark backgrounds without being too bright
- [ ] TypeScript clean: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)