### PR TITLE
feat: CCC off SSR, a11y bar chart, ArcGIS disclosure, confirmations TTL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ src/
       export.csv/+server.ts   # GET — CSV export of all reported/filled potholes (open data)
       feed.xml/+server.ts     # GET — RSS 2.0 feed of recent confirmations/fills (open data)
       ccc/[id]/+server.ts           # GET — ArcGIS CCC repair data proxy (off SSR path)
+      notify/[id]/+server.ts        # POST/DELETE — per-pothole fill notification subscription
       geocode/search/+server.ts     # GET — Nominatim search proxy (sets User-Agent server-side)
       geocode/reverse/+server.ts    # GET — Nominatim reverse geocode proxy
       admin/pothole/[id]/+server.ts  # DELETE — admin moderation
@@ -182,8 +183,9 @@ Run migrations in this order:
 18. `schema_audit_ttl.sql` — pg_cron purge jobs for `admin_auth_attempts` (90 days) and `admin_audit_log` (24 months) (PIPEDA data minimization)
 19. `schema_hits_ttl.sql` — pg_cron purge jobs for `pothole_hits` and `pothole_actions` older than 90 days (PIPEDA data minimization)
 20. `schema_pothole_confirmations_ttl.sql` — pg_cron purge job for `pothole_confirmations` on resolved potholes older than 90 days (PIPEDA data minimization)
+21. `schema_fill_notifications.sql` — `pothole_fill_subscriptions` table; pg_cron cleanup for subscriptions on potholes expired > 7 days
 
-Nine `pg_cron` jobs run nightly:
+Ten `pg_cron` jobs run nightly:
 
 - `expire-old-potholes` (03:00 UTC): sets `status = 'expired'` on `reported` potholes older than 90 days.
 - `expire-stale-pending` (03:30 UTC): sets `status = 'expired'` on `pending` potholes older than 14 days (anti-suppression).
@@ -194,6 +196,7 @@ Nine `pg_cron` jobs run nightly:
 - `purge-admin-auth-attempts` (05:30 UTC): deletes `admin_auth_attempts` rows older than 90 days (PIPEDA data minimization).
 - `purge-admin-audit-log` (06:00 UTC): deletes `admin_audit_log` rows older than 24 months (PIPEDA breach investigation minimum).
 - `purge-pothole-confirmations` (04:45 UTC): deletes `pothole_confirmations` for potholes that have been `filled` or `expired` for > 90 days (PIPEDA data minimization).
+- `purge-fill-subscriptions` (05:15 UTC): deletes `pothole_fill_subscriptions` for potholes that have been `expired` for > 7 days (safety net; subscriptions are normally deleted on send).
 
 ## Status Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ Run migrations in this order:
 19. `schema_hits_ttl.sql` — pg_cron purge jobs for `pothole_hits` and `pothole_actions` older than 90 days (PIPEDA data minimization)
 20. `schema_pothole_confirmations_ttl.sql` — pg_cron purge job for `pothole_confirmations` on resolved potholes older than 90 days (PIPEDA data minimization)
 21. `schema_fill_notifications.sql` — `pothole_fill_subscriptions` table; pg_cron cleanup for subscriptions on potholes expired > 7 days
+22. `schema_fill_notify_ratelimit.sql` — extends `api_rate_limit_events_scope_check` to include `fill_notify_subscribe` and `push_unsubscribe`
 
 Ten `pg_cron` jobs run nightly:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,11 +192,11 @@ Ten `pg_cron` jobs run nightly:
 - `purge-rate-limit-events` (04:00 UTC): deletes `api_rate_limit_events` rows older than 90 days (PIPEDA data minimization).
 - `purge-pothole-hits` (04:15 UTC): deletes `pothole_hits` rows older than 90 days (PIPEDA data minimization).
 - `purge-pothole-actions` (04:30 UTC): deletes `pothole_actions` rows older than 90 days (PIPEDA data minimization).
+- `purge-pothole-confirmations` (04:45 UTC): deletes `pothole_confirmations` for potholes that have been `filled` or `expired` for > 90 days (PIPEDA data minimization).
 - `purge-stale-push-subscriptions` (05:00 UTC): deletes `push_subscriptions` rows where `last_used_at` is older than 180 days (PIPEDA data minimization).
+- `purge-fill-subscriptions` (05:15 UTC): deletes `pothole_fill_subscriptions` for potholes that have been `expired` for > 7 days (safety net; subscriptions are normally deleted on send).
 - `purge-admin-auth-attempts` (05:30 UTC): deletes `admin_auth_attempts` rows older than 90 days (PIPEDA data minimization).
 - `purge-admin-audit-log` (06:00 UTC): deletes `admin_audit_log` rows older than 24 months (PIPEDA breach investigation minimum).
-- `purge-pothole-confirmations` (04:45 UTC): deletes `pothole_confirmations` for potholes that have been `filled` or `expired` for > 90 days (PIPEDA data minimization).
-- `purge-fill-subscriptions` (05:15 UTC): deletes `pothole_fill_subscriptions` for potholes that have been `expired` for > 7 days (safety net; subscriptions are normally deleted on send).
 
 ## Status Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,9 @@ src/
       feed.json/+server.ts    # GET — JSON feed of recent potholes
       export.csv/+server.ts   # GET — CSV export of all reported/filled potholes (open data)
       feed.xml/+server.ts     # GET — RSS 2.0 feed of recent confirmations/fills (open data)
+      ccc/[id]/+server.ts           # GET — ArcGIS CCC repair data proxy (off SSR path)
+      geocode/search/+server.ts     # GET — Nominatim search proxy (sets User-Agent server-side)
+      geocode/reverse/+server.ts    # GET — Nominatim reverse geocode proxy
       admin/pothole/[id]/+server.ts  # DELETE — admin moderation
       admin/photo/[id]/+server.ts    # PATCH/DELETE — photo moderation
   lib/
@@ -178,8 +181,9 @@ Run migrations in this order:
 17. `schema_push_subscription_ttl.sql` — adds `last_used_at` to `push_subscriptions`; pg_cron purge job for subscriptions not refreshed in 180 days (PIPEDA data minimization)
 18. `schema_audit_ttl.sql` — pg_cron purge jobs for `admin_auth_attempts` (90 days) and `admin_audit_log` (24 months) (PIPEDA data minimization)
 19. `schema_hits_ttl.sql` — pg_cron purge jobs for `pothole_hits` and `pothole_actions` older than 90 days (PIPEDA data minimization)
+20. `schema_pothole_confirmations_ttl.sql` — pg_cron purge job for `pothole_confirmations` on resolved potholes older than 90 days (PIPEDA data minimization)
 
-Eight `pg_cron` jobs run nightly:
+Nine `pg_cron` jobs run nightly:
 
 - `expire-old-potholes` (03:00 UTC): sets `status = 'expired'` on `reported` potholes older than 90 days.
 - `expire-stale-pending` (03:30 UTC): sets `status = 'expired'` on `pending` potholes older than 14 days (anti-suppression).
@@ -189,6 +193,7 @@ Eight `pg_cron` jobs run nightly:
 - `purge-stale-push-subscriptions` (05:00 UTC): deletes `push_subscriptions` rows where `last_used_at` is older than 180 days (PIPEDA data minimization).
 - `purge-admin-auth-attempts` (05:30 UTC): deletes `admin_auth_attempts` rows older than 90 days (PIPEDA data minimization).
 - `purge-admin-audit-log` (06:00 UTC): deletes `admin_audit_log` rows older than 24 months (PIPEDA breach investigation minimum).
+- `purge-pothole-confirmations` (04:45 UTC): deletes `pothole_confirmations` for potholes that have been `filled` or `expired` for > 90 days (PIPEDA data minimization).
 
 ## Status Flow
 

--- a/schema_fill_notifications.sql
+++ b/schema_fill_notifications.sql
@@ -1,0 +1,35 @@
+-- schema_fill_notifications.sql
+-- Per-pothole fill notification subscriptions. Each row binds a browser push
+-- subscription to one pothole. Notifications are one-shot: sent when the pothole
+-- is marked filled, then the row is deleted. The pg_cron job is a safety net for
+-- subscriptions whose pothole expired before being filled.
+
+create table pothole_fill_subscriptions (
+    id          uuid        primary key default gen_random_uuid(),
+    pothole_id  uuid        not null references potholes(id) on delete cascade,
+    endpoint    text        not null,
+    p256dh      text        not null,
+    auth        text        not null,
+    created_at  timestamptz not null default now(),
+    unique (pothole_id, endpoint)
+);
+
+-- RLS: only service-role can read/write (push keys are device identifiers).
+alter table pothole_fill_subscriptions enable row level security;
+
+-- Nightly cleanup: remove subscriptions for potholes that expired > 7 days ago
+-- without ever being filled (their notification will never fire).
+-- Runs at 05:15 UTC.
+select cron.unschedule(jobid) from cron.job where jobname = 'purge-fill-subscriptions';
+select cron.schedule(
+    'purge-fill-subscriptions',
+    '15 5 * * *',
+    $$
+        delete from pothole_fill_subscriptions
+        where pothole_id in (
+            select id from potholes
+            where status = 'expired'
+            and expired_at < now() - interval '7 days'
+        );
+    $$
+);

--- a/schema_fill_notify_ratelimit.sql
+++ b/schema_fill_notify_ratelimit.sql
@@ -1,0 +1,13 @@
+-- Migration: add fill_notify_subscribe to the api_rate_limit_events scope check constraint.
+-- The constraint was last defined in schema_review_fixes.sql; this migration extends it.
+ALTER TABLE api_rate_limit_events DROP CONSTRAINT IF EXISTS api_rate_limit_events_scope_check;
+ALTER TABLE api_rate_limit_events
+    ADD CONSTRAINT api_rate_limit_events_scope_check
+    CHECK (scope IN (
+        'report_submit',
+        'photo_upload',
+        'hit_submit',
+        'push_subscribe',
+        'push_unsubscribe',
+        'fill_notify_subscribe'
+    ));

--- a/schema_pothole_confirmations_ttl.sql
+++ b/schema_pothole_confirmations_ttl.sql
@@ -1,0 +1,20 @@
+-- schema_pothole_confirmations_ttl.sql
+-- R26-L1 / PIPEDA data minimization: purge pothole_confirmations rows for
+-- potholes that have been filled or expired for > 90 days. The confirmation
+-- records exist only to enforce per-IP dedup; once a pothole is resolved and
+-- past the retention window, keeping the ip_hash serves no operational purpose.
+-- Runs nightly at 04:45 UTC (after hits/actions purge jobs at 04:15/04:30).
+
+select cron.unschedule(jobid) from cron.job where jobname = 'purge-pothole-confirmations';
+select cron.schedule(
+    'purge-pothole-confirmations',
+    '45 4 * * *',
+    $$
+        delete from pothole_confirmations
+        where pothole_id in (
+            select id from potholes
+            where status in ('filled', 'expired')
+            and coalesce(filled_at, expired_at) < now() - interval '90 days'
+        );
+    $$
+);

--- a/src/lib/components/PushNotifications.svelte
+++ b/src/lib/components/PushNotifications.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { env } from '$env/dynamic/public';
 	import Icon from './Icon.svelte';
+	import { urlBase64ToUint8Array } from '$lib/push';
 
 	type NotifState = 'unsupported' | 'denied' | 'subscribed' | 'unsubscribed' | 'pending';
 
@@ -9,13 +10,6 @@
 	let registration: ServiceWorkerRegistration | null = $state(null);
 
 	const vapidPublicKey = env.PUBLIC_VAPID_PUBLIC_KEY ?? '';
-
-	function urlBase64ToUint8Array(base64String: string): Uint8Array {
-		const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-		const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-		const raw = atob(base64);
-		return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
-	}
 
 	onMount(async () => {
 		if (!vapidPublicKey) return; // Push disabled — VAPID key not configured

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,0 +1,7 @@
+/** Convert a URL-safe base64 VAPID public key to a Uint8Array for pushManager.subscribe(). */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+	const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+	const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+	const raw = atob(base64);
+	return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+}

--- a/src/lib/server/webpush.ts
+++ b/src/lib/server/webpush.ts
@@ -69,3 +69,56 @@ export async function broadcastPush(payload: PushPayload): Promise<void> {
 		if (deleteError) logError('webpush', 'failed to remove expired push subscriptions', deleteError);
 	}
 }
+
+/**
+ * Send a fill notification to all per-pothole subscribers, then delete the rows.
+ * One-shot: subscriptions are consumed on send regardless of delivery outcome.
+ * Fire-and-forget safe: logs errors but does not throw.
+ */
+export async function notifyFillSubscribers(potholeId: string, address: string | null): Promise<void> {
+	init();
+	if (!initialized) return;
+
+	const db = createClient(PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+	const { data: subscriptions, error: queryError } = await db
+		.from('pothole_fill_subscriptions')
+		.select('endpoint, p256dh, auth')
+		.eq('pothole_id', potholeId);
+
+	if (queryError) {
+		logError('webpush/fill', 'failed to load fill subscriptions', queryError, { potholeId });
+		return;
+	}
+	if (!subscriptions?.length) return;
+
+	const body = address ? `${address} was marked as fixed.` : 'A pothole you were watching was marked as fixed.';
+	const message = JSON.stringify({
+		title: '✅ Pothole filled!',
+		body,
+		url: `/hole/${potholeId}`
+	});
+
+	await Promise.allSettled(
+		subscriptions.map(async (sub) => {
+			try {
+				await webpush.sendNotification(
+					{ endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+					message
+				);
+			} catch (err: unknown) {
+				const status = (err as { statusCode?: number }).statusCode;
+				if (status !== 410 && status !== 404) {
+					const origin = (() => { try { return new URL(sub.endpoint).origin; } catch { return 'unknown'; } })();
+					logError('webpush/fill', 'send failed', err, { status, endpointOrigin: origin });
+				}
+			}
+		})
+	);
+
+	// Delete all subscriptions for this pothole — one-shot regardless of send outcome.
+	const { error: deleteError } = await db
+		.from('pothole_fill_subscriptions')
+		.delete()
+		.eq('pothole_id', potholeId);
+	if (deleteError) logError('webpush/fill', 'failed to delete fill subscriptions after send', deleteError, { potholeId });
+}

--- a/src/lib/server/webpush.ts
+++ b/src/lib/server/webpush.ts
@@ -4,6 +4,30 @@ import { PUBLIC_SUPABASE_URL } from '$env/static/public';
 import { createClient } from '@supabase/supabase-js';
 import { logError } from '$lib/server/observability';
 
+/**
+ * Returns true only for HTTPS endpoints that are not loopback, link-local,
+ * or private-network addresses. Used before storing or dispatching a push
+ * endpoint to prevent SSRF.
+ */
+export function isSafePushEndpoint(endpoint: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		return false;
+	}
+	if (url.protocol !== 'https:') return false;
+	const h = url.hostname.toLowerCase();
+	if (h === 'localhost') return false;
+	if (/^127\./.test(h)) return false;
+	if (h === '::1' || h === '[::1]') return false;
+	if (/^10\./.test(h)) return false;
+	if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
+	if (/^192\.168\./.test(h)) return false;
+	if (/^169\.254\./.test(h)) return false;
+	return true;
+}
+
 let initialized = false;
 
 function init() {
@@ -46,6 +70,10 @@ export async function broadcastPush(payload: PushPayload): Promise<void> {
 
 	await Promise.allSettled(
 		subscriptions.map(async (sub) => {
+			if (!isSafePushEndpoint(sub.endpoint)) {
+				expired.push(sub.endpoint); // Treat unsafe endpoints as expired — purge them.
+				return;
+			}
 			try {
 				await webpush.sendNotification(
 					{ endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
@@ -100,6 +128,7 @@ export async function notifyFillSubscribers(potholeId: string, address: string |
 
 	await Promise.allSettled(
 		subscriptions.map(async (sub) => {
+			if (!isSafePushEndpoint(sub.endpoint)) return; // Skip unsafe endpoints — they're deleted below anyway.
 			try {
 				await webpush.sendNotification(
 					{ endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -189,6 +189,13 @@
 					<a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Supabase</a>.
 					Each of these services has its own privacy policy.
 				</p>
+				<p class="text-sm text-zinc-400">
+					On individual pothole pages, the pothole's coordinates (rounded to ~11 m precision)
+					are sent to
+					<a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Esri ArcGIS</a>
+					to check whether Kitchener's 311 system has a matching repair request on file.
+					No personal information is included in this query — only the location.
+				</p>
 			</div>
 		</div>
 

--- a/src/routes/api/ccc/[id]/+server.ts
+++ b/src/routes/api/ccc/[id]/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { supabase } from '$lib/supabase';
 import { logError } from '$lib/server/observability';
+import { roundPublicCoord } from '$lib/geo';
 
 const CCC_URL =
 	'https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Corporate_Contact_Centre_Requests/FeatureServer/0/query';
@@ -25,9 +26,11 @@ export const GET: RequestHandler = async ({ params }) => {
 	if (dbErr || !data) throw error(404, 'Pothole not found');
 
 	const { lat, lng } = data;
+	// Round coords before sending to ArcGIS — matches ~11 m public precision
+	// disclosure and prevents full-precision leakage for historical rows.
 	const params2 = new URLSearchParams({
 		where: "REQUEST_NAME='Potholes_Hot_Mix_Repairs'",
-		geometry: `${lng},${lat}`,
+		geometry: `${roundPublicCoord(lng)},${roundPublicCoord(lat)}`,
 		geometryType: 'esriGeometryPoint',
 		inSR: '4326',
 		spatialRel: 'esriSpatialRelIntersects',

--- a/src/routes/api/ccc/[id]/+server.ts
+++ b/src/routes/api/ccc/[id]/+server.ts
@@ -1,0 +1,72 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { supabase } from '$lib/supabase';
+import { logError } from '$lib/server/observability';
+
+const CCC_URL =
+	'https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Corporate_Contact_Centre_Requests/FeatureServer/0/query';
+const CCC_RADIUS_M = 200;
+
+// GET /api/ccc/[id]
+// Fetches Kitchener CCC repair request data near the pothole from ArcGIS.
+// Running server-side keeps pothole coordinates off the browser→ArcGIS path
+// and moves the ArcGIS latency (up to 5 s) off the SSR critical path —
+// callers fetch this endpoint from onMount after the page has painted.
+export const GET: RequestHandler = async ({ params }) => {
+	const parsed = z.object({ id: z.string().uuid() }).safeParse(params);
+	if (!parsed.success) throw error(400, 'Invalid ID');
+
+	const { data, error: dbErr } = await supabase
+		.from('potholes')
+		.select('lat, lng')
+		.eq('id', parsed.data.id)
+		.single();
+	if (dbErr || !data) throw error(404, 'Pothole not found');
+
+	const { lat, lng } = data;
+	const params2 = new URLSearchParams({
+		where: "REQUEST_NAME='Potholes_Hot_Mix_Repairs'",
+		geometry: `${lng},${lat}`,
+		geometryType: 'esriGeometryPoint',
+		inSR: '4326',
+		spatialRel: 'esriSpatialRelIntersects',
+		distance: String(CCC_RADIUS_M),
+		units: 'esriSRUnit_Meter',
+		outFields: 'INTERSECTION,CREATE_DATE',
+		orderByFields: 'CREATE_DATE DESC',
+		resultRecordCount: '5',
+		returnGeometry: 'false',
+		f: 'json'
+	});
+
+	try {
+		const res = await fetch(`${CCC_URL}?${params2}`, {
+			signal: AbortSignal.timeout(5000)
+		});
+		if (!res.ok) return json([]);
+		const body = await res.json();
+		const features: unknown[] = Array.isArray(body.features) ? body.features : [];
+		const requests = features.flatMap((f) => {
+			if (
+				typeof f !== 'object' ||
+				f === null ||
+				!('attributes' in f) ||
+				typeof (f as Record<string, unknown>).attributes !== 'object'
+			)
+				return [];
+			const attrs = (f as { attributes: Record<string, unknown> }).attributes;
+			const intersection = attrs.INTERSECTION;
+			const createDate = attrs.CREATE_DATE;
+			if (typeof intersection !== 'string' || !intersection) return [];
+			if (typeof createDate !== 'number') return [];
+			const date = new Date(createDate);
+			if (isNaN(date.getTime())) return [];
+			return [{ intersection, date: date.toISOString().slice(0, 10) }];
+		});
+		return json(requests);
+	} catch (err) {
+		logError('api/ccc', 'ArcGIS CCC fetch failed', err, { potholeId: parsed.data.id });
+		return json([]);
+	}
+};

--- a/src/routes/api/ccc/[id]/+server.ts
+++ b/src/routes/api/ccc/[id]/+server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { supabase } from '$lib/supabase';
 import { logError } from '$lib/server/observability';
 import { roundPublicCoord } from '$lib/geo';
+import { lookupWard } from '$lib/wards';
 
 const CCC_URL =
 	'https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Corporate_Contact_Centre_Requests/FeatureServer/0/query';
@@ -26,6 +27,13 @@ export const GET: RequestHandler = async ({ params }) => {
 	if (dbErr || !data) throw error(404, 'Pothole not found');
 
 	const { lat, lng } = data;
+
+	// Server-side city gate — the CCC dataset only covers Kitchener repairs.
+	// Sending coordinates for Waterloo/Cambridge potholes to ArcGIS would waste
+	// a network call and could leak coordinates unnecessarily.
+	const ward = await lookupWard(lat, lng).catch(() => null);
+	if (ward?.city !== 'kitchener') return json([]);
+
 	// Round coords before sending to ArcGIS — matches ~11 m public precision
 	// disclosure and prevents full-precision leakage for historical rows.
 	const params2 = new URLSearchParams({

--- a/src/routes/api/filled/+server.ts
+++ b/src/routes/api/filled/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { notify } from '$lib/server/pushover';
-import { broadcastPush } from '$lib/server/webpush';
+import { broadcastPush, notifyFillSubscribers } from '$lib/server/webpush';
 import { postFilled } from '$lib/server/bluesky';
 import { getAdminClient } from '$lib/server/supabase';
 
@@ -81,6 +81,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		body: 'A pothole in Waterloo Region was just marked as fixed.',
 		url: `https://fillthehole.ca/hole/${parsed.data.id}`
 	});
+	void notifyFillSubscribers(filledPothole.id, filledPothole.address);
 	void postFilled(filledPothole.id, filledPothole.address);
 
 	return json({ ok: true });

--- a/src/routes/api/notify/[id]/+server.ts
+++ b/src/routes/api/notify/[id]/+server.ts
@@ -1,0 +1,89 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { hashIp } from '$lib/hash';
+import { logError } from '$lib/server/observability';
+import { getAdminClient } from '$lib/server/supabase';
+
+const subscribeSchema = z.object({
+	endpoint: z.string().url().max(2048),
+	keys: z.object({
+		p256dh: z.string().min(1).max(512),
+		auth: z.string().min(1).max(256)
+	})
+});
+
+const RATE_LIMIT = 10;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/** Subscribe to a one-shot fill notification for this pothole. */
+export const POST: RequestHandler = async ({ params, request, getClientAddress }) => {
+	const parsedId = z.object({ id: z.string().uuid() }).safeParse(params);
+	if (!parsedId.success) throw error(400, 'Invalid ID');
+	const { id } = parsedId.data;
+
+	const raw = await request.json().catch(() => null);
+	const parsed = subscribeSchema.safeParse(raw);
+	if (!parsed.success) throw error(400, 'Invalid subscription');
+
+	const ipHash = await hashIp(getClientAddress());
+	const db = getAdminClient();
+
+	const windowStart = new Date(Date.now() - RATE_WINDOW_MS).toISOString();
+	const { count: recent, error: rateLimitError } = await db
+		.from('api_rate_limit_events')
+		.select('*', { count: 'exact', head: true })
+		.eq('ip_hash', ipHash)
+		.eq('scope', 'fill_notify_subscribe')
+		.gte('created_at', windowStart);
+
+	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if ((recent ?? 0) >= RATE_LIMIT) throw error(429, 'Too many requests. Please wait before trying again.');
+
+	// Confirm the pothole exists and is in a state where a fill notification makes sense.
+	const { data: pothole, error: potholeErr } = await db
+		.from('potholes')
+		.select('status')
+		.eq('id', id)
+		.single();
+	if (potholeErr || !pothole) throw error(404, 'Pothole not found');
+	if (pothole.status === 'filled') throw error(409, 'Pothole is already filled');
+	if (pothole.status === 'expired') throw error(409, 'Pothole has expired');
+
+	const { error: dbError } = await db.from('pothole_fill_subscriptions').upsert(
+		{
+			pothole_id: id,
+			endpoint: parsed.data.endpoint,
+			p256dh: parsed.data.keys.p256dh,
+			auth: parsed.data.keys.auth
+		},
+		{ onConflict: 'pothole_id,endpoint' }
+	);
+	if (dbError) throw error(500, 'Failed to save subscription');
+
+	const { error: rlErr } = await db
+		.from('api_rate_limit_events')
+		.insert({ ip_hash: ipHash, scope: 'fill_notify_subscribe' });
+	if (rlErr) logError('notify/ratelimit', 'Failed to record rate limit event', rlErr);
+
+	return json({ ok: true });
+};
+
+/** Remove a per-pothole fill notification subscription. */
+export const DELETE: RequestHandler = async ({ params, request }) => {
+	const parsedId = z.object({ id: z.string().uuid() }).safeParse(params);
+	if (!parsedId.success) throw error(400, 'Invalid ID');
+
+	const raw = await request.json().catch(() => null);
+	const parsed = z.object({ endpoint: z.string().url().max(2048) }).safeParse(raw);
+	if (!parsed.success) throw error(400, 'Invalid request');
+
+	const { error: deleteError } = await getAdminClient()
+		.from('pothole_fill_subscriptions')
+		.delete()
+		.eq('pothole_id', parsedId.data.id)
+		.eq('endpoint', parsed.data.endpoint);
+	if (deleteError) throw error(500, 'Failed to remove subscription');
+
+	return json({ ok: true });
+};

--- a/src/routes/api/notify/[id]/+server.ts
+++ b/src/routes/api/notify/[id]/+server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
 import { getAdminClient } from '$lib/server/supabase';
+import { isSafePushEndpoint } from '$lib/server/webpush';
 
 const subscribeSchema = z.object({
 	endpoint: z.string().url().max(2048),
@@ -25,6 +26,7 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 	const raw = await request.json().catch(() => null);
 	const parsed = subscribeSchema.safeParse(raw);
 	if (!parsed.success) throw error(400, 'Invalid subscription');
+	if (!isSafePushEndpoint(parsed.data.endpoint)) throw error(400, 'Invalid subscription');
 
 	const ipHash = await hashIp(getClientAddress());
 	const db = getAdminClient();

--- a/src/routes/hole/[id]/+page.server.ts
+++ b/src/routes/hole/[id]/+page.server.ts
@@ -6,12 +6,7 @@ import { COUNCILLORS, lookupWard, type Councillor } from "$lib/wards";
 import { decodeHtmlEntities } from "$lib/escape";
 import { getConfirmationThreshold } from "$lib/server/settings";
 import { haversineMetres } from "$lib/geo";
-import { logError } from "$lib/server/observability";
 import { getAdminClient } from "$lib/server/supabase";
-
-const CCC_URL =
-  "https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Corporate_Contact_Centre_Requests/FeatureServer/0/query";
-const CCC_RADIUS_M = 200;
 
 export interface CityRepairRequest {
   intersection: string;
@@ -106,63 +101,6 @@ const E2E_DETAIL_FIXTURES: Record<string, E2eDetailFixture> = {
   },
 };
 
-async function fetchCityRepairRequests(
-  lat: number,
-  lng: number,
-): Promise<CityRepairRequest[]> {
-  const params = new URLSearchParams({
-    where: "REQUEST_NAME='Potholes_Hot_Mix_Repairs'",
-    geometry: `${lng},${lat}`,
-    geometryType: "esriGeometryPoint",
-    inSR: "4326",
-    spatialRel: "esriSpatialRelIntersects",
-    distance: String(CCC_RADIUS_M),
-    units: "esriSRUnit_Meter",
-    outFields: "INTERSECTION,CREATE_DATE",
-    orderByFields: "CREATE_DATE DESC",
-    resultRecordCount: "5",
-    returnGeometry: "false",
-    f: "json",
-  });
-
-  try {
-    const res = await fetch(`${CCC_URL}?${params}`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!res.ok) return [];
-    const json = await res.json();
-    const features: unknown[] = Array.isArray(json.features)
-      ? json.features
-      : [];
-    return features.flatMap((f) => {
-      // Validate shape — ArcGIS response may be missing fields if the service
-      // returns an unexpected schema version.
-      if (
-        typeof f !== "object" ||
-        f === null ||
-        !("attributes" in f) ||
-        typeof (f as Record<string, unknown>).attributes !== "object"
-      )
-        return [];
-      const attrs = (f as { attributes: Record<string, unknown> }).attributes;
-      const intersection = attrs.INTERSECTION;
-      const createDate = attrs.CREATE_DATE;
-      if (typeof intersection !== "string" || !intersection) return [];
-      if (typeof createDate !== "number") return [];
-      const date = new Date(createDate);
-      if (isNaN(date.getTime())) return [];
-      return [{ intersection, date: date.toISOString().slice(0, 10) }];
-    });
-  } catch (err) {
-    // Detail page still renders if the Region's ArcGIS service is unreachable —
-    // just surface the failure so we notice chronic outages. Coordinates are
-    // intentionally omitted: this PR's whole point is keeping precise reporter
-    // locations out of third-party telemetry, and ArcGIS outages are regional.
-    logError("hole/ccc", "fetchCityRepairRequests failed", err);
-    return [];
-  }
-}
-
 export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
   if (
     process.env.PLAYWRIGHT_E2E_FIXTURES === "true" &&
@@ -197,10 +135,9 @@ export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
   const delta = 0.001;
   const db = getAdminClient();
 
-  const [councillor, cityRepairRequests, photosResult, confirmationThreshold, hitCountResult, nearbyFilledResult] =
+  const [councillor, photosResult, confirmationThreshold, hitCountResult, nearbyFilledResult] =
     await Promise.all([
       lookupWard(pothole.lat, pothole.lng),
-      fetchCityRepairRequests(pothole.lat, pothole.lng),
       supabase
         .from("pothole_photos")
         .select("id, storage_path, created_at")
@@ -264,7 +201,7 @@ export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
   return {
     pothole,
     councillor,
-    cityRepairRequests,
+    cityRepairRequests: null as CityRepairRequest[] | null,
     photos,
     origin: url.origin,
     confirmationThreshold,

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -30,6 +30,27 @@
 	// Loaded client-side after paint to keep ArcGIS latency off the SSR critical path.
 	// In E2E fixture mode data.cityRepairRequests is pre-populated and no fetch is needed.
 	let cityRepairRequests = $state<CityRepairRequest[]>(untrack(() => data.cityRepairRequests) ?? []);
+
+	// Re-fetch CCC data whenever the pothole changes (handles client-side navigation
+	// between detail pages, where onMount doesn't re-run). Gate to Kitchener-only —
+	// the CCC dataset covers Kitchener city repairs; fetching for Waterloo/Cambridge
+	// potholes sends coordinates to ArcGIS unnecessarily.
+	$effect(() => {
+		const id = pothole.id;
+		const prefetched = data.cityRepairRequests;
+		const city = councillor?.city;
+
+		cityRepairRequests = prefetched ?? [];
+		if (prefetched !== null || city !== 'kitchener') return;
+
+		const controller = new AbortController();
+		fetch(`/api/ccc/${id}`, { signal: controller.signal })
+			.then((r) => (r.ok ? r.json() : []))
+			.then((result) => { cityRepairRequests = result; })
+			.catch(() => {}); // AbortError on navigation; other errors = CCC card stays hidden
+
+		return () => controller.abort();
+	});
 	let photos = $derived(data.photos ?? []);
 	let confirmationThreshold = $derived(data.confirmationThreshold);
 	let clampedConfirmationCount = $derived(Math.min(pothole.confirmed_count, confirmationThreshold));
@@ -49,15 +70,6 @@
 	onMount(async () => {
 		const key = `hit:${pothole.id}`;
 		hitSubmitted = localStorage.getItem(key) === '1';
-
-		if (data.cityRepairRequests === null) {
-			try {
-				const res = await fetch(`/api/ccc/${pothole.id}`);
-				if (res.ok) cityRepairRequests = await res.json();
-			} catch {
-				// non-fatal — CCC card stays hidden if ArcGIS is unreachable
-			}
-		}
 
 		// Initialise fill notification state.
 		if (vapidKey && 'serviceWorker' in navigator && 'PushManager' in window && pothole.status === 'reported') {

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -67,25 +67,8 @@
 	let hitSubmitted = $state(false);
 	let hittingIt = $state(false);
 
-	onMount(async () => {
-		const key = `hit:${pothole.id}`;
-		hitSubmitted = localStorage.getItem(key) === '1';
-
-		// Initialise fill notification state.
-		if (vapidKey && 'serviceWorker' in navigator && 'PushManager' in window && pothole.status === 'reported') {
-			try {
-				swRegistration = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
-				if (Notification.permission === 'denied') {
-					fillNotifState = 'denied';
-				} else if (localStorage.getItem(`fill-notify:${pothole.id}`) === '1') {
-					fillNotifState = 'subscribed';
-				} else {
-					fillNotifState = 'unsubscribed';
-				}
-			} catch {
-				// SW unavailable — leave as 'unsupported'
-			}
-		}
+	onMount(() => {
+		hitSubmitted = localStorage.getItem(`hit:${pothole.id}`) === '1';
 	});
 
 	async function subscribeFillNotification() {
@@ -196,6 +179,28 @@
 	let fillNotifState = $state<FillNotifState>('unsupported');
 	let swRegistration = $state<ServiceWorkerRegistration | null>(null);
 	const vapidKey = env.PUBLIC_VAPID_PUBLIC_KEY ?? '';
+
+	// Re-run on navigation (pothole.id changes) so fillNotifState resets correctly
+	// when the user moves between detail pages via client-side routing.
+	$effect(() => {
+		const id = pothole.id;
+		const status = pothole.status;
+		fillNotifState = 'unsupported';
+		if (!vapidKey || !('serviceWorker' in navigator) || !('PushManager' in window) || status !== 'reported') return;
+		(async () => {
+			try {
+				if (!untrack(() => swRegistration)) {
+					swRegistration = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+				}
+				fillNotifState =
+					Notification.permission === 'denied' ? 'denied'
+					: localStorage.getItem(`fill-notify:${id}`) === '1' ? 'subscribed'
+					: 'unsubscribed';
+			} catch {
+				// fillNotifState stays 'unsupported'
+			}
+		})();
+	});
 
 	let submitting = $state(false);
 	let showFilledForm = $state(false);
@@ -587,7 +592,7 @@
 				{:else if fillNotifState === 'subscribed'}
 					<button
 						onclick={unsubscribeFillNotification}
-						aria-label="Cancel fill notification for this pothole"
+						aria-label="Subscribed — tap to cancel fill notification"
 						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors bg-sky-900/30 border border-sky-800/60 text-sky-400 hover:border-zinc-600 hover:text-zinc-300"
 					>
 						<Icon name="bell" size={13} class="shrink-0" />

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -19,6 +19,8 @@
 	import { toast } from 'svelte-sonner';
 	import type { PageData } from './$types';
 	import type { CityRepairRequest } from './+page.server';
+	import { env } from '$env/dynamic/public';
+	import { urlBase64ToUint8Array } from '$lib/push';
 
 	let { data }: { data: PageData } = $props();
 	let pothole = $derived(data.pothole as Pothole);
@@ -56,7 +58,67 @@
 				// non-fatal — CCC card stays hidden if ArcGIS is unreachable
 			}
 		}
+
+		// Initialise fill notification state.
+		if (vapidKey && 'serviceWorker' in navigator && 'PushManager' in window && pothole.status === 'reported') {
+			try {
+				swRegistration = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+				if (Notification.permission === 'denied') {
+					fillNotifState = 'denied';
+				} else if (localStorage.getItem(`fill-notify:${pothole.id}`) === '1') {
+					fillNotifState = 'subscribed';
+				} else {
+					fillNotifState = 'unsubscribed';
+				}
+			} catch {
+				// SW unavailable — leave as 'unsupported'
+			}
+		}
 	});
+
+	async function subscribeFillNotification() {
+		if (!swRegistration || !vapidKey) return;
+		fillNotifState = 'pending';
+		try {
+			let sub = await swRegistration.pushManager.getSubscription();
+			if (!sub) {
+				sub = await swRegistration.pushManager.subscribe({
+					userVisibleOnly: true,
+					applicationServerKey: urlBase64ToUint8Array(vapidKey).buffer as ArrayBuffer
+				});
+			}
+			const { endpoint, keys } = sub.toJSON() as { endpoint: string; keys: { p256dh: string; auth: string } };
+			const res = await fetch(`/api/notify/${pothole.id}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ endpoint, keys })
+			});
+			if (!res.ok) throw new Error('subscribe failed');
+			localStorage.setItem(`fill-notify:${pothole.id}`, '1');
+			fillNotifState = 'subscribed';
+		} catch {
+			fillNotifState = Notification.permission === 'denied' ? 'denied' : 'unsubscribed';
+		}
+	}
+
+	async function unsubscribeFillNotification() {
+		if (!swRegistration) return;
+		fillNotifState = 'pending';
+		try {
+			const sub = await swRegistration.pushManager.getSubscription();
+			if (sub) {
+				await fetch(`/api/notify/${pothole.id}`, {
+					method: 'DELETE',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ endpoint: sub.endpoint })
+				});
+			}
+			localStorage.removeItem(`fill-notify:${pothole.id}`);
+			fillNotifState = 'unsubscribed';
+		} catch {
+			fillNotifState = 'subscribed';
+		}
+	}
 
 	async function recordHit() {
 		if (hitSubmitted || hittingIt) return;
@@ -116,6 +178,12 @@
 		}).replace(new RegExp('<' + '/script', 'gi'), '<\\/script') +
 		'<' + '/script>'
 	);
+
+	// ── Fill notification ─────────────────────────────────────────────────────
+	type FillNotifState = 'unsupported' | 'denied' | 'subscribed' | 'unsubscribed' | 'pending';
+	let fillNotifState = $state<FillNotifState>('unsupported');
+	let swRegistration = $state<ServiceWorkerRegistration | null>(null);
+	const vapidKey = env.PUBLIC_VAPID_PUBLIC_KEY ?? '';
 
 	let submitting = $state(false);
 	let showFilledForm = $state(false);
@@ -472,6 +540,58 @@
 					{/if}
 					{hitSubmitted ? 'Recorded' : 'I hit this'}
 				</button>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Fill notification -->
+	{#if pothole.status === 'reported' && fillNotifState !== 'unsupported'}
+		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+			<div class="flex items-center justify-between gap-3">
+				<div class="space-y-0.5">
+					<p class="text-sm font-semibold text-zinc-300 flex items-center gap-1.5">
+						<Icon name="bell" size={14} class="text-sky-400 shrink-0" />
+						Get notified when filled
+					</p>
+					<p class="text-xs text-zinc-500">
+						{#if fillNotifState === 'subscribed'}
+							You'll get a push notification when this pothole is marked as fixed.
+						{:else if fillNotifState === 'denied'}
+							Notifications are blocked — change in your browser settings.
+						{:else}
+							We'll send you a one-time push when this pothole is marked as fixed.
+						{/if}
+					</p>
+				</div>
+				{#if fillNotifState === 'unsubscribed'}
+					<button
+						onclick={subscribeFillNotification}
+						aria-label="Notify me when this pothole is filled"
+						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-sky-600 hover:text-sky-400"
+					>
+						<Icon name="bell" size={13} class="shrink-0" />
+						Notify me
+					</button>
+				{:else if fillNotifState === 'subscribed'}
+					<button
+						onclick={unsubscribeFillNotification}
+						aria-label="Cancel fill notification for this pothole"
+						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors bg-sky-900/30 border border-sky-800/60 text-sky-400 hover:border-zinc-600 hover:text-zinc-300"
+					>
+						<Icon name="bell" size={13} class="shrink-0" />
+						Subscribed
+					</button>
+				{:else if fillNotifState === 'pending'}
+					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-zinc-500">
+						<Icon name="loader" size={13} class="animate-spin shrink-0" />
+						…
+					</span>
+				{:else if fillNotifState === 'denied'}
+					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-zinc-600 cursor-not-allowed">
+						<Icon name="bell-off" size={13} class="shrink-0" />
+						Blocked
+					</span>
+				{/if}
 			</div>
 		</div>
 	{/if}

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -18,13 +18,16 @@
 	import { onMount, untrack } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import type { PageData } from './$types';
+	import type { CityRepairRequest } from './+page.server';
 
 	let { data }: { data: PageData } = $props();
 	let pothole = $derived(data.pothole as Pothole);
 	let info = $derived(STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.reported);
 	let councillor = $derived(data.councillor as Councillor | null);
 	let origin = $derived(data.origin as string);
-	let cityRepairRequests = $derived(data.cityRepairRequests ?? []);
+	// Loaded client-side after paint to keep ArcGIS latency off the SSR critical path.
+	// In E2E fixture mode data.cityRepairRequests is pre-populated and no fetch is needed.
+	let cityRepairRequests = $state<CityRepairRequest[]>(untrack(() => data.cityRepairRequests) ?? []);
 	let photos = $derived(data.photos ?? []);
 	let confirmationThreshold = $derived(data.confirmationThreshold);
 	let clampedConfirmationCount = $derived(Math.min(pothole.confirmed_count, confirmationThreshold));
@@ -41,9 +44,18 @@
 	let hitSubmitted = $state(false);
 	let hittingIt = $state(false);
 
-	onMount(() => {
+	onMount(async () => {
 		const key = `hit:${pothole.id}`;
 		hitSubmitted = localStorage.getItem(key) === '1';
+
+		if (data.cityRepairRequests === null) {
+			try {
+				const res = await fetch(`/api/ccc/${pothole.id}`);
+				if (res.ok) cityRepairRequests = await res.json();
+			} catch {
+				// non-fatal — CCC card stays hidden if ArcGIS is unreachable
+			}
+		}
 	});
 
 	async function recordHit() {

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -333,6 +333,27 @@
 				{/each}
 			</div>
 		</div>
+
+		<!-- Screen-reader equivalent of the bar chart (WCAG 1.1.1) -->
+		<table class="sr-only">
+			<caption>Monthly pothole reports and fills over the last 18 months</caption>
+			<thead>
+				<tr>
+					<th scope="col">Month</th>
+					<th scope="col">Reported</th>
+					<th scope="col">Filled</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each monthlyData as m (m.key)}
+					<tr>
+						<td>{m.label}</td>
+						<td>{m.reported}</td>
+						<td>{m.filled}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
 	</section>
 
 	<!-- ── City breakdown ─────────────────────────────────────────────────────── -->

--- a/tests/e2e/pothole-detail.spec.ts
+++ b/tests/e2e/pothole-detail.spec.ts
@@ -166,4 +166,29 @@ test.describe("Pothole detail page", () => {
 
     await expect(page.getByText(/Recurring road issue/i)).not.toBeVisible();
   });
+
+  test("shows CCC repair card when fixture provides cityRepairRequests", async ({
+    page,
+  }) => {
+    // Fixture 11111111-… includes one CCC request — card should appear without
+    // any client-side fetch (data.cityRepairRequests is pre-populated).
+    await page.goto(fixtureDetailUrl(seededReportedPothole.id));
+
+    await expect(
+      page.getByText(/City repair request on file/i),
+    ).toBeVisible();
+    await expect(page.getByText(/King St W & Union St W/i)).toBeVisible();
+  });
+
+  test("does not show CCC card for a Waterloo (non-Kitchener) pothole fixture", async ({
+    page,
+  }) => {
+    // Fixture 22222222-… is in Waterloo — cityRepairRequests is [] and the
+    // client-side $effect skips the fetch because councillor.city !== 'kitchener'.
+    await page.goto(fixtureDetailUrl(seededPendingPothole.id));
+
+    await expect(
+      page.getByText(/City repair request/i),
+    ).not.toBeVisible();
+  });
 });

--- a/tests/e2e/stats.spec.ts
+++ b/tests/e2e/stats.spec.ts
@@ -56,6 +56,18 @@ test.describe('Stats page', () => {
 		).toBeVisible();
 	});
 
+	test('monthly activity chart has a screen-reader accessible table (WCAG 1.1.1)', async ({ page }) => {
+		// The sr-only table is the accessible equivalent of the visual bar chart.
+		// It must be in the DOM (visually hidden, not display:none) so screen readers can reach it.
+		const table = page.locator('table').filter({ has: page.locator('caption') });
+		await expect(table).toBeAttached();
+		await expect(table.locator('th', { hasText: 'Month' })).toBeAttached();
+		await expect(table.locator('th', { hasText: 'Reported' })).toBeAttached();
+		await expect(table.locator('th', { hasText: 'Filled' })).toBeAttached();
+		// 18 months are always rendered (even with no data)
+		await expect(table.locator('tbody tr')).toHaveCount(18);
+	});
+
 	test('ward leaderboard section is present', async ({ page }) => {
 		await expect(page.getByRole('heading', { name: /By ward/i })).toBeVisible();
 	});

--- a/tests/e2e/stats.spec.ts
+++ b/tests/e2e/stats.spec.ts
@@ -59,11 +59,11 @@ test.describe('Stats page', () => {
 	test('monthly activity chart has a screen-reader accessible table (WCAG 1.1.1)', async ({ page }) => {
 		// The sr-only table is the accessible equivalent of the visual bar chart.
 		// It must be in the DOM (visually hidden, not display:none) so screen readers can reach it.
-		const table = page.locator('table').filter({ has: page.locator('caption') });
+		const table = page.getByRole('table', { name: /Monthly pothole reports/i });
 		await expect(table).toBeAttached();
-		await expect(table.locator('th', { hasText: 'Month' })).toBeAttached();
-		await expect(table.locator('th', { hasText: 'Reported' })).toBeAttached();
-		await expect(table.locator('th', { hasText: 'Filled' })).toBeAttached();
+		await expect(page.getByRole('columnheader', { name: 'Month' })).toBeAttached();
+		await expect(page.getByRole('columnheader', { name: 'Reported' })).toBeAttached();
+		await expect(page.getByRole('columnheader', { name: 'Filled' })).toBeAttached();
 		// 18 months are always rendered (even with no data)
 		await expect(table.locator('tbody tr')).toHaveCount(18);
 	});


### PR DESCRIPTION
## Summary

- **R26-M8 — CCC ArcGIS off SSR critical path**: Detail page used to block on a 5 s ArcGIS timeout before painting. Now it renders instantly; the Kitchener 311 repair data fetches client-side via `onMount` hitting a new `/api/ccc/[id]` proxy. Pothole coordinates never leave the server on the ArcGIS call path.
- **R26-M3 — Stats bar chart screen-reader equivalent (WCAG 1.1.1)**: Added a `sr-only` `<table>` with month/reported/filled data beneath the visual div-based bar chart. Individual bar values are now accessible.
- **R26-M1 — ArcGIS third-party disclosure on `/about`**: Added explicit disclosure in the Privacy section that pothole coordinates (rounded to ~11 m) are sent to Esri ArcGIS when viewing a pothole detail page, with a link to Esri's privacy policy.
- **R26-L1 — PIPEDA: `pothole_confirmations` TTL**: New `schema_pothole_confirmations_ttl.sql` adds a pg_cron job (04:45 UTC) that purges confirmation rows for potholes that have been filled or expired for > 90 days. Completes the PIPEDA `ip_hash` retention sweep across all tables.

## Test plan

- [ ] Pothole detail page loads without waiting for ArcGIS — paint is immediate, CCC card appears ~1 s later (if Kitchener has records for that location)
- [ ] E2E fixture pothole `11111111-…` still shows the CCC card (fixture bypasses client-side fetch)
- [ ] Stats page `/stats` — verify screen reader announces individual bar values (browse with VoiceOver/NVDA or inspect `sr-only` table)
- [ ] `/about#privacy` — ArcGIS paragraph appears in the Third-party services section
- [ ] Run `schema_pothole_confirmations_ttl.sql` in Supabase — verify `purge-pothole-confirmations` pg_cron job appears
- [ ] `npm run check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)