### PR TITLE
perf(M4): preload critical fonts to eliminate CSS @import waterfall

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,13 @@
 	import { page } from '$app/state';
 	import '../app.css';
 	import type { LayoutData } from './$types';
+	// ?url tells Vite to emit the file as an asset and resolve to its hashed URL,
+	// giving us correct preload hrefs without hardcoding build-time hashes.
+	import barlowBold from '@fontsource/barlow-condensed/files/barlow-condensed-latin-700-normal.woff2?url';
+	import publicSans400 from '@fontsource/public-sans/files/public-sans-latin-400-normal.woff2?url';
+	import publicSans500 from '@fontsource/public-sans/files/public-sans-latin-500-normal.woff2?url';
+	import publicSans600 from '@fontsource/public-sans/files/public-sans-latin-600-normal.woff2?url';
+	import publicSans700 from '@fontsource/public-sans/files/public-sans-latin-700-normal.woff2?url';
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 	let counts = $derived(data.counts);
@@ -15,6 +22,12 @@
 <svelte:head>
 	<title>Waterloo Region Pothole Tracker — FillTheHole.ca</title>
 	<link rel="canonical" href="https://fillthehole.ca{page.url.pathname}" />
+	<!-- Preload critical fonts — eliminates the CSS @import waterfall for first paint -->
+	<link rel="preload" href={barlowBold} as="font" type="font/woff2" crossorigin="anonymous" />
+	<link rel="preload" href={publicSans400} as="font" type="font/woff2" crossorigin="anonymous" />
+	<link rel="preload" href={publicSans500} as="font" type="font/woff2" crossorigin="anonymous" />
+	<link rel="preload" href={publicSans600} as="font" type="font/woff2" crossorigin="anonymous" />
+	<link rel="preload" href={publicSans700} as="font" type="font/woff2" crossorigin="anonymous" />
 </svelte:head>
 
 <div class="flex flex-col min-h-screen bg-zinc-950">


### PR DESCRIPTION
## Summary

- Adds `<link rel="preload as="font">` hints in the layout `<svelte:head>` for the five latin-subset font weights used on every page: Barlow Condensed 700, Public Sans 400/500/600/700
- Uses Vite's `?url` suffix on the woff2 imports so preload hrefs resolve to content-hashed asset paths at build time — no hardcoded hashes
- Keeps the existing `@import` declarations in `app.css` (needed for `@font-face` rules)

## Why

The `@import` chain in `app.css` creates a serial discovery waterfall before the browser can start fetching fonts: HTML → CSS → @fontsource CSS → @font-face → woff2. The preload hints queue the woff2 fetches in parallel with the initial HTML parse, eliminating multiple round-trips from the critical rendering path and reducing flash-of-unstyled-text on first paint.

## Test plan

- [ ] `npm run build` — verify no errors
- [ ] Open DevTools Network tab on homepage — `barlow-condensed-latin-700-normal.woff2` and `public-sans-latin-*.woff2` should appear in early network activity with `rel=preload` initiator
- [ ] No visual regressions on home, report, stats, detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)