### PR TITLE
fix(ux): GPS-first report flow, tools panel overflow, Bluesky observability

### DIFF
--- a/docs/code-review/review-2026-04-27.md
+++ b/docs/code-review/review-2026-04-27.md
@@ -78,17 +78,29 @@ Every new `scope` value used in `api_rate_limit_events` inserts requires a schem
 
 ---
 
-## Open (carry forward from Apr 20 review)
+## Previously Open — All Closed as of 2026-04-28
 
-The following items from `review-2026-04-20.md` remain open as of this session. High-priority ones:
+All items carried forward from `review-2026-04-20.md` are now resolved:
 
-| ID | Finding | Effort |
-|----|---------|--------|
-| SEC-1 | MFA challenge deduplication before insert | S |
-| SILENT-1–3 | `console.error` in admin-auth.ts, `touchSession`/`invalidateSession` not error-checked | S–M |
-| A11Y-3 | `text-zinc-400` contrast failure on `bg-zinc-950` | S |
-| PERF-P2-4 | Leaflet `map.remove()` missing on component unmount | S |
-| CODE-1 | `getAdminClient()` duplicated across 25+ files | S |
-| PRIV-1 | No pre-submission consent notice on report form | S |
+| ID | Finding | Closed in |
+|----|---------|-----------|
+| SEC-1 | MFA challenge deduplication before insert | PR #145 |
+| SILENT-1–3 | `console.error` in admin-auth.ts, `touchSession`/`invalidateSession` not error-checked | PR #145 |
+| A11Y-3 | `text-zinc-400` contrast failure on `bg-zinc-950` | PR #145 |
+| PERF-P2-4 | Leaflet `map.remove()` missing on component unmount | PR #146 |
+| CODE-1 | `getAdminClient()` duplicated across 25+ files | PR #145 |
+| PRIV-1 | No pre-submission consent notice on report form | PR #145 |
 
-See `review-2026-04-20.md` for the full ranked list and roadmap.
+Additionally fixed in PRs #145–#148 (not previously tracked):
+
+| ID | Finding | Closed in |
+|----|---------|-----------|
+| SILENT-5 | `pothole_confirmations` delete not error-checked in admin delete action | PR #145 |
+| SILENT-7 | `admin_trusted_devices` `last_used_at` update not error-checked | PR #145 |
+| A11Y-4 | Photo section header `<div>` not a `<label>`; `<input>` inside conditional made label dangling | PR #145 |
+| A11Y-5 | Live reported count not announced to AT; mobile tray count had duplicate `aria-live` | PR #146, #147 |
+| A11Y-8 | Submitted card `<h2>` appeared before `<h1>` in DOM, violating heading order | PR #147 |
+| UX-8 | No disclosure that photos are reviewed before appearing publicly | PR #145 |
+| UX-9 | Ward heatmap loaded silently with no feedback | PR #146 |
+| SEM-1 | `x-frame-options-misconfiguration` — `allowFrame` param controlled header | PR #148 |
+| SEM-2,3 | `unsafe-formatstring` in `observability.ts` and `hash.ts` | PR #148 |

--- a/src/lib/server/bluesky.ts
+++ b/src/lib/server/bluesky.ts
@@ -6,6 +6,9 @@ const BSKY_PDS = 'https://bsky.social';
 // Bluesky's grapheme limit per post.
 const MAX_POST_LENGTH = 300;
 
+// Log the "not configured" warning at most once per process lifetime.
+let _warnedNotConfigured = false;
+
 interface Session {
 	accessJwt: string;
 	did: string;
@@ -17,7 +20,10 @@ async function createSession(): Promise<Session | null> {
 
 	// Not configured — silently no-op so the app works without Bluesky.
 	if (!handle || !password) {
-		console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		if (!_warnedNotConfigured) {
+			_warnedNotConfigured = true;
+			console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		}
 		return null;
 	}
 
@@ -32,7 +38,7 @@ async function createSession(): Promise<Session | null> {
 		const body = await res.text().catch(() => '');
 		logError(
 			'bluesky/session',
-			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD in Netlify env vars (HTTP ${res.status})`,
+			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD environment variables (HTTP ${res.status})`,
 			new Error(body || String(res.status))
 		);
 		return null;

--- a/src/lib/server/bluesky.ts
+++ b/src/lib/server/bluesky.ts
@@ -16,7 +16,10 @@ async function createSession(): Promise<Session | null> {
 	const password = env.BLUESKY_APP_PASSWORD;
 
 	// Not configured — silently no-op so the app works without Bluesky.
-	if (!handle || !password) return null;
+	if (!handle || !password) {
+		console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		return null;
+	}
 
 	const res = await fetch(`${BSKY_PDS}/xrpc/com.atproto.server.createSession`, {
 		method: 'POST',
@@ -27,7 +30,11 @@ async function createSession(): Promise<Session | null> {
 
 	if (!res.ok) {
 		const body = await res.text().catch(() => '');
-		logError('bluesky/session', `Auth failed with HTTP ${res.status}`, new Error(body || String(res.status)));
+		logError(
+			'bluesky/session',
+			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD in Netlify env vars (HTTP ${res.status})`,
+			new Error(body || String(res.status))
+		);
 		return null;
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,7 @@
 	let watchlistCount = $state(0);
 	let watchlistSection: HTMLElement | null = null;
 	let mobileToolsOpen = $state(false);
+	let reportLocating = $state(false);
 	let liveReportedCount = $derived(
 		potholes.filter((pothole) => pothole.status === 'reported').length
 	);
@@ -69,6 +70,31 @@
 		if (mapRef) mapRef.getContainer().style.cursor = 'crosshair';
 		await tick();
 		cancelReportModeButton?.focus();
+	}
+
+	// Mobile-only: try GPS first, navigate directly to /report if available.
+	// Falls back to pin-drop mode if location is denied or unavailable.
+	function reportHereFromGps() {
+		mobileToolsOpen = false;
+
+		if (!navigator.geolocation) {
+			enterReportMode();
+			return;
+		}
+
+		reportLocating = true;
+		navigator.geolocation.getCurrentPosition(
+			({ coords }) => {
+				reportLocating = false;
+				goto(`/report?lat=${coords.latitude}&lng=${coords.longitude}`);
+			},
+			() => {
+				reportLocating = false;
+				toastError('Location access denied. Tap the map to drop a pin instead.');
+				enterReportMode();
+			},
+			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }
+		);
 	}
 
 	function exitReportMode() {
@@ -638,8 +664,8 @@
 
 	{#if mapReady}
 		<div class="absolute safe-bottom-mobile-tray inset-x-3 z-[1000] sm:hidden">
-			<div class="rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl overflow-hidden">
-				<div class="flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-zinc-800/80">
+			<div class="rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl overflow-hidden flex flex-col">
+				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-zinc-800/80">
 					<div class="min-w-0">
 						<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sky-300">Map tools</p>
 						<p class="text-sm text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
@@ -657,16 +683,21 @@
 					</button>
 				</div>
 
-				<div class="grid grid-cols-2 gap-2 px-4 py-3">
+				<div class="shrink-0 grid grid-cols-2 gap-2 px-4 py-3">
 					<button
 						type="button"
-						onclick={enterReportMode}
+						onclick={reportHereFromGps}
 						aria-pressed={reportMode}
-						disabled={reportMode}
+						disabled={reportMode || reportLocating}
 						class="inline-flex items-center justify-center gap-2 rounded-xl bg-sky-700 px-3 py-3 text-sm font-bold text-white transition-colors hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
 					>
-						<Icon name="map-pin" size={14} class="shrink-0" />
-						Report here
+						{#if reportLocating}
+							<Icon name="loader" size={14} class="animate-spin shrink-0" />
+							Locating…
+						{:else}
+							<Icon name="map-pin" size={14} class="shrink-0" />
+							Report here
+						{/if}
 					</button>
 					<button
 						type="button"
@@ -685,7 +716,8 @@
 				</div>
 
 				{#if mobileToolsOpen}
-					<div id="mobile-map-tools" class="border-t border-zinc-800 px-4 py-3 space-y-4">
+					<div id="mobile-map-tools" class="border-t border-zinc-800 overflow-y-auto max-h-[50dvh]">
+						<div class="px-4 py-3 space-y-4">
 						<div class="space-y-2">
 							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">Recent live reports</h2>
 							{#if recentReportedPotholes.length > 0}
@@ -761,6 +793,7 @@
 								{/each}
 							</div>
 						</div>
+					</div>
 					</div>
 				{/if}
 			</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -78,6 +78,7 @@
 		mobileToolsOpen = false;
 
 		if (!navigator.geolocation) {
+			toastError('Location is not available in this browser. Tap the map to drop a pin instead.');
 			enterReportMode();
 			return;
 		}
@@ -88,9 +89,17 @@
 				reportLocating = false;
 				goto(`/report?lat=${coords.latitude}&lng=${coords.longitude}`);
 			},
-			() => {
+			(error) => {
 				reportLocating = false;
-				toastError('Location access denied. Tap the map to drop a pin instead.');
+				let message = 'Unable to get your location. Tap the map to drop a pin instead.';
+				if (error.code === error.PERMISSION_DENIED) {
+					message = 'Location access denied. Tap the map to drop a pin instead.';
+				} else if (error.code === error.POSITION_UNAVAILABLE) {
+					message = 'Your location is unavailable right now. Tap the map to drop a pin instead.';
+				} else if (error.code === error.TIMEOUT) {
+					message = 'Getting your location took too long. Tap the map to drop a pin instead.';
+				}
+				toastError(message);
 				enterReportMode();
 			},
 			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }


### PR DESCRIPTION
## Summary

Three mobile UX and observability fixes:

**Report here → GPS-first (mobile)**
Previously tapping "Report here" entered pin-drop mode requiring a map tap — forcing users to first use "Find me" to locate themselves, then tap that spot. The button now calls `navigator.geolocation` immediately and navigates directly to `/report?lat=...&lng=...`. If location is denied or the API is unavailable, it falls back to pin-drop with a descriptive toast. Desktop pin-drop flow is unchanged.

**Mobile tools panel overflow**
The panel is `absolute` with `bottom` anchored to the safe area. When expanded, content grew upward; with 4 recent reports + layers + status guide, the header (containing the "Hide" button) scrolled above the top of the viewport, trapping users with no way to close the panel. Fixed with `flex-col` + `shrink-0` on the header and action rows, and `overflow-y-auto max-h-[50dvh]` on the collapsible section — it now scrolls internally.

**Bluesky posting observability**
Added `console.info` when credentials are absent (now visible in Netlify function logs, confirming posting is disabled intentionally vs. silently broken). Auth failure message updated to point directly at `BLUESKY_HANDLE`/`BLUESKY_APP_PASSWORD` in Netlify env vars — most likely cause of the silent posting regression.

> To restore Bluesky posting: check Netlify env vars for `BLUESKY_HANDLE` and `BLUESKY_APP_PASSWORD`. If the app password was rotated in Bluesky account settings, the Netlify var needs updating. Errors surface in Sentry under `area: bluesky/session`.

## Test plan

- [ ] Mobile: tap "Report here" — should show "Locating…" spinner then navigate to `/report` pre-filled with GPS coordinates
- [ ] Mobile: deny location permission, tap "Report here" — should show toast and enter pin-drop mode
- [ ] Mobile: open tools panel, verify it's scrollable and the "Hide" button in the header remains visible at all viewport sizes
- [ ] Netlify function logs: confirm `[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set` appears if either env var is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)