### PR TITLE
fix(M15/M21/M22): toast overlay, empty map CTA, confirmation progress bar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -106,4 +106,7 @@
 	</footer>
 </div>
 
-<Toaster richColors position="bottom-center" />
+<!-- Fixed overlay keeps Toaster out of document flow regardless of hydration timing. -->
+<div style="position:fixed;inset:0;z-index:9999;pointer-events:none" aria-live="off">
+	<Toaster richColors position="bottom-center" />
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -107,6 +107,6 @@
 </div>
 
 <!-- Fixed overlay keeps Toaster out of document flow regardless of hydration timing. -->
-<div style="position:fixed;inset:0;z-index:9999;pointer-events:none" aria-live="off">
+<div style="position:fixed;inset:0;z-index:9999;pointer-events:none">
 	<Toaster richColors position="bottom-center" />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -761,9 +761,22 @@
 		</div>
 	{/if}
 
-	{#if potholes.length === 0}
-		<div class="absolute top-4 left-1/2 -translate-x-1/2 bg-zinc-950 border border-zinc-700 rounded-xl px-4 py-2 text-sm text-zinc-400 z-[1000]">
-			No potholes yet —&nbsp;<a href="/report" class="text-sky-400 hover:text-sky-300 underline">be the first to report one!</a>
+	{#if potholes.length === 0 && mapReady}
+		<div class="absolute inset-0 flex items-center justify-center z-[1000] pointer-events-none">
+			<div class="pointer-events-auto bg-zinc-950/95 border border-zinc-700 rounded-2xl px-8 py-6 max-w-xs w-full mx-4 text-center shadow-2xl">
+				<div class="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center mx-auto mb-3">
+					<Icon name="map-pin" size={18} class="text-sky-400" />
+				</div>
+				<h2 class="text-sm font-semibold text-white mb-1">No potholes reported yet</h2>
+				<p class="text-xs text-zinc-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
+				<a
+					href="/report"
+					class="inline-flex items-center gap-1.5 bg-sky-600 hover:bg-sky-500 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
+				>
+					<Icon name="plus" size={13} strokeWidth={2.5} />
+					Report a pothole
+				</a>
+			</div>
 		</div>
 	{/if}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -771,7 +771,7 @@
 				<p class="text-xs text-zinc-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
 				<a
 					href="/report"
-					class="inline-flex items-center gap-1.5 bg-sky-600 hover:bg-sky-500 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
+					class="inline-flex items-center gap-1.5 bg-sky-700 hover:bg-sky-600 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
 				>
 					<Icon name="plus" size={13} strokeWidth={2.5} />
 					Report a pothole

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -27,6 +27,11 @@
 	let cityRepairRequests = $derived(data.cityRepairRequests ?? []);
 	let photos = $derived(data.photos ?? []);
 	let confirmationThreshold = $derived(data.confirmationThreshold);
+	let clampedConfirmationCount = $derived(Math.min(pothole.confirmed_count, confirmationThreshold));
+	let remainingConfirmations = $derived(Math.max(0, confirmationThreshold - pothole.confirmed_count));
+	let confirmationProgressPct = $derived(
+		confirmationThreshold > 0 ? Math.min(100, (clampedConfirmationCount / confirmationThreshold) * 100) : 0
+	);
 	let submitted = $derived(page.url.searchParams.get('submitted') === '1');
 	let officialCityLink = $derived(councillor ? CITY_REPORT_LINKS[councillor.city] : null);
 	let nearbyFilled = $derived(data.nearbyFilled ?? []);
@@ -303,10 +308,8 @@
 							Your report is saved and waiting for independent confirmation before it appears on the public map.
 						</p>
 						<div class="space-y-1">
-							{@const clampedCount = Math.min(pothole.confirmed_count, confirmationThreshold)}
-							{@const progressPct = confirmationThreshold > 0 ? Math.min(100, (clampedCount / confirmationThreshold) * 100) : 0}
-							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
-								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{progressPct}%"></div>
+							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 							</div>
 							<p class="text-xs text-zinc-500 tabular-nums">{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</p>
 						</div>
@@ -389,15 +392,12 @@
 				it appears on the public map.
 			</p>
 			<div class="space-y-1.5">
-				{@const clampedCount = Math.min(pothole.confirmed_count, data.confirmationThreshold)}
-				{@const remaining = Math.max(0, data.confirmationThreshold - pothole.confirmed_count)}
-				{@const progressPct = data.confirmationThreshold > 0 ? Math.min(100, (clampedCount / data.confirmationThreshold) * 100) : 0}
 				<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
-					<span>{pothole.confirmed_count} of {data.confirmationThreshold} confirmation{data.confirmationThreshold === 1 ? '' : 's'}</span>
-					<span>{remaining} more needed</span>
+					<span>{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</span>
+					<span>{remainingConfirmations} more needed</span>
 				</div>
-				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedCount} aria-valuemin={0} aria-valuemax={data.confirmationThreshold} aria-label="Confirmation progress">
-					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{progressPct}%"></div>
+				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 				</div>
 			</div>
 		</div>

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -302,16 +302,19 @@
 					<Icon name="check-circle" size={18} class="text-sky-400" />
 				</div>
 				<div class="space-y-1.5">
-					<h2 class="text-base font-semibold text-white">Report received</h2>
+					<h2 id="submitted-card-heading" class="text-base font-semibold text-white">Report received</h2>
 					{#if pothole.status === 'pending'}
 						<p class="text-sm text-zinc-300">
 							Your report is saved and waiting for independent confirmation before it appears on the public map.
 						</p>
 						<div class="space-y-1">
-							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="submitted-card-heading">
 								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 							</div>
-							<p class="text-xs text-zinc-500 tabular-nums">{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</p>
+							<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
+								<span>{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</span>
+								<span>{remainingConfirmations} more needed</span>
+							</div>
 						</div>
 					{:else if pothole.status === 'reported'}
 						<p class="text-sm text-zinc-300">
@@ -383,7 +386,7 @@
 	<!-- Pending notice -->
 	{#if pothole.status === 'pending'}
 		<div class="bg-zinc-800/50 border border-zinc-700 rounded-xl p-4 space-y-3">
-			<p class="flex items-center gap-2 text-zinc-300 font-semibold">
+			<p id="pending-notice-heading" class="flex items-center gap-2 text-zinc-300 font-semibold">
 				<Icon name="clock" size={16} class="text-zinc-400 shrink-0" />
 				Awaiting confirmation
 			</p>
@@ -396,7 +399,7 @@
 					<span>{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</span>
 					<span>{remainingConfirmations} more needed</span>
 				</div>
-				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="pending-notice-heading">
 					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 				</div>
 			</div>

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -303,8 +303,10 @@
 							Your report is saved and waiting for independent confirmation before it appears on the public map.
 						</p>
 						<div class="space-y-1">
-							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={pothole.confirmed_count} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
-								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{Math.min(100, (pothole.confirmed_count / confirmationThreshold) * 100)}%"></div>
+							{@const clampedCount = Math.min(pothole.confirmed_count, confirmationThreshold)}
+							{@const progressPct = confirmationThreshold > 0 ? Math.min(100, (clampedCount / confirmationThreshold) * 100) : 0}
+							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{progressPct}%"></div>
 							</div>
 							<p class="text-xs text-zinc-500 tabular-nums">{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</p>
 						</div>
@@ -387,12 +389,15 @@
 				it appears on the public map.
 			</p>
 			<div class="space-y-1.5">
+				{@const clampedCount = Math.min(pothole.confirmed_count, data.confirmationThreshold)}
+				{@const remaining = Math.max(0, data.confirmationThreshold - pothole.confirmed_count)}
+				{@const progressPct = data.confirmationThreshold > 0 ? Math.min(100, (clampedCount / data.confirmationThreshold) * 100) : 0}
 				<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
 					<span>{pothole.confirmed_count} of {data.confirmationThreshold} confirmation{data.confirmationThreshold === 1 ? '' : 's'}</span>
-					<span>{data.confirmationThreshold - pothole.confirmed_count} more needed</span>
+					<span>{remaining} more needed</span>
 				</div>
-				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={pothole.confirmed_count} aria-valuemin={0} aria-valuemax={data.confirmationThreshold} aria-label="Confirmation progress">
-					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{Math.min(100, (pothole.confirmed_count / data.confirmationThreshold) * 100)}%"></div>
+				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedCount} aria-valuemin={0} aria-valuemax={data.confirmationThreshold} aria-label="Confirmation progress">
+					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{progressPct}%"></div>
 				</div>
 			</div>
 		</div>

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -302,9 +302,12 @@
 						<p class="text-sm text-zinc-300">
 							Your report is saved and waiting for independent confirmation before it appears on the public map.
 						</p>
-						<p class="text-xs text-zinc-400 tabular-nums">
-							Progress: {pothole.confirmed_count}/{confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}
-						</p>
+						<div class="space-y-1">
+							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={pothole.confirmed_count} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-label="Confirmation progress">
+								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{Math.min(100, (pothole.confirmed_count / confirmationThreshold) * 100)}%"></div>
+							</div>
+							<p class="text-xs text-zinc-500 tabular-nums">{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</p>
+						</div>
 					{:else if pothole.status === 'reported'}
 						<p class="text-sm text-zinc-300">
 							This pothole is now live on the public map. Share the link or report it officially to help it get fixed faster.
@@ -374,8 +377,8 @@
 
 	<!-- Pending notice -->
 	{#if pothole.status === 'pending'}
-		<div class="bg-zinc-800/50 border border-zinc-700 rounded-xl p-4 text-center space-y-1.5">
-			<p class="flex items-center justify-center gap-2 text-zinc-300 font-semibold">
+		<div class="bg-zinc-800/50 border border-zinc-700 rounded-xl p-4 space-y-3">
+			<p class="flex items-center gap-2 text-zinc-300 font-semibold">
 				<Icon name="clock" size={16} class="text-zinc-400 shrink-0" />
 				Awaiting confirmation
 			</p>
@@ -383,9 +386,15 @@
 				This pothole needs independent reports from others physically at this location before
 				it appears on the public map.
 			</p>
-			<p class="text-zinc-600 text-xs mt-2 tabular-nums">
-				Confirmations: {pothole.confirmed_count}/{data.confirmationThreshold}
-			</p>
+			<div class="space-y-1.5">
+				<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
+					<span>{pothole.confirmed_count} of {data.confirmationThreshold} confirmation{data.confirmationThreshold === 1 ? '' : 's'}</span>
+					<span>{data.confirmationThreshold - pothole.confirmed_count} more needed</span>
+				</div>
+				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={pothole.confirmed_count} aria-valuemin={0} aria-valuemax={data.confirmationThreshold} aria-label="Confirmation progress">
+					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{Math.min(100, (pothole.confirmed_count / data.confirmationThreshold) * 100)}%"></div>
+				</div>
+			</div>
 		</div>
 	{/if}
 

--- a/tests/e2e/pothole-detail.spec.ts
+++ b/tests/e2e/pothole-detail.spec.ts
@@ -105,7 +105,8 @@ test.describe("Pothole detail page", () => {
     await expect(
       page.getByText(/waiting for independent confirmation/i),
     ).toBeVisible();
-    await expect(page.getByText(/Progress: 1\/2 confirmations/i)).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: /Confirmation progress/i })).toBeVisible();
+    await expect(page.getByText(/1 of 2 confirmations/i)).toBeVisible();
     await expect(
       page.getByRole("heading", {
         level: 1,

--- a/tests/e2e/pothole-detail.spec.ts
+++ b/tests/e2e/pothole-detail.spec.ts
@@ -105,8 +105,8 @@ test.describe("Pothole detail page", () => {
     await expect(
       page.getByText(/waiting for independent confirmation/i),
     ).toBeVisible();
-    await expect(page.getByRole('progressbar', { name: /Confirmation progress/i })).toBeVisible();
-    await expect(page.getByText(/1 of 2 confirmations/i)).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: /Confirmation progress/i }).first()).toBeVisible();
+    await expect(page.getByText(/1 of 2 confirmations/i).first()).toBeVisible();
     await expect(
       page.getByRole("heading", {
         level: 1,

--- a/tests/e2e/pothole-detail.spec.ts
+++ b/tests/e2e/pothole-detail.spec.ts
@@ -105,7 +105,7 @@ test.describe("Pothole detail page", () => {
     await expect(
       page.getByText(/waiting for independent confirmation/i),
     ).toBeVisible();
-    await expect(page.getByRole('progressbar', { name: /Confirmation progress/i }).first()).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: /Report received/i })).toBeVisible();
     await expect(page.getByText(/1 of 2 confirmations/i).first()).toBeVisible();
     await expect(
       page.getByRole("heading", {


### PR DESCRIPTION
## Summary

**M15 — Toast CLS fix**
Wraps `<Toaster>` in an explicit `position:fixed; inset:0; pointer-events:none` overlay so it can never participate in document flow regardless of hydration timing. Eliminates a potential CLS source on first paint.

**M21 — Empty map state CTA**
Replaces the small `top-4` pill with a centered card overlay (only shown after map is ready). Uses `pointer-events-none` on the backdrop so map pan/zoom still works underneath, and `pointer-events-auto` on the card for the CTA.

**M22 — Confirmation progress bar on pending detail page**
Replaces bare "X/Y" text counts with a visual `role="progressbar"` bar on both the post-submit card and the standalone pending notice. Shows current count, total needed, and remaining count — much clearer progress feedback for reporters.

## Test plan

- [ ] Home page — no visible change, Toaster toasts still appear at bottom-center and are dismissible
- [ ] Dev with empty DB — map shows centered card with "Report a pothole" CTA
- [ ] Normal load — empty state card does not flash before map is ready (`mapReady` guard)
- [ ] Navigate to a pending pothole detail page — progress bar renders correctly at current fill %
- [ ] With confirmed_count = 0 and threshold = 2 — bar is empty, "0 of 2", "2 more needed"
- [ ] With confirmed_count = 1 and threshold = 2 — bar is 50% filled, "1 more needed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)