### PR TITLE
style: Civic Data Portal visual redesign — stone/amber, system dark mode, bordered surfaces

### DIFF
--- a/docs/code-review/review-2026-04-27.md
+++ b/docs/code-review/review-2026-04-27.md
@@ -78,17 +78,29 @@ Every new `scope` value used in `api_rate_limit_events` inserts requires a schem
 
 ---
 
-## Open (carry forward from Apr 20 review)
+## Previously Open — All Closed as of 2026-04-28
 
-The following items from `review-2026-04-20.md` remain open as of this session. High-priority ones:
+All items carried forward from `review-2026-04-20.md` are now resolved:
 
-| ID | Finding | Effort |
-|----|---------|--------|
-| SEC-1 | MFA challenge deduplication before insert | S |
-| SILENT-1–3 | `console.error` in admin-auth.ts, `touchSession`/`invalidateSession` not error-checked | S–M |
-| A11Y-3 | `text-zinc-400` contrast failure on `bg-zinc-950` | S |
-| PERF-P2-4 | Leaflet `map.remove()` missing on component unmount | S |
-| CODE-1 | `getAdminClient()` duplicated across 25+ files | S |
-| PRIV-1 | No pre-submission consent notice on report form | S |
+| ID | Finding | Closed in |
+|----|---------|-----------|
+| SEC-1 | MFA challenge deduplication before insert | PR #145 |
+| SILENT-1–3 | `console.error` in admin-auth.ts, `touchSession`/`invalidateSession` not error-checked | PR #145 |
+| A11Y-3 | `text-zinc-400` contrast failure on `bg-zinc-950` | PR #145 |
+| PERF-P2-4 | Leaflet `map.remove()` missing on component unmount | PR #146 |
+| CODE-1 | `getAdminClient()` duplicated across 25+ files | PR #145 |
+| PRIV-1 | No pre-submission consent notice on report form | PR #145 |
 
-See `review-2026-04-20.md` for the full ranked list and roadmap.
+Additionally fixed in PRs #145–#148 (not previously tracked):
+
+| ID | Finding | Closed in |
+|----|---------|-----------|
+| SILENT-5 | `pothole_confirmations` delete not error-checked in admin delete action | PR #145 |
+| SILENT-7 | `admin_trusted_devices` `last_used_at` update not error-checked | PR #145 |
+| A11Y-4 | Photo section header `<div>` not a `<label>`; `<input>` inside conditional made label dangling | PR #145 |
+| A11Y-5 | Live reported count not announced to AT; mobile tray count had duplicate `aria-live` | PR #146, #147 |
+| A11Y-8 | Submitted card `<h2>` appeared before `<h1>` in DOM, violating heading order | PR #147 |
+| UX-8 | No disclosure that photos are reviewed before appearing publicly | PR #145 |
+| UX-9 | Ward heatmap loaded silently with no feedback | PR #146 |
+| SEM-1 | `x-frame-options-misconfiguration` — `allowFrame` param controlled header | PR #148 |
+| SEM-2,3 | `unsafe-formatstring` in `observability.ts` and `hash.ts` | PR #148 |

--- a/docs/superpowers/plans/2026-05-20-visual-redesign.md
+++ b/docs/superpowers/plans/2026-05-20-visual-redesign.md
@@ -1,0 +1,816 @@
+# Visual Redesign — Civic Data Portal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the AI-SaaS visual design (zinc + sky-500 + rounded-2xl + tracking-label pattern) with a Civic Data Portal aesthetic — warm stone palette, amber-500 accent, system-adaptive dark mode, bordered card surfaces, and weight-based label hierarchy.
+
+**Architecture:** Pure visual refactor — no logic, API, or data changes. All changes are Tailwind utility classes and CSS custom properties. Dark mode uses `prefers-color-scheme` media query via Tailwind v4's built-in `dark:` variant (no JS toggle required).
+
+**Tech Stack:** SvelteKit, Tailwind CSS v4, `src/app.css` for global tokens.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-visual-redesign-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/app.css` | Add warm-charcoal token, update focus ring, fix Barlow Condensed `.page-title`, remove duplicate safe-area rules |
+| `src/routes/+layout.svelte` | Nav, header, footer — zinc→stone, sky→amber, rounded-lg→rounded-md |
+| `src/lib/components/HomeIntroCard.svelte` | Remove icon halos + step cards, bordered surface, amber CTA |
+| `src/routes/report/+page.svelte` | Form cards, tab bar, GPS button, inputs, severity cards, submit button |
+| `src/routes/hole/[id]/+page.svelte` | Status badge outlined, zinc→stone surfaces, amber action buttons |
+| `src/routes/stats/+page.svelte` | Bordered surfaces, amber accent, time-filter buttons |
+| `src/routes/about/+page.svelte` | Text colours, bordered cards, amber accent |
+| `src/routes/how-to/+page.svelte` | Bordered legend cards, step icons, text colours |
+| `src/routes/+page.svelte` | Mobile tool tray, homepage overlay colours |
+| `src/routes/hole/[id]/+page.svelte` | Status badge — outlined inline (STATUS_CONFIG only has icon colours) |
+
+---
+
+## Task 1: CSS Foundation — Tokens & Dark Mode
+
+**Files:**
+- Modify: `src/app.css`
+
+- [ ] **Step 1: Update `@theme` block to add warm-charcoal custom colour and remove stale asphalt tokens**
+
+  Replace the entire `@theme` block in `src/app.css`:
+
+  ```css
+  @theme {
+    --font-sans: "Public Sans", system-ui, sans-serif;
+    --font-brand: "Barlow Condensed", system-ui, sans-serif;
+    --color-asphalt: #191714;
+  }
+  ```
+
+  (`--color-asphalt-light` removed — unused after this redesign. `--color-asphalt` is now the warm dark base used in dark mode.)
+
+- [ ] **Step 2: Update focus ring from sky-500 to amber-500**
+
+  In `src/app.css`, change:
+
+  ```css
+  :focus-visible {
+    outline: 2px solid #f59e0b; /* amber-500 */
+    outline-offset: 2px;
+  }
+  ```
+
+- [ ] **Step 3: Update `.page-title` to use Barlow Condensed and fix `.section-title`**
+
+  Replace the `.page-title` and `.section-title` blocks:
+
+  ```css
+  .page-title {
+    font-family: var(--font-brand);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    line-height: 1;
+    text-wrap: balance;
+  }
+
+  .section-title {
+    font-family: var(--font-brand);
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1.1;
+    text-wrap: balance;
+  }
+  ```
+
+- [ ] **Step 4: Remove duplicate safe-area rules**
+
+  Lines 89–99 of `src/app.css` repeat `.safe-header`, `.safe-header-inner`, and `.safe-bottom` verbatim from lines 63–73. Delete lines 89–99 (the second block).
+
+- [ ] **Step 5: Verify the dev server starts without errors**
+
+  ```bash
+  npm run dev
+  ```
+
+  Expected: server starts at http://localhost:5173 with no CSS parse errors in the terminal.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/app.css
+  git commit -m "style: update CSS tokens — amber focus ring, Barlow Condensed headings, warm-charcoal token"
+  ```
+
+---
+
+## Task 2: Layout — Nav, Header, Footer
+
+**Files:**
+- Modify: `src/routes/+layout.svelte`
+
+- [ ] **Step 1: Update body wrapper background**
+
+  In `src/routes/+layout.svelte` line 33, change:
+
+  ```svelte
+  <div class="flex flex-col min-h-screen bg-stone-50 dark:bg-asphalt">
+  ```
+
+- [ ] **Step 2: Update skip link**
+
+  Line 37–39, change `bg-sky-600` to `bg-amber-500`:
+
+  ```svelte
+  class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-amber-500 focus:text-white focus:px-4 focus:py-2 focus:rounded-md focus:font-semibold focus:outline-none"
+  ```
+
+- [ ] **Step 3: Update header surface**
+
+  Line 42, change:
+
+  ```svelte
+  <header class="bg-white border-b border-stone-200 dark:bg-stone-900 dark:border-stone-700 sticky top-0 z-50 safe-header">
+  ```
+
+- [ ] **Step 4: Update wordmark accent colour**
+
+  Line 48–50, change `text-sky-500` to `text-amber-500` and `group-hover:text-sky-400` to `group-hover:text-amber-400`:
+
+  ```svelte
+  <span class="font-brand font-bold text-xl leading-none text-stone-900 dark:text-white group-hover:text-amber-500 dark:group-hover:text-amber-400 transition-colors">
+    FillTheHole<span class="text-amber-500">.ca</span>
+  </span>
+  ```
+
+- [ ] **Step 5: Update live stat text colours**
+
+  Lines 55–65, change `text-zinc-300` → `text-stone-600 dark:text-stone-300`, `text-white` → `text-stone-900 dark:text-white`, `text-zinc-700` → `text-stone-300 dark:text-stone-600`:
+
+  ```svelte
+  <div class="hidden sm:flex items-center gap-3 text-sm" aria-label="Pothole statistics">
+    <span class="flex items-center gap-1.5 text-stone-600 dark:text-stone-300">
+      <span class="w-2 h-2 rounded-full bg-orange-500 shrink-0"></span>
+      <span class="text-stone-900 dark:text-white font-semibold tabular-nums">{counts.reported}</span>
+      reported
+    </span>
+    <span class="text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+    <span class="flex items-center gap-1.5 text-stone-600 dark:text-stone-300">
+      <span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>
+      <span class="text-stone-900 dark:text-white font-semibold tabular-nums">{counts.filled}</span>
+      filled
+    </span>
+  </div>
+  ```
+
+- [ ] **Step 6: Update nav links**
+
+  Lines 70–87, change `text-zinc-300 hover:text-white` → `text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white` on all nav links:
+
+  ```svelte
+  <a href="/stats" class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
+    Stats
+  </a>
+  <a href="/how-to" class="hidden sm:inline text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
+    How to
+  </a>
+  <a href="/about" class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
+    About
+  </a>
+  <a
+    href="https://github.com/BreakableHoodie/filltheholedotca"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="hidden sm:inline-flex text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors"
+    aria-label="View source on GitHub"
+  >
+    <Icon name="github" size={18} />
+  </a>
+  ```
+
+- [ ] **Step 7: Update CTA button**
+
+  Lines 88–94, change `bg-sky-700 hover:bg-sky-600 rounded-lg` → `bg-amber-500 hover:bg-amber-600 rounded-md`:
+
+  ```svelte
+  <a
+    href="/report"
+    class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold px-3.5 py-2 rounded-md transition-colors whitespace-nowrap text-sm"
+  >
+    <Icon name="plus" size={14} strokeWidth={2.5} />
+    Report a pothole
+  </a>
+  ```
+
+- [ ] **Step 8: Update footer**
+
+  Line 104, change:
+
+  ```svelte
+  <footer class="bg-white border-t border-stone-200 dark:bg-stone-900 dark:border-stone-700 py-5 text-center text-stone-500 dark:text-stone-400 text-xs px-4 space-y-1.5">
+  ```
+
+  Lines 108–116, change link colours from `text-zinc-300 hover:text-white` → `text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white` and separators from `text-zinc-600` → `text-stone-300 dark:text-stone-600`:
+
+  ```svelte
+  <p>Track potholes. Contact your councillor. Hold the city accountable.</p>
+  <p>
+    Community-sourced data — not official. Use at your own risk.
+    <a href="/how-to" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">How to use</a>
+    <span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+    <a href="/about#privacy" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Privacy</a>
+    <span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+    <a href="/about#disclaimer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Disclaimer</a>
+    <span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+    <a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">GitHub</a>
+    <span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+    <a href="https://github.com/BreakableHoodie/filltheholedotca/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">AGPL-3.0</a>
+  </p>
+  ```
+
+- [ ] **Step 9: Verify in browser**
+
+  Open http://localhost:5173. Confirm:
+  - Header is white (light mode) with stone border
+  - Wordmark shows amber `.ca`
+  - "Report a pothole" button is amber
+  - Nav links are stone-grey
+  - Footer is white with stone border
+
+  To verify dark mode: in Chrome DevTools → Rendering → Emulate CSS media feature `prefers-color-scheme: dark`. Confirm header and footer flip to stone-900.
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add src/routes/+layout.svelte
+  git commit -m "style: nav/header/footer — stone palette, amber accent, system-adaptive dark mode"
+  ```
+
+---
+
+## Task 3: HomeIntroCard — Remove AI Design Tells
+
+**Files:**
+- Modify: `src/lib/components/HomeIntroCard.svelte`
+
+- [ ] **Step 1: Rewrite the card surface and label**
+
+  Replace the outer card div and label (lines 57–61):
+
+  ```svelte
+  <div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-5 shadow-xl">
+    <div class="flex items-start justify-between gap-3">
+      <div class="space-y-2">
+        <p class="text-xs font-semibold text-stone-500 dark:text-stone-400">Waterloo Region civic tool</p>
+        <h2 id="welcome-title" class="page-title text-3xl text-stone-900 dark:text-white">Report a pothole in about 30 seconds</h2>
+        <p class="text-sm text-stone-600 dark:text-stone-300 leading-relaxed">
+          Independent community tracker for Kitchener, Waterloo, and Cambridge.
+          No account required.
+        </p>
+      </div>
+      <button
+        type="button"
+        onclick={dismiss}
+        class="rounded-md p-2 text-stone-400 hover:text-stone-700 dark:hover:text-white hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+        aria-label="Dismiss introduction"
+      >
+        <Icon name="x" size={16} />
+      </button>
+    </div>
+  ```
+
+- [ ] **Step 2: Replace step cards with simple bordered list**
+
+  Remove the `STEPS` array and the `{#each STEPS}` block entirely. Replace with:
+
+  ```svelte
+  <ol class="mt-4 space-y-3 text-sm">
+    <li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+      <div>
+        <span class="font-semibold text-stone-900 dark:text-white">Report</span>
+        <span class="text-stone-500 dark:text-stone-400"> — confirm the location and submit. Nearby reports are merged.</span>
+      </div>
+    </li>
+    <li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+      <div>
+        <span class="font-semibold text-stone-900 dark:text-white">Contact</span>
+        <span class="text-stone-500 dark:text-stone-400"> — email your ward councillor directly from the pothole page.</span>
+      </div>
+    </li>
+    <li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+      <div>
+        <span class="font-semibold text-stone-900 dark:text-white">Track</span>
+        <span class="text-stone-500 dark:text-stone-400"> — once the city fills it, mark it done.</span>
+      </div>
+    </li>
+  </ol>
+  ```
+
+  Also remove the `import Icon` line and the `STEPS` constant from the `<script>` block, since Icon is no longer used in this component. Keep `onMount` and `dismiss`.
+
+  Wait — `Icon` is still used in the dismiss button. Keep the import.
+
+- [ ] **Step 3: Update CTA buttons**
+
+  Replace lines 91–107:
+
+  ```svelte
+  <div class="mt-4 flex flex-col sm:flex-row gap-2">
+    <a
+      href="/report"
+      onclick={dismiss}
+      class="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-amber-500 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-amber-600"
+    >
+      Report a pothole
+    </a>
+    <a
+      href="/about"
+      onclick={dismiss}
+      class="inline-flex items-center justify-center gap-2 rounded-md border border-stone-300 dark:border-stone-600 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-300 transition-colors hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white"
+    >
+      Learn how it works
+    </a>
+  </div>
+
+  <p class="mt-3 text-xs text-stone-500 dark:text-stone-400">
+    Community-run and open source. For official action, report to the city too.
+  </p>
+  ```
+
+- [ ] **Step 4: Verify in browser**
+
+  Open http://localhost:5173. The intro card (if first visit — clear localStorage or use a private window) should show:
+  - White card with stone border (light) / stone-900 with stone-700 border (dark)
+  - No icon halos
+  - Simple bordered list with amber left border
+  - Amber "Report a pothole" button
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/lib/components/HomeIntroCard.svelte
+  git commit -m "style(home): remove icon halos and step cards from intro card; amber-bordered list"
+  ```
+
+---
+
+## Task 4: Report Form
+
+**Files:**
+- Modify: `src/routes/report/+page.svelte`
+
+- [ ] **Step 1: Update page text colours**
+
+  Lines 440–446, change `text-white` → `text-stone-900 dark:text-white`, `text-zinc-300` → `text-stone-600 dark:text-stone-300`:
+
+  ```svelte
+  <h1 class="page-title text-3xl sm:text-4xl text-stone-900 dark:text-white mb-1">Report a pothole</h1>
+  <p class="page-intro text-stone-600 dark:text-stone-300 text-sm">Report the location in about 30 seconds. No account required.</p>
+  <p class="text-xs text-stone-600 dark:text-stone-300 mt-2">Independent community tracker for Waterloo Region. For official repair action, report to the city too.</p>
+  <p class="flex items-start gap-1.5 text-xs text-stone-600 dark:text-stone-300 mt-2">
+    <Icon name="alert-triangle" size={13} class="text-amber-500 shrink-0 mt-0.5" />
+    Stay safe — report from the sidewalk or after pulling over. Never stop in a live traffic lane.
+  </p>
+  ```
+
+- [ ] **Step 2: Update location card surface**
+
+  Line 451, change:
+
+  ```svelte
+  <div class="border border-stone-200 dark:border-stone-700 rounded-md bg-white dark:bg-stone-900 p-4 space-y-3">
+  ```
+
+- [ ] **Step 3: Update location card label and tab bar**
+
+  Lines 452–478:
+
+  ```svelte
+  <div class="flex items-center gap-2 text-sm font-semibold text-stone-700 dark:text-stone-300">
+    <Icon name="crosshair" size={14} class="text-amber-500" />
+    Location
+  </div>
+  <p class="text-xs text-stone-500 dark:text-stone-400">Use your current location for the fastest report, or switch to address search or map pin if needed.</p>
+
+  <div role="tablist" aria-label="Choose a location source" class="flex gap-1 bg-stone-100 dark:bg-stone-800 rounded-md p-1">
+    {#each LOCATION_TABS as tab (tab.mode)}
+      <button
+        id={`location-tab-${tab.mode}`}
+        role="tab"
+        aria-selected={locationMode === tab.mode}
+        aria-controls={`location-panel-${tab.mode}`}
+        tabindex={locationMode === tab.mode ? 0 : -1}
+        type="button"
+        onclick={() => (locationMode = tab.mode)}
+        onkeydown={(event) => handleLocationTabKeydown(event, tab.mode)}
+        class="flex-1 min-h-[44px] py-1.5 px-2 rounded-sm text-xs font-semibold transition-colors
+          {locationMode === tab.mode
+            ? 'bg-white dark:bg-stone-700 text-stone-900 dark:text-white shadow-sm'
+            : 'text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'}"
+      >
+        {tab.label}
+      </button>
+    {/each}
+  </div>
+  ```
+
+- [ ] **Step 4: Update GPS button**
+
+  Lines 488–512, change `border-zinc-700 hover:border-sky-500 hover:bg-sky-500/5 text-zinc-400 hover:text-sky-400` → amber equivalents:
+
+  ```svelte
+  <button
+    type="button"
+    onclick={getLocation}
+    disabled={gpsStatus === 'loading'}
+    class="w-full py-3 rounded-md border-2 border-dashed font-semibold text-sm transition-colors flex items-center justify-center gap-2
+      {gpsStatus === 'got'
+        ? 'border-green-500 bg-green-500/10 text-green-600 dark:text-green-400'
+        : gpsStatus === 'error'
+        ? 'border-red-500 bg-red-500/10 text-red-600 dark:text-red-400'
+        : 'border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-500 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400'}"
+  >
+  ```
+
+- [ ] **Step 5: Update address input**
+
+  Line 565:
+
+  ```svelte
+  class="w-full bg-white dark:bg-stone-800 border border-stone-300 dark:border-stone-600 rounded-md px-3 py-2.5 text-sm text-stone-900 dark:text-white placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:border-amber-500"
+  ```
+
+- [ ] **Step 6: Grep for remaining zinc/sky references in this file and fix them**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]" src/routes/report/+page.svelte
+  ```
+
+  For each remaining instance, apply the pattern: `zinc-[number]` → `stone-[same-number]`, `bg-sky-` → `bg-amber-`, `text-sky-` → `text-amber-`, `border-sky-` → `border-amber-`.
+
+  Exception: `border-green-`, `bg-red-`, `border-red-` — leave these as-is (status colours).
+
+- [ ] **Step 7: Update submit button (near the bottom of the template)**
+
+  Find the submit button (search for `submitting`). Change from `bg-sky-700` or similar to:
+
+  ```svelte
+  class="w-full py-3 rounded-md bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-bold text-sm transition-colors flex items-center justify-center gap-2"
+  ```
+
+- [ ] **Step 8: Verify in browser**
+
+  Open http://localhost:5173/report. Confirm:
+  - Location card has white/stone-200 border (not zinc)
+  - Tab bar is stone-100 background
+  - GPS button uses amber hover
+  - Submit button is amber
+
+- [ ] **Step 9: Commit**
+
+  ```bash
+  git add src/routes/report/+page.svelte
+  git commit -m "style(report): stone surfaces, amber accent, updated form inputs and GPS button"
+  ```
+
+---
+
+## Task 5: Pothole Detail Page
+
+**Files:**
+- Modify: `src/routes/hole/[id]/+page.svelte`
+
+- [ ] **Step 1: Grep for zinc and sky-accent references**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]\|rounded-xl\|rounded-2xl" src/routes/hole/[id]/+page.svelte | head -50
+  ```
+
+- [ ] **Step 2: Update surface cards**
+
+  For every `bg-zinc-900 border-zinc-800 rounded-xl` or similar card, change to:
+
+  ```svelte
+  bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md
+  ```
+
+- [ ] **Step 3: Update text colours**
+
+  - `text-zinc-400`, `text-zinc-300` → `text-stone-500 dark:text-stone-400`
+  - `text-white` headings → `text-stone-900 dark:text-white`
+  - `text-zinc-200` → `text-stone-700 dark:text-stone-200`
+
+- [ ] **Step 4: Update inline status badges**
+
+  `STATUS_CONFIG` in `src/lib/constants.ts` only controls icon colours — badge styling is inline in this template. Grep for `bg-orange-500/10`, `bg-sky-500/10`, `bg-green-500/10`, `rounded-full` to find status display elements. Convert filled pills to outlined badges:
+
+  ```svelte
+  <!-- Before (filled pill): -->
+  <span class="rounded-full bg-orange-500/10 text-orange-400 text-xs px-2 py-0.5">Reported</span>
+
+  <!-- After (outlined): -->
+  <span class="rounded border border-orange-500 text-orange-600 dark:text-orange-400 text-xs font-semibold px-1.5 py-0.5">Reported</span>
+  ```
+
+  Per-status border/text colours:
+  - `pending`: `border-orange-500 text-orange-600 dark:text-orange-400`
+  - `reported`: `border-sky-500 text-sky-600 dark:text-sky-400`
+  - `filled`: `border-green-500 text-green-600 dark:text-green-400`
+  - `expired`: `border-stone-400 text-stone-500`
+
+  Leave the progress bar (`bg-sky-500 rounded-full`) unchanged — it's a functional indicator, not a badge.
+
+- [ ] **Step 5: Update action buttons**
+
+  Any `bg-sky-700 hover:bg-sky-600` → `bg-amber-500 hover:bg-amber-600`, `rounded-lg` → `rounded-md`.
+  Any `border-zinc-700` secondary buttons → `border-stone-300 dark:border-stone-600`.
+
+- [ ] **Step 6: Update icon accent colours**
+
+  `text-sky-400` icons → `text-amber-500`. Leave `text-green-400`, `text-orange-400`, `text-red-400` — those are status colours.
+
+- [ ] **Step 7: Verify in browser**
+
+  Open any pothole detail page (e.g., http://localhost:5173/hole/[any-id-from-homepage]). Confirm surface cards, action buttons, and status badge match the new design.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add src/routes/hole/[id]/+page.svelte
+  git commit -m "style(detail): stone surfaces, outlined status badge, amber action buttons"
+  ```
+
+---
+
+## Task 6: Stats Dashboard
+
+**Files:**
+- Modify: `src/routes/stats/+page.svelte`
+
+- [ ] **Step 1: Grep for zinc and sky references**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]\|rounded-xl\|rounded-2xl" src/routes/stats/+page.svelte | head -50
+  ```
+
+- [ ] **Step 2: Update metric cards**
+
+  Every `bg-zinc-900 border-zinc-800 rounded-xl` → `bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md`.
+
+- [ ] **Step 3: Update time-window filter buttons**
+
+  Find the `WINDOWS` filter buttons. Change active state from `bg-zinc-800` / `bg-sky-600` to:
+
+  ```svelte
+  {windowDays === w.value
+    ? 'bg-amber-500 text-white'
+    : 'bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white'}
+  ```
+
+  Add `rounded-md` to the button class.
+
+- [ ] **Step 4: Update text colours**
+
+  - `text-zinc-400` → `text-stone-500 dark:text-stone-400`
+  - `text-white` numbers/headings → `text-stone-900 dark:text-white`
+
+- [ ] **Step 5: Update chart/bar accent**
+
+  Any `bg-sky-500` chart bars → `bg-amber-500`. Leave `bg-green-500` fill bars as-is.
+
+- [ ] **Step 6: Verify in browser**
+
+  Open http://localhost:5173/stats. Confirm metric cards have stone borders, filter buttons are amber when active.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/routes/stats/+page.svelte
+  git commit -m "style(stats): stone bordered cards, amber filter buttons and chart accent"
+  ```
+
+---
+
+## Task 7: About Page
+
+**Files:**
+- Modify: `src/routes/about/+page.svelte`
+
+- [ ] **Step 1: Update page heading and body text colours**
+
+  Line 14: `text-white` → `text-stone-900 dark:text-white`
+  Line 15: `text-zinc-400` → `text-stone-600 dark:text-stone-400`
+  Throughout: `text-zinc-300` → `text-stone-600 dark:text-stone-300`, `text-white` section headings → `text-stone-900 dark:text-white`
+
+- [ ] **Step 2: Update the "Report it officially too" card**
+
+  Line 35: `bg-zinc-900 border border-zinc-700 rounded-xl` → `bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md`
+
+- [ ] **Step 3: Update accent text**
+
+  Line 30: `text-sky-300 font-medium` → `text-amber-600 dark:text-amber-400 font-medium`
+
+- [ ] **Step 4: Update icon colours**
+
+  `text-sky-400` → `text-amber-500` on all Icon components.
+
+- [ ] **Step 5: Grep and fix remaining zinc references**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]\|rounded-xl" src/routes/about/+page.svelte
+  ```
+
+  Fix each remaining instance.
+
+- [ ] **Step 6: Verify in browser**
+
+  Open http://localhost:5173/about. Confirm body text is readable in both light and dark mode.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/routes/about/+page.svelte
+  git commit -m "style(about): stone text colours, amber accent, bordered official-links card"
+  ```
+
+---
+
+## Task 8: How-to Page
+
+**Files:**
+- Modify: `src/routes/how-to/+page.svelte`
+
+- [ ] **Step 1: Update page heading and body text**
+
+  `text-white` headings → `text-stone-900 dark:text-white`
+  `text-zinc-400` body → `text-stone-600 dark:text-stone-400`
+
+- [ ] **Step 2: Update status legend cards**
+
+  Lines 27–38 (the colour-coded status legend `div` rows): change `bg-zinc-900 border border-zinc-800 rounded-lg` → `border border-stone-200 dark:border-stone-700 rounded-md` with no background fill — let the surface inherit.
+
+  ```svelte
+  <div class="flex items-center gap-3 border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3">
+  ```
+
+- [ ] **Step 3: Update section icon colours**
+
+  `text-sky-400` → `text-amber-500` on all `<Icon>` components.
+
+- [ ] **Step 4: Grep and fix remaining zinc references**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]\|rounded-xl" src/routes/how-to/+page.svelte
+  ```
+
+  Fix each remaining instance.
+
+- [ ] **Step 5: Verify in browser**
+
+  Open http://localhost:5173/how-to. Confirm legend cards have stone borders, icons are amber.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/routes/how-to/+page.svelte
+  git commit -m "style(how-to): stone legend cards, amber icons, text colour updates"
+  ```
+
+---
+
+## Task 9: Homepage Map Page
+
+**Files:**
+- Modify: `src/routes/+page.svelte`
+
+- [ ] **Step 1: Grep for zinc and sky references in the homepage**
+
+  ```bash
+  grep -n "zinc\|sky-[5-9]\|rounded-xl\|rounded-2xl" src/routes/+page.svelte | head -60
+  ```
+
+- [ ] **Step 2: Update mobile tool tray**
+
+  Find the mobile tool tray component (floats over the map). Update surface: `bg-zinc-900/95 border-zinc-800` → `bg-white/95 dark:bg-stone-900/95 border-stone-200 dark:border-stone-700 backdrop-blur-sm`.
+  Update tray button active states from sky/zinc to amber/stone.
+
+- [ ] **Step 3: Update map overlay UI elements**
+
+  Any floating panels or cards over the map: `bg-zinc-900 rounded-xl` → `bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-stone-700`.
+  Text colours: zinc → stone equivalents.
+
+- [ ] **Step 4: Leave Leaflet map elements unchanged**
+
+  Leaflet injects its own CSS. Do not attempt to style `.leaflet-*` classes here — that's a separate concern outside this spec.
+
+- [ ] **Step 5: Verify in browser**
+
+  Open http://localhost:5173. Confirm the mobile tool tray and any map overlays use stone/amber instead of zinc/sky.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/routes/+page.svelte
+  git commit -m "style(home): mobile tool tray and map overlays — stone surface, amber active states"
+  ```
+
+---
+
+## Task 10: Global Sweep — Catch Remaining Instances
+
+**Files:**
+- Any remaining `src/` files
+
+- [ ] **Step 1: Find all remaining zinc references in `src/`**
+
+  ```bash
+  grep -rn "zinc-" src/ --include="*.svelte" --include="*.ts" --include="*.css" | grep -v "node_modules"
+  ```
+
+- [ ] **Step 2: Find all remaining rounded-xl/2xl references**
+
+  ```bash
+  grep -rn "rounded-xl\|rounded-2xl" src/ --include="*.svelte"
+  ```
+
+- [ ] **Step 3: Find remaining sky-accent references (not status colours)**
+
+  ```bash
+  grep -rn "bg-sky-\|text-sky-[4-9]\|border-sky-" src/ --include="*.svelte"
+  ```
+
+  Note: `text-sky-` on status badges for "reported" potholes is intentional — do not change those. Only change sky as an accent colour (buttons, icons, links).
+
+- [ ] **Step 4: Fix each remaining instance using the established patterns**
+
+  For each file returned:
+  - `bg-zinc-[N]` → `bg-stone-[N]` (or `bg-asphalt` for the darkest bg)
+  - `border-zinc-[N]` → `border-stone-[N]`
+  - `text-zinc-[N]` → `text-stone-[N]`
+  - `bg-sky-[5-7]` accent → `bg-amber-[4-6]`
+  - `text-sky-[3-5]` accent → `text-amber-[4-6]`
+  - `rounded-xl` interactive → `rounded-md`
+  - `rounded-2xl` cards → `rounded-md`
+
+- [ ] **Step 5: Verify build passes**
+
+  ```bash
+  npm run build 2>&1 | tail -20
+  ```
+
+  Expected: build completes with no errors.
+
+- [ ] **Step 6: Final visual walkthrough**
+
+  Open http://localhost:5173. Walk through:
+  1. Homepage (map + intro card)
+  2. Report form
+  3. A pothole detail page
+  4. Stats
+  5. About
+  6. How-to
+
+  For each, toggle dark mode via DevTools → Rendering → `prefers-color-scheme: dark`. Confirm nothing is invisible (white-on-white, black-on-black).
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add -p  # review and stage remaining changes
+  git commit -m "style: sweep remaining zinc/sky/rounded-xl instances across all pages"
+  ```
+
+---
+
+## Task 11: PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+  ```bash
+  git push origin fix/mobile-ux-bluesky
+  gh pr create \
+    --title "style: Civic Data Portal visual redesign — stone/amber, system dark mode, bordered surfaces" \
+    --body "$(cat <<'EOF'
+  ## Summary
+
+  - Replaces AI-SaaS visual pattern (zinc + sky-500 + rounded-2xl + tracking labels) with Civic Data Portal aesthetic
+  - Stone palette replaces zinc (warm concrete undertone vs synthetic cool grey)
+  - Amber-500 replaces sky-500 as primary accent (road marking semantic connection)
+  - System-adaptive dark mode via `prefers-color-scheme` — no JS toggle required
+  - Bordered card surfaces replace filled zinc backgrounds (document-like, not dashboard-like)
+  - `uppercase tracking-[0.18em]` label pattern removed; weight hierarchy used instead
+  - `rounded-xl`/`rounded-2xl` capped at `rounded-md` throughout
+  - HomeIntroCard step cards replaced with amber-bordered list (no icon halos)
+  - Status badges switched to outlined pattern
+  - All pages updated: home, report, detail, stats, about, how-to
+
+  ## Test plan
+
+  - [ ] Light mode visual walkthrough: home, report, detail, stats, about, how-to
+  - [ ] Dark mode walkthrough (DevTools → Rendering → prefers-color-scheme: dark)
+  - [ ] Mobile viewport check (375px)
+  - [ ] Intro card appears on first visit (clear localStorage), dismisses correctly
+  - [ ] Report form submits successfully
+  - [ ] `npm run build` passes
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```

--- a/docs/superpowers/specs/2026-05-20-visual-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-20-visual-redesign-design.md
@@ -1,0 +1,166 @@
+# Visual Redesign — Civic Data Portal
+
+**Date:** 2026-05-20  
+**Status:** Approved — pending implementation plan
+
+## Problem
+
+The site's current visual design reads as a generic AI-generated dark SaaS dashboard: zinc palette, sky-500 accent, rounded-2xl cards, `uppercase tracking-[0.18em] text-xs` labels, and filled card backgrounds. None of these choices are distinctive or connected to the subject matter (civic infrastructure, Waterloo Region roads).
+
+## Direction: Civic Data Portal
+
+Reference: 18F, mySociety, well-made regional transit trackers. Data-legible, purposeful, clearly a public tool — not an app.
+
+## Design System
+
+### Color Palette
+
+System-adaptive: light by default, dark mode respects `prefers-color-scheme`. Defined as CSS custom properties in `src/app.css`, applied via Tailwind v4 utility classes.
+
+**Light mode:**
+```css
+--color-bg:       #fafaf9   /* stone-50 */
+--color-surface:  #ffffff
+--color-border:   #e7e5e4   /* stone-200 */
+--color-text:     #1c1917   /* stone-900 */
+--color-muted:    #78716c   /* stone-500 */
+--color-accent:   #f59e0b   /* amber-500 */
+--color-accent-hover: #d97706  /* amber-600 */
+```
+
+**Dark mode:**
+```css
+--color-bg:       #191714   /* custom warm charcoal — not zinc */
+--color-surface:  #1c1917   /* stone-900 */
+--color-border:   #44403c   /* stone-700 */
+--color-text:     #f5f5f4   /* stone-100 */
+--color-muted:    #a8a29e   /* stone-400 */
+--color-accent:   #fbbf24   /* amber-400 */
+--color-accent-hover: #f59e0b  /* amber-500 */
+```
+
+**Semantic / status colours** (same in both modes, backgrounds differ):
+- Pending: `orange-500` text, `orange-50` bg (light) / `orange-500/15` bg (dark)
+- Reported/confirmed: `sky-600` text, `sky-50` bg (light) / `sky-500/15` bg (dark)
+- Filled: `green-600` text, `green-50` bg (light) / `green-500/15` bg (dark)
+- Expired: `stone-500` text, `stone-100` bg (light) / `stone-500/15` bg (dark)
+
+**Rationale for amber over sky-500:** sky-500 is the dominant AI-generated accent colour. Amber connects semantically to road markings, caution signage, and construction — the actual subject matter.
+
+**Rationale for stone over zinc:** Both are neutral greys; stone has a faint warm undertone that reads as concrete/paper/pavement. Zinc reads synthetic.
+
+### Typography
+
+Typefaces stay (already loaded via @fontsource):
+- **Barlow Condensed** — brand/headings only (site name, page titles, section headers)
+- **Public Sans** — all UI text, body, labels, data
+
+**What changes:**
+
+Remove `uppercase tracking-[0.18em] text-xs` label pattern everywhere. This is the most visible AI design tell. Replace with weight hierarchy:
+
+```
+Before: text-xs uppercase tracking-[0.18em] text-zinc-400
+After:  text-xs font-semibold text-stone-500
+```
+
+Apply tabular-nums to all numeric data displays (`font-variant-numeric: tabular-nums`).
+
+### Component Patterns
+
+**Cards / surfaces:**
+```
+Before: rounded-xl bg-zinc-900 border border-zinc-800
+After:  rounded-md border border-stone-200 bg-white dark:border-stone-700 dark:bg-stone-900
+```
+
+Document-like, not SaaS-like. Borders define surfaces; background fills do not.
+
+**Buttons (primary):**
+```
+Before: bg-sky-700 rounded-xl
+After:  bg-amber-500 hover:bg-amber-600 text-white rounded-md font-semibold
+```
+
+**Buttons (secondary/ghost):**
+```
+Before: rounded-xl border-zinc-700
+After:  rounded-md border-stone-300 dark:border-stone-600 text-stone-700 dark:text-stone-300
+```
+
+**Status badges:**
+```
+Before: rounded-full bg-orange-500/10 text-orange-400 (filled pill)
+After:  rounded border border-current text-xs font-semibold px-1.5 py-0.5 (outlined)
+```
+
+**Icon halos:** Remove `bg-[colour]/10` rounded icon backgrounds entirely. Icons appear inline or with plain colour, no halo.
+
+**Border radius cap:** `rounded-md` (6px) maximum across all interactive elements. `rounded-full` only for circular avatar/indicator dots.
+
+**Section dividers:** Explicit `border-b border-stone-200 dark:border-stone-700` lines, not implied by card background contrast.
+
+## Page-by-Page Spec
+
+### Navigation (`+layout.svelte`)
+
+```
+Before: bg-zinc-900 border-zinc-800 (sticky header)
+After:  bg-white border-stone-200 dark:bg-stone-900 dark:border-stone-700
+```
+
+- "fillthehole.ca" wordmark: Barlow Condensed, stone-900/stone-100
+- Nav links: Public Sans, stone-600/stone-400, hover underline
+- "Report a Pothole" CTA: amber-500, rounded-md
+- Live stat indicator dots (orange/green pulses): unchanged — functional signal
+
+### Homepage / Map (`+page.svelte`)
+
+- Leaflet map: unchanged
+- `HomeIntroCard`: replace step cards (bg-zinc-900/rounded-xl with orange-500/10 icon halos) with a single short sentence in a minimal bordered card. Dismissible on first visit (existing localStorage behaviour stays).
+- Mobile tool tray: stone borders, amber-500 active states
+
+### Report Form (`report/+page.svelte`)
+
+- Single-column layout, generous vertical spacing
+- Severity selector: outlined bordered options, amber-500 selected state
+- GPS status: drop tracking/uppercase label; use `text-xs font-semibold text-stone-500`
+- Submit button: amber-500 rounded-md
+- Form card: bordered surface (no filled background)
+
+### Pothole Detail (`hole/[id]/+page.svelte`)
+
+- Status badge: outlined, not filled pill
+- Councillor card: simple bordered surface
+- Action buttons (confirm, mark filled): amber-500 rounded-md
+- Photo gallery: unchanged functionally; cards get bordered-surface treatment
+
+### Stats Dashboard (`stats/+page.svelte`)
+
+- Metric cards: bordered surface treatment
+- Numbers: tabular-nums
+- Ward leaderboard: simple bordered table rows instead of card grid where possible
+- Charts/bars: amber accent
+
+### About / How-to (`about/`, `how-to/`)
+
+- Numbered step cards → simple `<ol>` with left border accent (`border-l-2 border-amber-500 pl-4`)
+- No icon halos
+- Prose unchanged
+
+## Implementation Notes
+
+- Tailwind v4 uses `@theme` and CSS custom properties — define the full token set in `src/app.css` under `@theme`
+- Dark mode: use `prefers-color-scheme` media query on `:root`, not a class-based toggle (no JS required)
+- `rounded-xl` and `rounded-2xl` are removed from the codebase; grep and replace
+- `bg-zinc-*` classes are replaced with `bg-stone-*` or the custom charcoal variable
+- `sky-500`/`sky-600`/`sky-700` as accent → `amber-500`/`amber-600`/`amber-400` (note: sky stays for "reported" status colour)
+- All `uppercase tracking-[0.18em]` patterns → `font-semibold` with no tracking override
+
+## Out of Scope
+
+- Map tile style (Leaflet default tiles unchanged)
+- Leaflet marker/cluster styles (addressed separately if needed)
+- Admin UI (separate surface, not public-facing)
+- OG image templates (can be updated in a follow-on)
+- Any functional changes — this is visual only

--- a/src/app.css
+++ b/src/app.css
@@ -12,7 +12,7 @@
  * Use focus:outline-none on elements that define their own focus treatment.
  */
 :focus-visible {
-  outline: 2px solid #0ea5e9; /* sky-500 */
+  outline: 2px solid #f59e0b; /* amber-500 */
   outline-offset: 2px;
 }
 
@@ -24,8 +24,7 @@
 @theme {
   --font-sans: "Public Sans", system-ui, sans-serif;
   --font-brand: "Barlow Condensed", system-ui, sans-serif;
-  --color-asphalt: #0f0f0f;
-  --color-asphalt-light: #1a1a1a;
+  --color-asphalt: #191714;
 }
 
 body {
@@ -40,17 +39,17 @@ body {
 }
 
 .page-title {
-  font-family: var(--font-sans);
-  font-weight: 700;
-  letter-spacing: -0.025em;
+  font-family: var(--font-brand);
+  font-weight: 800;
+  letter-spacing: -0.01em;
   line-height: 1;
   text-wrap: balance;
 }
 
 .section-title {
-  font-family: var(--font-sans);
+  font-family: var(--font-brand);
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   line-height: 1.1;
   text-wrap: balance;
 }
@@ -84,16 +83,4 @@ body {
   .safe-bottom-watchlist {
     bottom: 1rem;
   }
-}
-
-/* iOS safe area support — accounts for notch/Dynamic Island and home indicator */
-.safe-header {
-  padding-top: env(safe-area-inset-top);
-}
-.safe-header-inner {
-  padding-left: max(1rem, env(safe-area-inset-left));
-  padding-right: max(1rem, env(safe-area-inset-right));
-}
-.safe-bottom {
-  bottom: calc(1.5rem + env(safe-area-inset-bottom));
 }

--- a/src/lib/components/HomeIntroCard.svelte
+++ b/src/lib/components/HomeIntroCard.svelte
@@ -24,29 +24,6 @@
 		visible = false;
 	}
 
-	const STEPS = [
-		{
-			icon: 'map-pin' as const,
-			iconClass: 'text-orange-400',
-			bgClass: 'bg-orange-500/10',
-			title: 'Report',
-			desc: 'Standing next to a pothole? Open the app, confirm the location, and submit. Independent reports from nearby residents put it on the public map.',
-		},
-		{
-			icon: 'mail' as const,
-			iconClass: 'text-sky-400',
-			bgClass: 'bg-sky-500/10',
-			title: 'Contact',
-			desc: 'Share the link or email your ward councillor directly from the pothole page. The more people who see it, the harder it is to ignore.',
-		},
-		{
-			icon: 'check-circle' as const,
-			iconClass: 'text-green-400',
-			bgClass: 'bg-green-500/10',
-			title: 'Filled',
-			desc: 'Once the city fills it, mark it done. Public accountability, one hole at a time.',
-		},
-	] as const;
 </script>
 
 {#if visible}
@@ -54,12 +31,12 @@
 		aria-labelledby="welcome-title"
 		class="absolute top-4 left-4 right-4 z-[1001] sm:left-6 sm:right-auto sm:max-w-md"
 	>
-		<div class="bg-zinc-950 border border-zinc-800 rounded-2xl p-5 shadow-2xl">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-5 shadow-xl">
 			<div class="flex items-start justify-between gap-3">
 				<div class="space-y-2">
-					<p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-300">Waterloo Region civic tool</p>
-					<h2 id="welcome-title" class="font-brand font-bold text-3xl leading-none text-white">Report a pothole in about 30 seconds</h2>
-					<p class="text-sm text-zinc-300 leading-relaxed">
+					<p class="text-xs font-semibold text-stone-500 dark:text-stone-400">Waterloo Region civic tool</p>
+					<h2 id="welcome-title" class="page-title text-3xl text-stone-900 dark:text-white">Report a pothole in about 30 seconds</h2>
+					<p class="text-sm text-stone-600 dark:text-stone-300 leading-relaxed">
 						Independent community tracker for Kitchener, Waterloo, and Cambridge.
 						No account required.
 					</p>
@@ -67,46 +44,52 @@
 				<button
 					type="button"
 					onclick={dismiss}
-					class="rounded-lg p-2 text-zinc-500 hover:text-white hover:bg-zinc-800 transition-colors"
+					class="rounded-md p-2 text-stone-400 hover:text-stone-700 dark:hover:text-white hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
 					aria-label="Dismiss introduction"
 				>
 					<Icon name="x" size={16} />
 				</button>
 			</div>
 
-			<div class="mt-4 grid gap-2">
-				{#each STEPS as step (step.title)}
-					<div class="flex items-start gap-3 bg-zinc-900 rounded-xl p-3">
-						<div class="shrink-0 mt-0.5 p-1.5 rounded-md {step.bgClass}">
-							<Icon name={step.icon} size={15} class={step.iconClass} />
-						</div>
-						<div>
-							<div class="font-semibold text-white text-xs mb-0.5">{step.title}</div>
-							<p class="text-zinc-400 text-xs leading-relaxed">{step.desc}</p>
-						</div>
+			<ol class="mt-4 space-y-3 text-sm">
+				<li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+					<div>
+						<span class="font-semibold text-stone-900 dark:text-white">Report</span>
+						<span class="text-stone-500 dark:text-stone-400"> — confirm the location and submit. Nearby reports are merged.</span>
 					</div>
-				{/each}
-			</div>
+				</li>
+				<li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+					<div>
+						<span class="font-semibold text-stone-900 dark:text-white">Contact</span>
+						<span class="text-stone-500 dark:text-stone-400"> — email your ward councillor directly from the pothole page.</span>
+					</div>
+				</li>
+				<li class="flex gap-3 items-start border-l-2 border-amber-500 pl-3">
+					<div>
+						<span class="font-semibold text-stone-900 dark:text-white">Track</span>
+						<span class="text-stone-500 dark:text-stone-400"> — once the city fills it, mark it done.</span>
+					</div>
+				</li>
+			</ol>
 
 			<div class="mt-4 flex flex-col sm:flex-row gap-2">
 				<a
 					href="/report"
 					onclick={dismiss}
-					class="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-sky-700 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-sky-600"
+					class="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-amber-500 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-amber-600"
 				>
-					<Icon name="map-pin" size={15} class="shrink-0" />
 					Report a pothole
 				</a>
 				<a
 					href="/about"
 					onclick={dismiss}
-					class="inline-flex items-center justify-center gap-2 rounded-xl border border-zinc-700 px-4 py-3 text-sm font-semibold text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+					class="inline-flex items-center justify-center gap-2 rounded-md border border-stone-300 dark:border-stone-600 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-300 transition-colors hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white"
 				>
 					Learn how it works
 				</a>
 			</div>
 
-			<p class="mt-3 text-xs text-zinc-400">
+			<p class="mt-3 text-xs text-stone-500 dark:text-stone-400">
 				Community-run and open source. For official action, report to the city too.
 			</p>
 		</div>

--- a/src/lib/components/PushNotifications.svelte
+++ b/src/lib/components/PushNotifications.svelte
@@ -78,7 +78,7 @@
 {#if notifState === 'unsubscribed'}
 	<button
 		onclick={subscribe}
-		class="inline-flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+		class="inline-flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-200 transition-colors"
 		title="Get notified when potholes are fixed"
 	>
 		<Icon name="bell" size={13} />
@@ -87,19 +87,19 @@
 {:else if notifState === 'subscribed'}
 	<button
 		onclick={unsubscribe}
-		class="inline-flex items-center gap-1.5 text-xs text-sky-400 hover:text-sky-300 transition-colors"
+		class="inline-flex items-center gap-1.5 text-xs text-amber-400 hover:text-amber-300 transition-colors"
 		title="You're receiving fill notifications — click to turn off"
 	>
 		<Icon name="bell" size={13} />
 		Notified
 	</button>
 {:else if notifState === 'denied'}
-	<span class="inline-flex items-center gap-1.5 text-xs text-zinc-600 cursor-not-allowed" title="Notifications blocked — change in browser settings">
+	<span class="inline-flex items-center gap-1.5 text-xs text-stone-600 cursor-not-allowed" title="Notifications blocked — change in browser settings">
 		<Icon name="bell-off" size={13} />
 		Blocked
 	</span>
 {:else if notifState === 'pending'}
-	<span class="inline-flex items-center gap-1.5 text-xs text-zinc-400 animate-pulse">
+	<span class="inline-flex items-center gap-1.5 text-xs text-stone-400 animate-pulse">
 		<Icon name="bell" size={13} />
 		…
 	</span>

--- a/src/lib/components/SocialShare.svelte
+++ b/src/lib/components/SocialShare.svelte
@@ -24,12 +24,12 @@
 		{
 			name: 'Bluesky',
 			href: `https://bsky.app/intent/compose?text=${SHARE_TEXT}`,
-			hoverClass: 'hover:border-sky-500/40 hover:text-sky-400'
+			hoverClass: 'hover:border-amber-500/40 hover:text-amber-400'
 		},
 		{
 			name: 'Threads',
 			href: `https://www.threads.net/intent/post?text=${SHARE_TEXT}`,
-			hoverClass: 'hover:border-zinc-400/40 hover:text-zinc-200'
+			hoverClass: 'hover:border-stone-400/40 hover:text-stone-200'
 		},
 		{
 			name: 'LinkedIn',
@@ -90,7 +90,7 @@
 				{p.name}
 			</a>
 			{#if i < platforms.length - 1}
-				<span class="mx-1 text-zinc-600" aria-hidden="true">·</span>
+				<span class="mx-1 text-stone-600" aria-hidden="true">·</span>
 			{/if}
 		{/each}
 	</span>
@@ -102,7 +102,7 @@
 				href={p.href}
 				target="_blank"
 				rel="noopener noreferrer"
-				class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-zinc-800 border border-zinc-700 text-zinc-300 transition-colors {p.hoverClass}"
+				class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-stone-800 border border-stone-700 text-stone-300 transition-colors {p.hoverClass}"
 			>
 				{p.name}
 				<Icon name="external-link" size={13} class="shrink-0 opacity-60" />
@@ -113,7 +113,7 @@
 		<button
 			type="button"
 			onclick={copyLink}
-			class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-zinc-500 hover:text-white transition-colors"
+			class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-stone-800 border border-stone-700 text-stone-300 hover:border-stone-500 hover:text-white transition-colors"
 		>
 			{#if copied}
 				<Icon name="check" size={13} class="shrink-0 text-green-400" />
@@ -127,7 +127,7 @@
 			<button
 				type="button"
 				onclick={nativeShare}
-				class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-sky-700 hover:bg-sky-600 border border-sky-600 text-white transition-colors"
+				class="inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold bg-amber-600 hover:bg-amber-500 border border-amber-500 text-white transition-colors"
 			>
 				<Icon name="share-2" size={13} class="shrink-0" />
 				Share

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -78,32 +78,32 @@
 </script>
 
 {#if ids.length > 0}
-	<section aria-labelledby="watchlist-heading" class="bg-zinc-950 border-t border-zinc-800">
+	<section aria-labelledby="watchlist-heading" class="bg-stone-950 border-t border-stone-800">
 		<div class="max-w-6xl mx-auto px-4 py-8">
 			<div class="flex items-center gap-2 mb-5">
-				<Icon name="bookmark-filled" size={15} class="text-sky-400 shrink-0" />
-				<h2 id="watchlist-heading" class="text-sm font-semibold text-zinc-300 uppercase tracking-wider">
+				<Icon name="bookmark-filled" size={15} class="text-amber-400 shrink-0" />
+				<h2 id="watchlist-heading" class="text-sm font-semibold text-stone-300 uppercase tracking-wider">
 					My Watchlist
 				</h2>
-				<span class="text-zinc-600 text-xs tabular-nums ml-1">({ids.length})</span>
+				<span class="text-stone-600 text-xs tabular-nums ml-1">({ids.length})</span>
 			</div>
 
 			{#if loading}
 				<!-- Skeleton cards — match expected layout to prevent CLS -->
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each [...Array(Math.min(ids.length, PAGE_SIZE)).keys()] as i (i)}
-						<div class="relative bg-zinc-900 rounded-xl overflow-hidden border border-zinc-800 h-[100px] animate-pulse">
-							<div class="absolute inset-y-0 left-0 w-[3px] bg-zinc-700"></div>
+						<div class="relative bg-stone-900 rounded-md overflow-hidden border border-stone-800 h-[100px] animate-pulse">
+							<div class="absolute inset-y-0 left-0 w-[3px] bg-stone-700"></div>
 							<div class="pl-5 pr-3 pt-3.5 pb-3.5 flex flex-col gap-2.5">
-								<div class="h-4 bg-zinc-700 rounded w-3/4"></div>
-								<div class="h-3 bg-zinc-800 rounded w-1/2"></div>
-								<div class="h-3 bg-zinc-800 rounded w-1/3"></div>
+								<div class="h-4 bg-stone-700 rounded w-3/4"></div>
+								<div class="h-3 bg-stone-800 rounded w-1/2"></div>
+								<div class="h-3 bg-stone-800 rounded w-1/3"></div>
 							</div>
 						</div>
 					{/each}
 				</div>
 			{:else if fetchError}
-				<p class="text-zinc-400 text-sm">Couldn't load watchlist status. Try refreshing.</p>
+				<p class="text-stone-400 text-sm">Couldn't load watchlist status. Try refreshing.</p>
 			{:else if potholes.length > 0}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each visiblePotholes as pothole (pothole.id)}
@@ -113,12 +113,12 @@
 						{@const accentColor =
 							pothole.status === 'reported' ? 'bg-orange-500' :
 							pothole.status === 'filled'   ? 'bg-green-500' :
-							pothole.status === 'expired'  ? 'bg-zinc-600' : 'bg-zinc-700'}
+							pothole.status === 'expired'  ? 'bg-stone-600' : 'bg-stone-700'}
 						{@const pillColor =
 							pothole.status === 'reported' ? 'bg-orange-500/10 text-orange-400' :
 							pothole.status === 'filled'   ? 'bg-green-500/10 text-green-400' :
-							'bg-zinc-700/60 text-zinc-400'}
-						<div class="relative bg-zinc-900 rounded-xl overflow-hidden border border-zinc-800 hover:border-zinc-700 transition-colors">
+							'bg-stone-700/60 text-stone-400'}
+						<div class="relative bg-stone-900 rounded-md overflow-hidden border border-stone-800 hover:border-stone-700 transition-colors">
 							<!-- Status accent strip -->
 							<div class="absolute inset-y-0 left-0 w-[3px] {accentColor}"></div>
 
@@ -127,13 +127,13 @@
 								<div class="flex items-start justify-between gap-2">
 									<a
 										href="/hole/{pothole.id}"
-										class="flex-1 text-sm font-semibold text-white hover:text-sky-400 transition-colors leading-snug line-clamp-2"
+										class="flex-1 text-sm font-semibold text-white hover:text-amber-400 transition-colors leading-snug line-clamp-2"
 									>
 										{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 									</a>
 									<button
 										onclick={() => unwatch(pothole.id)}
-										class="shrink-0 text-zinc-600 hover:text-zinc-300 transition-colors p-1 -mr-1 rounded-md hover:bg-zinc-800"
+										class="shrink-0 text-stone-600 hover:text-stone-300 transition-colors p-1 -mr-1 rounded-md hover:bg-stone-800"
 										aria-label="Remove {pothole.address || 'this pothole'} from watchlist"
 										title="Remove from watchlist"
 									>
@@ -147,20 +147,20 @@
 										<Icon name={info.icon} size={11} />
 										{info.label}
 									</span>
-									<span class="text-xs text-zinc-600 tabular-nums shrink-0">{daysLabel(pothole)}</span>
+									<span class="text-xs text-stone-600 tabular-nums shrink-0">{daysLabel(pothole)}</span>
 								</div>
 
 								<!-- Footer: view link + photo badge -->
 								<div class="flex items-center justify-between gap-2 pt-0.5">
 									<a
 										href="/hole/{pothole.id}"
-										class="text-xs font-medium text-zinc-400 hover:text-sky-400 transition-colors"
+										class="text-xs font-medium text-stone-400 hover:text-amber-400 transition-colors"
 										aria-label="View details for {pothole.address || 'this pothole'}"
 									>
 										View details →
 									</a>
 									{#if pothole.photos_published}
-										<span class="inline-flex items-center gap-1 text-[11px] text-zinc-600">
+										<span class="inline-flex items-center gap-1 text-[11px] text-stone-600">
 											<Icon name="camera" size={11} />
 											Photo
 										</span>
@@ -175,7 +175,7 @@
 						<button
 							type="button"
 							onclick={() => (showAll = !showAll)}
-							class="text-xs font-medium text-zinc-400 hover:text-sky-400 transition-colors"
+							class="text-xs font-medium text-stone-400 hover:text-amber-400 transition-colors"
 						>
 							{showAll ? 'Show fewer' : `Show ${potholes.length - PAGE_SIZE} more`}
 						</button>

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -82,7 +82,7 @@
 		<div class="max-w-6xl mx-auto px-4 py-8">
 			<div class="flex items-center gap-2 mb-5">
 				<Icon name="bookmark-filled" size={15} class="text-amber-400 shrink-0" />
-				<h2 id="watchlist-heading" class="text-sm font-semibold text-stone-300 uppercase tracking-wider">
+				<h2 id="watchlist-heading" class="text-sm font-semibold text-stone-300">
 					My Watchlist
 				</h2>
 				<span class="text-stone-600 text-xs tabular-nums ml-1">({ids.length})</span>

--- a/src/lib/server/bluesky.ts
+++ b/src/lib/server/bluesky.ts
@@ -6,6 +6,9 @@ const BSKY_PDS = 'https://bsky.social';
 // Bluesky's grapheme limit per post.
 const MAX_POST_LENGTH = 300;
 
+// Log the "not configured" warning at most once per process lifetime.
+let _warnedNotConfigured = false;
+
 interface Session {
 	accessJwt: string;
 	did: string;
@@ -17,7 +20,10 @@ async function createSession(): Promise<Session | null> {
 
 	// Not configured — silently no-op so the app works without Bluesky.
 	if (!handle || !password) {
-		console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		if (!_warnedNotConfigured) {
+			_warnedNotConfigured = true;
+			console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		}
 		return null;
 	}
 
@@ -32,7 +38,7 @@ async function createSession(): Promise<Session | null> {
 		const body = await res.text().catch(() => '');
 		logError(
 			'bluesky/session',
-			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD in Netlify env vars (HTTP ${res.status})`,
+			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD environment variables (HTTP ${res.status})`,
 			new Error(body || String(res.status))
 		);
 		return null;

--- a/src/lib/server/bluesky.ts
+++ b/src/lib/server/bluesky.ts
@@ -16,7 +16,10 @@ async function createSession(): Promise<Session | null> {
 	const password = env.BLUESKY_APP_PASSWORD;
 
 	// Not configured — silently no-op so the app works without Bluesky.
-	if (!handle || !password) return null;
+	if (!handle || !password) {
+		console.info('[bluesky] BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — posting disabled');
+		return null;
+	}
 
 	const res = await fetch(`${BSKY_PDS}/xrpc/com.atproto.server.createSession`, {
 		method: 'POST',
@@ -27,7 +30,11 @@ async function createSession(): Promise<Session | null> {
 
 	if (!res.ok) {
 		const body = await res.text().catch(() => '');
-		logError('bluesky/session', `Auth failed with HTTP ${res.status}`, new Error(body || String(res.status)));
+		logError(
+			'bluesky/session',
+			`Auth failed — check BLUESKY_HANDLE and BLUESKY_APP_PASSWORD in Netlify env vars (HTTP ${res.status})`,
+			new Error(body || String(res.status))
+		);
 		return null;
 	}
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -22,7 +22,7 @@
 				An error occurred
 			{/if}
 		</h1>
-		<p class="text-stone-400 text-sm">
+		<p class="text-stone-600 dark:text-stone-400 text-sm">
 			{#if page.status === 404}
 				This pothole might have been filled — or the link is broken.
 			{:else}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -13,7 +13,7 @@
 	</div>
 
 	<div class="space-y-2">
-		<h1 class="page-title text-xl sm:text-2xl text-white">
+		<h1 class="page-title text-xl sm:text-2xl text-stone-900 dark:text-white">
 			{#if page.status === 404}
 				Page not found
 			{:else if page.status >= 500}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -8,7 +8,7 @@
 </svelte:head>
 
 <div class="max-w-lg mx-auto px-4 py-20 text-center space-y-6">
-	<div class="font-brand font-bold text-8xl text-zinc-800 tabular-nums select-none">
+	<div class="font-brand font-bold text-8xl text-stone-800 tabular-nums select-none">
 		{page.status}
 	</div>
 
@@ -22,7 +22,7 @@
 				An error occurred
 			{/if}
 		</h1>
-		<p class="text-zinc-400 text-sm">
+		<p class="text-stone-400 text-sm">
 			{#if page.status === 404}
 				This pothole might have been filled — or the link is broken.
 			{:else}
@@ -33,7 +33,7 @@
 
 	<a
 		href="/"
-		class="inline-flex items-center gap-2 px-5 py-2.5 bg-sky-700 hover:bg-sky-600 text-white font-semibold rounded-xl transition-colors text-sm"
+		class="inline-flex items-center gap-2 px-5 py-2.5 bg-amber-600 hover:bg-amber-500 text-white font-semibold rounded-md transition-colors text-sm"
 	>
 		<Icon name="arrow-left" size={14} class="shrink-0" />
 		Back to map

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
 	<!-- Skip link: must be the first focusable element for keyboard/screen reader users -->
 	<a
 		href="#maincontent"
-		class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-amber-500 focus:text-white focus:px-4 focus:py-2 focus:rounded-md focus:font-semibold focus:outline-none"
+		class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-stone-900 dark:focus:bg-white focus:text-white dark:focus:text-stone-900 focus:px-4 focus:py-2 focus:rounded-md focus:font-semibold focus:outline-none"
 	>
 		Skip to main content
 	</a>
@@ -45,8 +45,8 @@
 				<!-- Logo mark + wordmark -->
 				<a href="/" class="flex items-center gap-2.5 group">
 					<img src="/icon-192.png" alt="" aria-hidden="true" width="26" height="26" class="shrink-0 rounded-sm" />
-					<span class="font-brand font-bold text-xl leading-none text-stone-900 dark:text-white group-hover:text-amber-500 dark:group-hover:text-amber-400 transition-colors">
-						FillTheHole<span class="text-amber-500">.ca</span>
+					<span class="font-brand font-bold text-xl leading-none text-stone-900 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+						FillTheHole<span class="text-amber-600 dark:text-amber-400">.ca</span>
 					</span>
 				</a>
 
@@ -87,7 +87,7 @@
 					</a>
 					<a
 						href="/report"
-						class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold px-3.5 py-2 rounded-md transition-colors whitespace-nowrap text-sm"
+						class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-stone-900 font-semibold px-3.5 py-2 rounded-md transition-colors whitespace-nowrap text-sm"
 					>
 						<Icon name="plus" size={14} strokeWidth={2.5} />
 						Report a pothole

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,64 +30,64 @@
 	<link rel="preload" href={publicSans700} as="font" type="font/woff2" crossorigin="anonymous" />
 </svelte:head>
 
-<div class="flex flex-col min-h-screen bg-zinc-950">
+<div class="flex flex-col min-h-screen bg-stone-50 dark:bg-asphalt">
 	<!-- Skip link: must be the first focusable element for keyboard/screen reader users -->
 	<a
 		href="#maincontent"
-		class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-sky-600 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:font-semibold focus:outline-none"
+		class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-amber-500 focus:text-white focus:px-4 focus:py-2 focus:rounded-md focus:font-semibold focus:outline-none"
 	>
 		Skip to main content
 	</a>
 
-	<header class="bg-zinc-900 border-b border-zinc-800 sticky top-0 z-50 safe-header">
+	<header class="bg-white border-b border-stone-200 dark:bg-stone-900 dark:border-stone-700 sticky top-0 z-50 safe-header">
 		<div class="max-w-6xl mx-auto py-3 safe-header-inner">
 			<div class="flex items-center justify-between gap-3 flex-wrap">
 				<!-- Logo mark + wordmark -->
 				<a href="/" class="flex items-center gap-2.5 group">
 					<img src="/icon-192.png" alt="" aria-hidden="true" width="26" height="26" class="shrink-0 rounded-sm" />
-					<span class="font-brand font-bold text-xl leading-none text-white group-hover:text-sky-400 transition-colors">
-						FillTheHole<span class="text-sky-500">.ca</span>
+					<span class="font-brand font-bold text-xl leading-none text-stone-900 dark:text-white group-hover:text-amber-500 dark:group-hover:text-amber-400 transition-colors">
+						FillTheHole<span class="text-amber-500">.ca</span>
 					</span>
 				</a>
 
 				<!-- Live stat dots -->
 				<div class="hidden sm:flex items-center gap-3 text-sm" aria-label="Pothole statistics">
-					<span class="flex items-center gap-1.5 text-zinc-300">
+					<span class="flex items-center gap-1.5 text-stone-600 dark:text-stone-300">
 						<span class="w-2 h-2 rounded-full bg-orange-500 shrink-0"></span>
-						<span class="text-white font-semibold tabular-nums">{counts.reported}</span>
+						<span class="text-stone-900 dark:text-white font-semibold tabular-nums">{counts.reported}</span>
 						reported
 					</span>
-					<span class="text-zinc-700" aria-hidden="true">·</span>
-					<span class="flex items-center gap-1.5 text-zinc-300">
+					<span class="text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+					<span class="flex items-center gap-1.5 text-stone-600 dark:text-stone-300">
 						<span class="w-2 h-2 rounded-full bg-green-500 shrink-0"></span>
-						<span class="text-white font-semibold tabular-nums">{counts.filled}</span>
+						<span class="text-stone-900 dark:text-white font-semibold tabular-nums">{counts.filled}</span>
 						filled
 					</span>
 				</div>
 
 				<nav class="flex items-center gap-3 text-sm">
 					<PushNotifications />
-					<a href="/stats" class="text-zinc-300 hover:text-white transition-colors">
+					<a href="/stats" class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
 						Stats
 					</a>
-					<a href="/how-to" class="hidden sm:inline text-zinc-300 hover:text-white transition-colors">
+					<a href="/how-to" class="hidden sm:inline text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
 						How to
 					</a>
-					<a href="/about" class="text-zinc-300 hover:text-white transition-colors">
+					<a href="/about" class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors">
 						About
 					</a>
 					<a
 						href="https://github.com/BreakableHoodie/filltheholedotca"
 						target="_blank"
 						rel="noopener noreferrer"
-						class="hidden sm:inline-flex text-zinc-300 hover:text-white transition-colors"
+						class="hidden sm:inline-flex text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white transition-colors"
 						aria-label="View source on GitHub"
 					>
 						<Icon name="github" size={18} />
 					</a>
 					<a
 						href="/report"
-						class="inline-flex items-center gap-1.5 bg-sky-700 hover:bg-sky-600 text-white font-semibold px-3.5 py-2 rounded-lg transition-colors whitespace-nowrap text-sm"
+						class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold px-3.5 py-2 rounded-md transition-colors whitespace-nowrap text-sm"
 					>
 						<Icon name="plus" size={14} strokeWidth={2.5} />
 						Report a pothole
@@ -101,19 +101,19 @@
 		{@render children()}
 	</main>
 
-	<footer class="bg-zinc-900 border-t border-zinc-800 py-5 text-center text-zinc-300 text-xs px-4 space-y-1.5">
+	<footer class="bg-white border-t border-stone-200 dark:bg-stone-900 dark:border-stone-700 py-5 text-center text-stone-500 dark:text-stone-400 text-xs px-4 space-y-1.5">
 		<p>Track potholes. Contact your councillor. Hold the city accountable.</p>
 		<p>
 			Community-sourced data — not official. Use at your own risk.
-			<a href="/how-to" class="underline hover:text-white transition-colors">How to use</a>
-			<span class="mx-1 text-zinc-600" aria-hidden="true">·</span>
-			<a href="/about#privacy" class="underline hover:text-white transition-colors">Privacy</a>
-			<span class="mx-1 text-zinc-600" aria-hidden="true">·</span>
-			<a href="/about#disclaimer" class="underline hover:text-white transition-colors">Disclaimer</a>
-			<span class="mx-1 text-zinc-600" aria-hidden="true">·</span>
-			<a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">GitHub</a>
-			<span class="mx-1 text-zinc-600" aria-hidden="true">·</span>
-			<a href="https://github.com/BreakableHoodie/filltheholedotca/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">AGPL-3.0</a>
+			<a href="/how-to" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">How to use</a>
+			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+			<a href="/about#privacy" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Privacy</a>
+			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+			<a href="/about#disclaimer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Disclaimer</a>
+			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+			<a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">GitHub</a>
+			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+			<a href="https://github.com/BreakableHoodie/filltheholedotca/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">AGPL-3.0</a>
 		</p>
 		<p><SocialShare compact /></p>
 	</footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,7 @@
 	let watchlistCount = $state(0);
 	let watchlistSection: HTMLElement | null = null;
 	let mobileToolsOpen = $state(false);
+	let reportLocating = $state(false);
 	let liveReportedCount = $derived(
 		potholes.filter((pothole) => pothole.status === 'reported').length
 	);
@@ -69,6 +70,31 @@
 		if (mapRef) mapRef.getContainer().style.cursor = 'crosshair';
 		await tick();
 		cancelReportModeButton?.focus();
+	}
+
+	// Mobile-only: try GPS first, navigate directly to /report if available.
+	// Falls back to pin-drop mode if location is denied or unavailable.
+	function reportHereFromGps() {
+		mobileToolsOpen = false;
+
+		if (!navigator.geolocation) {
+			enterReportMode();
+			return;
+		}
+
+		reportLocating = true;
+		navigator.geolocation.getCurrentPosition(
+			({ coords }) => {
+				reportLocating = false;
+				goto(`/report?lat=${coords.latitude}&lng=${coords.longitude}`);
+			},
+			() => {
+				reportLocating = false;
+				toastError('Location access denied. Tap the map to drop a pin instead.');
+				enterReportMode();
+			},
+			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }
+		);
 	}
 
 	function exitReportMode() {
@@ -638,8 +664,8 @@
 
 	{#if mapReady}
 		<div class="absolute safe-bottom-mobile-tray inset-x-3 z-[1000] sm:hidden">
-			<div class="rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl overflow-hidden">
-				<div class="flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-zinc-800/80">
+			<div class="rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl overflow-hidden flex flex-col">
+				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-zinc-800/80">
 					<div class="min-w-0">
 						<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sky-300">Map tools</p>
 						<p class="text-sm text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
@@ -657,16 +683,21 @@
 					</button>
 				</div>
 
-				<div class="grid grid-cols-2 gap-2 px-4 py-3">
+				<div class="shrink-0 grid grid-cols-2 gap-2 px-4 py-3">
 					<button
 						type="button"
-						onclick={enterReportMode}
+						onclick={reportHereFromGps}
 						aria-pressed={reportMode}
-						disabled={reportMode}
+						disabled={reportMode || reportLocating}
 						class="inline-flex items-center justify-center gap-2 rounded-xl bg-sky-700 px-3 py-3 text-sm font-bold text-white transition-colors hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
 					>
-						<Icon name="map-pin" size={14} class="shrink-0" />
-						Report here
+						{#if reportLocating}
+							<Icon name="loader" size={14} class="animate-spin shrink-0" />
+							Locating…
+						{:else}
+							<Icon name="map-pin" size={14} class="shrink-0" />
+							Report here
+						{/if}
 					</button>
 					<button
 						type="button"
@@ -685,7 +716,8 @@
 				</div>
 
 				{#if mobileToolsOpen}
-					<div id="mobile-map-tools" class="border-t border-zinc-800 px-4 py-3 space-y-4">
+					<div id="mobile-map-tools" class="border-t border-zinc-800 overflow-y-auto max-h-[50dvh]">
+						<div class="px-4 py-3 space-y-4">
 						<div class="space-y-2">
 							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">Recent live reports</h2>
 							{#if recentReportedPotholes.length > 0}
@@ -761,6 +793,7 @@
 								{/each}
 							</div>
 						</div>
+					</div>
 					</div>
 				{/if}
 			</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -78,6 +78,7 @@
 		mobileToolsOpen = false;
 
 		if (!navigator.geolocation) {
+			toastError('Location is not available in this browser. Tap the map to drop a pin instead.');
 			enterReportMode();
 			return;
 		}
@@ -88,9 +89,17 @@
 				reportLocating = false;
 				goto(`/report?lat=${coords.latitude}&lng=${coords.longitude}`);
 			},
-			() => {
+			(error) => {
 				reportLocating = false;
-				toastError('Location access denied. Tap the map to drop a pin instead.');
+				let message = 'Unable to get your location. Tap the map to drop a pin instead.';
+				if (error.code === error.PERMISSION_DENIED) {
+					message = 'Location access denied. Tap the map to drop a pin instead.';
+				} else if (error.code === error.POSITION_UNAVAILABLE) {
+					message = 'Your location is unavailable right now. Tap the map to drop a pin instead.';
+				} else if (error.code === error.TIMEOUT) {
+					message = 'Getting your location took too long. Tap the map to drop a pin instead.';
+				}
+				toastError(message);
 				enterReportMode();
 			},
 			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -539,7 +539,7 @@
 					     so sighted keyboard users see where focus is. -->
 					<a
 						href="/hole/{pothole.id}"
-						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-zinc-950 focus:text-sky-400 focus:px-4 focus:py-2 focus:rounded-lg focus:border focus:border-zinc-700 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-sky-500"
+						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-stone-50 dark:focus:bg-asphalt focus:text-amber-500 focus:px-4 focus:py-2 focus:rounded-md focus:border focus:border-stone-200 dark:focus:border-stone-700 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500"
 					>
 						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'}
@@ -551,14 +551,14 @@
 </aside>
 
 <div class="relative w-full isolate" style="height: calc(100dvh - 57px - env(safe-area-inset-top))">
-	<div bind:this={mapEl} class="w-full h-full bg-zinc-900"></div>
+	<div bind:this={mapEl} class="w-full h-full bg-white dark:bg-stone-900"></div>
 	<HomeIntroCard />
 
 	{#if !mapReady}
-		<div class="absolute inset-0 flex items-center justify-center bg-zinc-900">
+		<div class="absolute inset-0 flex items-center justify-center bg-white dark:bg-stone-900">
 			<div class="text-center">
-				<div class="mx-auto w-9 h-9 rounded-full border-2 border-zinc-700 border-t-sky-500 animate-spin mb-4"></div>
-				<div class="text-sm text-zinc-300">Loading the map…</div>
+				<div class="mx-auto w-9 h-9 rounded-full border-2 border-stone-200 dark:border-stone-700 border-t-sky-500 animate-spin mb-4"></div>
+				<div class="text-sm text-stone-600 dark:text-stone-300">Loading the map…</div>
 			</div>
 		</div>
 	{/if}
@@ -566,16 +566,16 @@
 		<!-- Report-here banner -->
 		{#if reportMode}
 			<div
-				class="absolute top-4 left-4 right-4 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 z-[1001] flex flex-wrap items-center gap-2 sm:gap-3 bg-zinc-950 border border-sky-600 rounded-xl px-4 py-3 shadow-xl"
+				class="absolute top-4 left-4 right-4 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 z-[1001] flex flex-wrap items-center gap-2 sm:gap-3 bg-stone-50 dark:bg-asphalt border border-amber-500 rounded-md px-4 py-3 shadow-xl"
 			>
-				<span class="text-sm text-white grow" role="status" aria-live="polite" aria-atomic="true">
+				<span class="text-sm text-stone-900 dark:text-white grow" role="status" aria-live="polite" aria-atomic="true">
 					Tap the map where the pothole is
 				</span>
 				{#if reportLatLng}
 				<button
 					type="button"
 					onclick={confirmReportLocation}
-					class="bg-sky-600 hover:bg-sky-500 text-white text-xs font-bold px-3 py-1.5 rounded-lg transition-colors"
+					class="bg-amber-500 hover:bg-amber-600 text-white text-xs font-bold px-3 py-1.5 rounded-md transition-colors"
 				>
 					Confirm location →
 				</button>
@@ -584,7 +584,7 @@
 				bind:this={cancelReportModeButton}
 				type="button"
 				onclick={exitReportMode}
-				class="text-zinc-400 hover:text-white text-xs px-2 py-1 rounded transition-colors"
+				class="text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-xs px-2 py-1 rounded transition-colors"
 				aria-label="Cancel"
 			>
 				✕ Cancel
@@ -598,7 +598,7 @@
 			<button
 				onclick={locateMe}
 				disabled={locating}
-				class="bg-zinc-950 border border-zinc-700 hover:border-zinc-500 rounded-xl px-3 py-2 text-xs text-zinc-300 transition-colors flex items-center gap-1.5 disabled:opacity-50"
+				class="bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 hover:border-stone-400 dark:hover:border-stone-500 rounded-md px-3 py-2 text-xs text-stone-600 dark:text-stone-300 transition-colors flex items-center gap-1.5 disabled:opacity-50"
 			>
 				{#if locating}
 					<Icon name="loader" size={12} class="animate-spin shrink-0" />
@@ -615,22 +615,22 @@
 				onclick={enterReportMode}
 				aria-pressed={reportMode}
 				disabled={reportMode}
-				class="bg-sky-700 border border-sky-600 hover:border-sky-400 rounded-xl px-3 py-2 text-xs text-white font-semibold transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+				class="bg-amber-500 border border-amber-500 hover:border-amber-400 rounded-md px-3 py-2 text-xs text-white font-semibold transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
 			>
 				<Icon name="map-pin" size={12} class="shrink-0" />
 				Report here
 			</button>
 
 			<!-- Layers panel -->
-			<div class="bg-zinc-950 border border-zinc-700 rounded-xl p-3 space-y-2 text-xs">
-				<div class="text-zinc-400 font-semibold uppercase tracking-wider text-[10px] mb-1">Layers</div>
+			<div class="bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 space-y-2 text-xs">
+				<div class="text-stone-500 dark:text-stone-400 font-semibold uppercase tracking-wider text-[10px] mb-1">Layers</div>
 
 				{#each ([
 					['reported', 'Reported'],
 					['expired',  'Expired'],
 					['filled',   'Filled'],
 				] as const) as [key, label] (key)}
-					<label class="flex items-center gap-2 cursor-pointer text-zinc-300 hover:text-white">
+					<label class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white">
 						<input
 							type="checkbox"
 							checked={layers[key]}
@@ -641,8 +641,8 @@
 					</label>
 				{/each}
 
-				<div class="border-t border-zinc-700 pt-2">
-					<label class="flex items-center gap-2 cursor-pointer text-zinc-300 hover:text-white">
+				<div class="border-t border-stone-200 dark:border-stone-700 pt-2">
+					<label class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white">
 						<input
 							type="checkbox"
 							checked={layers.wards}
@@ -659,11 +659,11 @@
 
 	<!-- Legend -->
 	{#if mapReady}
-		<div class="absolute safe-bottom right-4 hidden sm:block bg-zinc-950 border border-zinc-700 rounded-xl p-3 text-xs space-y-1.5 z-[1000]">
-			<div class="text-zinc-400 font-semibold mb-2 uppercase tracking-wider text-[10px]">Status</div>
+		<div class="absolute safe-bottom right-4 hidden sm:block bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 text-xs space-y-1.5 z-[1000]">
+			<div class="text-stone-500 dark:text-stone-400 font-semibold mb-2 uppercase tracking-wider text-[10px]">Status</div>
 			{#each ['reported', 'expired', 'filled'] as status (status)}
 				{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
-				<div class="flex items-center gap-2 text-zinc-300">
+				<div class="flex items-center gap-2 text-stone-600 dark:text-stone-300">
 					<Icon name={info.icon} size={12} class={info.colorClass} />
 					<span>{info.label}</span>
 				</div>
@@ -673,19 +673,19 @@
 
 	{#if mapReady}
 		<div class="absolute safe-bottom-mobile-tray inset-x-3 z-[1000] sm:hidden">
-			<div class="rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl overflow-hidden flex flex-col">
-				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-zinc-800/80">
+			<div class="rounded-md border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 shadow-2xl overflow-hidden flex flex-col">
+				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-stone-200/80 dark:border-stone-800/80">
 					<div class="min-w-0">
-						<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sky-300">Map tools</p>
-						<p class="text-sm text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
-						<p class="text-[11px] text-zinc-400">Tap a marker for details or drop a pin to report a new one.</p>
+						<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-500">Map tools</p>
+						<p class="text-sm text-stone-900 dark:text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
+						<p class="text-[11px] text-stone-500 dark:text-stone-400">Tap a marker for details or drop a pin to report a new one.</p>
 					</div>
 					<button
 						type="button"
 						onclick={() => (mobileToolsOpen = !mobileToolsOpen)}
 						aria-expanded={mobileToolsOpen}
 						aria-controls="mobile-map-tools"
-						class="shrink-0 inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 px-3 py-2 text-xs font-semibold text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+						class="shrink-0 inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-stone-700 px-3 py-2 text-xs font-semibold text-stone-600 dark:text-stone-300 transition-colors hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white"
 					>
 						<Icon name="layers" size={12} class="shrink-0" />
 						{mobileToolsOpen ? 'Hide' : 'Tools'}
@@ -698,7 +698,7 @@
 						onclick={reportHereFromGps}
 						aria-pressed={reportMode}
 						disabled={reportMode || reportLocating}
-						class="inline-flex items-center justify-center gap-2 rounded-xl bg-sky-700 px-3 py-3 text-sm font-bold text-white transition-colors hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
+						class="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-3 py-3 text-sm font-bold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-60"
 					>
 						{#if reportLocating}
 							<Icon name="loader" size={14} class="animate-spin shrink-0" />
@@ -712,7 +712,7 @@
 						type="button"
 						onclick={locateMe}
 						disabled={locating}
-						class="inline-flex items-center justify-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-3 text-sm font-semibold text-zinc-200 transition-colors hover:border-zinc-500 hover:text-white disabled:opacity-60"
+						class="inline-flex items-center justify-center gap-2 rounded-md border border-stone-200 dark:border-stone-700 bg-stone-100 dark:bg-stone-800 px-3 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200 transition-colors hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white disabled:opacity-60"
 					>
 						{#if locating}
 							<Icon name="loader" size={14} class="animate-spin shrink-0" />
@@ -725,35 +725,35 @@
 				</div>
 
 				{#if mobileToolsOpen}
-					<div id="mobile-map-tools" class="border-t border-zinc-800 overflow-y-auto max-h-[50dvh]">
+					<div id="mobile-map-tools" class="border-t border-stone-200 dark:border-stone-800 overflow-y-auto max-h-[50dvh]">
 						<div class="px-4 py-3 space-y-4">
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">Recent live reports</h2>
+							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Recent live reports</h2>
 							{#if recentReportedPotholes.length > 0}
 								<div class="space-y-2">
 									{#each recentReportedPotholes as pothole (pothole.id)}
 										<button
 											type="button"
 											onclick={() => focusPothole(pothole.id)}
-											class="w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-3 text-left transition-colors hover:border-zinc-600 hover:bg-zinc-800"
+											class="w-full rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-left transition-colors hover:border-stone-300 dark:hover:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800"
 											aria-label={`Open report for ${pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}`}
 										>
 											<div class="flex items-start justify-between gap-3">
 												<div class="min-w-0">
-													<p class="truncate text-sm font-semibold text-white">
+													<p class="truncate text-sm font-semibold text-stone-900 dark:text-white">
 														{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 													</p>
-													<p class="mt-1 text-[11px] leading-relaxed text-zinc-400 line-clamp-2">
+													<p class="mt-1 text-[11px] leading-relaxed text-stone-500 dark:text-stone-400 line-clamp-2">
 														{pothole.description || 'Jump to this marker to review details, share it, or mark it fixed.'}
 													</p>
 													{#if pothole.photos_published}
-														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-zinc-400">
+														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-stone-500 dark:text-stone-400">
 															<Icon name="camera" size={11} />
 															Photo
 														</span>
 													{/if}
 												</div>
-												<span class="shrink-0 rounded-full bg-zinc-800 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-300">
+												<span class="shrink-0 rounded-full bg-stone-100 dark:bg-stone-800 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-500">
 													Open
 												</span>
 											</div>
@@ -761,14 +761,14 @@
 									{/each}
 								</div>
 							{:else}
-								<p class="rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-3 text-xs leading-relaxed text-zinc-400">
+								<p class="rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-xs leading-relaxed text-stone-500 dark:text-stone-400">
 									Live reports will appear here once the community has confirmed them.
 								</p>
 							{/if}
 						</div>
 
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">Layers</h2>
+							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Layers</h2>
 							<div class="grid grid-cols-2 gap-2">
 								{#each ([
 									['reported', 'Reported'],
@@ -781,21 +781,21 @@
 										onclick={() => toggleLayer(key)}
 										aria-pressed={layers[key]}
 										disabled={key === 'wards' && wardLoading}
-										class="inline-flex items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-xs font-semibold transition-colors disabled:opacity-60 {layers[key] ? 'border-sky-600 bg-sky-500/10 text-white' : 'border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-500 hover:text-white'}"
+										class="inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2.5 text-xs font-semibold transition-colors disabled:opacity-60 {layers[key] ? 'border-amber-500 bg-amber-500/10 text-stone-900 dark:text-white' : 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-900 text-stone-600 dark:text-stone-300 hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white'}"
 									>
 										<span>{key === 'wards' && wardLoading ? 'Loading…' : label}</span>
-										<span class="text-[10px] uppercase tracking-wide text-zinc-400">{layers[key] ? 'On' : 'Off'}</span>
+										<span class="text-[10px] uppercase tracking-wide text-stone-500 dark:text-stone-400">{layers[key] ? 'On' : 'Off'}</span>
 									</button>
 								{/each}
 							</div>
 						</div>
 
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">Status guide</h2>
+							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Status guide</h2>
 							<div class="grid grid-cols-1 gap-2">
 								{#each ['reported', 'expired', 'filled'] as status (status)}
 									{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
-									<div class="flex items-center gap-2 rounded-xl bg-zinc-900 px-3 py-2 text-xs text-zinc-300 border border-zinc-800">
+									<div class="flex items-center gap-2 rounded-md bg-stone-50 dark:bg-stone-900 px-3 py-2 text-xs text-stone-600 dark:text-stone-300 border border-stone-200 dark:border-stone-800">
 										<Icon name={info.icon} size={12} class={info.colorClass} />
 										<span>{info.label}</span>
 									</div>
@@ -811,15 +811,15 @@
 
 	{#if potholes.length === 0 && mapReady}
 		<div class="absolute inset-0 flex items-center justify-center z-[1000] pointer-events-none">
-			<div class="pointer-events-auto bg-zinc-950/95 border border-zinc-700 rounded-2xl px-8 py-6 max-w-xs w-full mx-4 text-center shadow-2xl">
-				<div class="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center mx-auto mb-3">
-					<Icon name="map-pin" size={18} class="text-sky-400" />
+			<div class="pointer-events-auto bg-white/95 dark:bg-stone-900/95 border border-stone-200 dark:border-stone-700 rounded-md px-8 py-6 max-w-xs w-full mx-4 text-center shadow-2xl">
+				<div class="w-10 h-10 rounded-full bg-stone-100 dark:bg-stone-800 flex items-center justify-center mx-auto mb-3">
+					<Icon name="map-pin" size={18} class="text-amber-500" />
 				</div>
-				<h2 class="text-sm font-semibold text-white mb-1">No potholes reported yet</h2>
-				<p class="text-xs text-zinc-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
+				<h2 class="text-sm font-semibold text-stone-900 dark:text-white mb-1">No potholes reported yet</h2>
+				<p class="text-xs text-stone-500 dark:text-stone-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
 				<a
 					href="/report"
-					class="inline-flex items-center gap-1.5 bg-sky-700 hover:bg-sky-600 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
+					class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-white text-xs font-semibold px-4 py-2 rounded-md transition-colors"
 				>
 					<Icon name="plus" size={13} strokeWidth={2.5} />
 					Report a pothole
@@ -833,7 +833,7 @@
 		<div class="absolute safe-bottom-watchlist left-1/2 -translate-x-1/2 z-[1000]">
 			<button
 				onclick={() => watchlistSection?.scrollIntoView({ behavior: 'smooth' })}
-				class="inline-flex items-center gap-1.5 bg-zinc-950 border border-sky-800 text-sky-400 text-xs font-semibold px-3 py-1.5 rounded-full hover:border-sky-600 hover:text-sky-300 transition-colors shadow-lg"
+				class="inline-flex items-center gap-1.5 bg-white dark:bg-stone-900 border border-amber-500 text-amber-500 text-xs font-semibold px-3 py-1.5 rounded-full hover:border-amber-400 hover:text-amber-400 transition-colors shadow-lg"
 				aria-label="Scroll to watchlist"
 			>
 				<Icon name="bookmark-filled" size={12} class="shrink-0" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -819,7 +819,7 @@
 				<p class="text-xs text-stone-500 dark:text-stone-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
 				<a
 					href="/report"
-					class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-white text-xs font-semibold px-4 py-2 rounded-md transition-colors"
+					class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-stone-900 text-xs font-semibold px-4 py-2 rounded-md transition-colors"
 				>
 					<Icon name="plus" size={13} strokeWidth={2.5} />
 					Report a pothole

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -539,7 +539,7 @@
 					     so sighted keyboard users see where focus is. -->
 					<a
 						href="/hole/{pothole.id}"
-						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-stone-50 dark:focus:bg-asphalt focus:text-amber-500 focus:px-4 focus:py-2 focus:rounded-md focus:border focus:border-stone-200 dark:focus:border-stone-700 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500"
+						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-stone-900 dark:focus:bg-white focus:text-white dark:focus:text-stone-900 focus:px-4 focus:py-2 focus:rounded-md focus:border focus:border-stone-700 dark:focus:border-stone-200 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500"
 					>
 						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	import WatchlistPanel from '$lib/components/WatchlistPanel.svelte';
 	import { STATUS_CONFIG } from '$lib/constants';
 	import { escapeHtml } from '$lib/escape';
-	import { inWardFeature } from '$lib/geo';
+	import { inWardFeature, roundPublicCoord } from '$lib/geo';
 	import { ICONS } from '$lib/icons';
 	import { toastError } from '$lib/toast';
 	import type { Pothole } from '$lib/types';
@@ -87,7 +87,7 @@
 		navigator.geolocation.getCurrentPosition(
 			({ coords }) => {
 				reportLocating = false;
-				goto(`/report?lat=${coords.latitude}&lng=${coords.longitude}`);
+				goto(`/report?lat=${roundPublicCoord(coords.latitude)}&lng=${roundPublicCoord(coords.longitude)}`);
 			},
 			(error) => {
 				reportLocating = false;
@@ -120,7 +120,7 @@
 	function confirmReportLocation() {
 		if (!reportLatLng) return;
 		mobileToolsOpen = false;
-		goto(`/report?lat=${reportLatLng.lat}&lng=${reportLatLng.lng}`);
+		goto(`/report?lat=${roundPublicCoord(reportLatLng.lat)}&lng=${roundPublicCoord(reportLatLng.lng)}`);
 	}
 	let wardLayerRef: Leaflet.GeoJSON | null = null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -557,7 +557,7 @@
 	{#if !mapReady}
 		<div class="absolute inset-0 flex items-center justify-center bg-white dark:bg-stone-900">
 			<div class="text-center">
-				<div class="mx-auto w-9 h-9 rounded-full border-2 border-stone-200 dark:border-stone-700 border-t-sky-500 animate-spin mb-4"></div>
+				<div class="mx-auto w-9 h-9 rounded-full border-2 border-stone-200 dark:border-stone-700 border-t-amber-500 animate-spin mb-4"></div>
 				<div class="text-sm text-stone-600 dark:text-stone-300">Loading the map…</div>
 			</div>
 		</div>
@@ -623,7 +623,7 @@
 
 			<!-- Layers panel -->
 			<div class="bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 space-y-2 text-xs">
-				<div class="text-stone-500 dark:text-stone-400 font-semibold uppercase tracking-wider text-[10px] mb-1">Layers</div>
+				<div class="text-stone-500 dark:text-stone-400 font-semibold text-[10px] mb-1">Layers</div>
 
 				{#each ([
 					['reported', 'Reported'],
@@ -660,7 +660,7 @@
 	<!-- Legend -->
 	{#if mapReady}
 		<div class="absolute safe-bottom right-4 hidden sm:block bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 text-xs space-y-1.5 z-[1000]">
-			<div class="text-stone-500 dark:text-stone-400 font-semibold mb-2 uppercase tracking-wider text-[10px]">Status</div>
+			<div class="text-stone-500 dark:text-stone-400 font-semibold mb-2 text-[10px]">Status</div>
 			{#each ['reported', 'expired', 'filled'] as status (status)}
 				{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
 				<div class="flex items-center gap-2 text-stone-600 dark:text-stone-300">
@@ -676,7 +676,7 @@
 			<div class="rounded-md border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 shadow-2xl overflow-hidden flex flex-col">
 				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-stone-200/80 dark:border-stone-800/80">
 					<div class="min-w-0">
-						<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-500">Map tools</p>
+						<p class="text-[11px] font-semibold text-amber-500">Map tools</p>
 						<p class="text-sm text-stone-900 dark:text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
 						<p class="text-[11px] text-stone-500 dark:text-stone-400">Tap a marker for details or drop a pin to report a new one.</p>
 					</div>
@@ -728,7 +728,7 @@
 					<div id="mobile-map-tools" class="border-t border-stone-200 dark:border-stone-800 overflow-y-auto max-h-[50dvh]">
 						<div class="px-4 py-3 space-y-4">
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Recent live reports</h2>
+							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Recent live reports</h2>
 							{#if recentReportedPotholes.length > 0}
 								<div class="space-y-2">
 									{#each recentReportedPotholes as pothole (pothole.id)}
@@ -753,7 +753,7 @@
 														</span>
 													{/if}
 												</div>
-												<span class="shrink-0 rounded-full bg-stone-100 dark:bg-stone-800 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-500">
+												<span class="shrink-0 rounded bg-stone-100 dark:bg-stone-800 px-2 py-1 text-[10px] font-semibold text-amber-500">
 													Open
 												</span>
 											</div>
@@ -768,7 +768,7 @@
 						</div>
 
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Layers</h2>
+							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Layers</h2>
 							<div class="grid grid-cols-2 gap-2">
 								{#each ([
 									['reported', 'Reported'],
@@ -784,14 +784,14 @@
 										class="inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2.5 text-xs font-semibold transition-colors disabled:opacity-60 {layers[key] ? 'border-amber-500 bg-amber-500/10 text-stone-900 dark:text-white' : 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-900 text-stone-600 dark:text-stone-300 hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white'}"
 									>
 										<span>{key === 'wards' && wardLoading ? 'Loading…' : label}</span>
-										<span class="text-[10px] uppercase tracking-wide text-stone-500 dark:text-stone-400">{layers[key] ? 'On' : 'Off'}</span>
+										<span class="text-[10px] font-semibold text-stone-500 dark:text-stone-400">{layers[key] ? 'On' : 'Off'}</span>
 									</button>
 								{/each}
 							</div>
 						</div>
 
 						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 dark:text-stone-400">Status guide</h2>
+							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Status guide</h2>
 							<div class="grid grid-cols-1 gap-2">
 								{#each ['reported', 'expired', 'filled'] as status (status)}
 									{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -11,12 +11,12 @@
 
 <div class="max-w-2xl mx-auto px-4 py-12 space-y-10">
 	<div>
-		<h1 class="page-title text-4xl sm:text-5xl text-white mb-2">About</h1>
-		<p class="page-intro text-zinc-400 text-lg">Civic accountability, one pothole at a time.</p>
+		<h1 class="page-title text-4xl sm:text-5xl text-stone-900 dark:text-white mb-2">About</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-lg">Civic accountability, one pothole at a time.</p>
 	</div>
 
-	<section class="space-y-4 text-zinc-300 leading-relaxed">
-		<h2 class="section-title text-xl text-white">Why this exists</h2>
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Why this exists</h2>
 		<p>
 			Potholes damage cars, bend bike wheels, and throw cyclists. They're a hazard for
 			everyone — drivers, riders, and pedestrians alike. But reporting them through official
@@ -27,17 +27,17 @@
 			fillthehole.ca makes the problem visible. Every reported pothole goes on a public map.
 			Every day it stays unfilled is tracked. Your councillor's contact is one tap away.
 		</p>
-		<p class="text-sky-300 font-medium">
+		<p class="text-amber-600 dark:text-amber-400 font-medium">
 			Sunlight is the best disinfectant. A public map is hard to ignore.
 		</p>
 	</section>
 
-	<section class="bg-zinc-900 border border-zinc-700 rounded-xl p-6 space-y-4">
-		<h2 class="section-title flex items-center gap-2 text-xl text-white">
-			<Icon name="external-link" size={18} class="text-sky-400 shrink-0" />
+	<section class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-6 space-y-4">
+		<h2 class="section-title flex items-center gap-2 text-xl text-stone-900 dark:text-white">
+			<Icon name="external-link" size={18} class="text-amber-500 shrink-0" />
 			Report it officially too
 		</h2>
-		<p class="text-zinc-400 text-sm">
+		<p class="text-stone-600 dark:text-stone-400 text-sm">
 			This map creates public pressure — but an official report creates a paper trail the city
 			is legally required to respond to. Do both.
 		</p>
@@ -47,7 +47,7 @@
 					href={link.href}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex items-center gap-2 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors {link.id === 'kitchener' ? 'bg-sky-700 hover:bg-sky-600' : 'bg-zinc-700 hover:bg-zinc-600'}"
+					class="flex items-center gap-2 text-white text-sm font-semibold px-4 py-2 rounded-md transition-colors {link.id === 'kitchener' ? 'bg-amber-600 hover:bg-amber-500' : 'bg-stone-300 dark:bg-stone-700 hover:bg-stone-200 dark:hover:bg-stone-600 text-stone-900 dark:text-white'}"
 				>
 					<Icon name="external-link" size={14} class="shrink-0" />
 					{link.label}
@@ -61,29 +61,29 @@
 				</a>
 			{/each}
 		</div>
-		<div class="bg-zinc-800 rounded-lg p-3 text-xs text-zinc-400 leading-relaxed space-y-2">
+		<div class="bg-stone-100 dark:bg-stone-800 rounded-md p-3 text-xs text-stone-600 dark:text-stone-400 leading-relaxed space-y-2">
 			<p>
-				<strong class="text-zinc-300">Not sure who maintains the road?</strong> Major roads like
+				<strong class="text-stone-900 dark:text-stone-300">Not sure who maintains the road?</strong> Major roads like
 				King St, Victoria St, Weber St, and Erb St are <em>Regional roads</em> maintained by the
 				Region of Waterloo — not your local city. Local residential streets belong to whichever
 				city you're in. When in doubt, report to both.
 			</p>
 			<p>
-				<strong class="text-zinc-300">Provincial highways (401, 7/8, 85) are MTO's responsibility</strong>,
+				<strong class="text-stone-900 dark:text-stone-300">Provincial highways (401, 7/8, 85) are MTO's responsibility</strong>,
 				not the city or Region. Report those to the
-				<a href="https://www.ontario.ca/page/report-problem-provincial-highway" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Ministry of Transportation Ontario</a>.
+				<a href="https://www.ontario.ca/page/report-problem-provincial-highway" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Ministry of Transportation Ontario</a>.
 			</p>
 		</div>
 	</section>
 
-	<section class="space-y-4 text-zinc-300 leading-relaxed">
-		<h2 class="section-title text-xl text-white">How it works</h2>
-		<p class="text-sm text-zinc-400">
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">How it works</h2>
+		<p class="text-sm text-stone-600 dark:text-stone-400">
 			The basics are below.
-			<a href="/how-to" class="text-sky-400 underline hover:text-sky-300 transition-colors">Full how-to guide →</a>
+			<a href="/how-to" class="text-amber-600 dark:text-amber-400 underline hover:text-amber-500 dark:hover:text-amber-300 transition-colors">Full how-to guide →</a>
 		</p>
 
-		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-xl p-4 text-sm text-amber-200/90">
+		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-md p-4 text-sm text-amber-200/90">
 			<Icon name="alert-triangle" size={18} class="text-amber-400 shrink-0 mt-0.5" />
 			<p>
 				<strong class="text-amber-300">Stay safe when reporting.</strong>
@@ -94,26 +94,26 @@
 		</div>
 
 		<div class="grid gap-4">
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 flex gap-4 items-start">
-				<div class="shrink-0 mt-0.5 p-2 rounded-lg bg-orange-500/10">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 flex gap-4 items-start">
+				<div class="shrink-0 mt-0.5 p-2 rounded-md bg-orange-500/10">
 					<Icon name="map-pin" size={20} class="text-orange-400" />
 				</div>
 				<div>
-					<div class="font-semibold text-white mb-1">1. Report</div>
-					<p class="text-sm text-zinc-400">
+					<div class="font-semibold text-stone-900 dark:text-white mb-1">1. Report</div>
+					<p class="text-sm text-stone-600 dark:text-stone-400">
 						Standing next to a pothole? Open the app on your phone, lock your GPS location,
 						and submit. Independent reports from the same location help verify it and put it on the map.
 					</p>
 				</div>
 			</div>
 
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 flex gap-4 items-start">
-				<div class="shrink-0 mt-0.5 p-2 rounded-lg bg-sky-500/10">
-					<Icon name="mail" size={20} class="text-sky-400" />
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 flex gap-4 items-start">
+				<div class="shrink-0 mt-0.5 p-2 rounded-md bg-amber-500/10">
+					<Icon name="mail" size={20} class="text-amber-500" />
 				</div>
 				<div>
-					<div class="font-semibold text-white mb-1">2. Contact</div>
-					<p class="text-sm text-zinc-400">
+					<div class="font-semibold text-stone-900 dark:text-white mb-1">2. Contact</div>
+					<p class="text-sm text-stone-600 dark:text-stone-400">
 						Share the pothole link with your ward councillor or on social media.
 						The detail page shows your councillor's contact info and a direct email link.
 						The more people who see it, the harder it is to ignore.
@@ -121,13 +121,13 @@
 				</div>
 			</div>
 
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 flex gap-4 items-start">
-				<div class="shrink-0 mt-0.5 p-2 rounded-lg bg-green-500/10">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 flex gap-4 items-start">
+				<div class="shrink-0 mt-0.5 p-2 rounded-md bg-green-500/10">
 					<Icon name="check-circle" size={20} class="text-green-400" />
 				</div>
 				<div>
-					<div class="font-semibold text-white mb-1">3. Watch it get filled</div>
-					<p class="text-sm text-zinc-400">
+					<div class="font-semibold text-stone-900 dark:text-white mb-1">3. Watch it get filled</div>
+					<p class="text-sm text-stone-600 dark:text-stone-400">
 						When the city fills it, mark it done. The counter goes up. The data stays public —
 						showing how long repairs take across the city.
 					</p>
@@ -136,87 +136,87 @@
 		</div>
 	</section>
 
-	<section class="space-y-4 text-zinc-300 leading-relaxed" id="privacy">
-		<h2 class="section-title text-xl text-white">Privacy</h2>
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed" id="privacy">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Privacy</h2>
 		<p>
 			No accounts. No names. No tracking. Here's exactly what this site does and doesn't do with your data.
 		</p>
 
 		<div class="space-y-3">
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<div class="flex items-center gap-2 text-sm font-semibold text-white">
-					<Icon name="crosshair" size={14} class="text-zinc-400 shrink-0" />
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="crosshair" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
 					GPS coordinates
 				</div>
-				<p class="text-sm text-zinc-400">
+				<p class="text-sm text-stone-600 dark:text-stone-400">
 					When you report a pothole, your GPS coordinates are stored to place the pin on the map.
 					That's their only purpose. They are never sold, shared with third parties, or tied to any identity.
 				</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<div class="flex items-center gap-2 text-sm font-semibold text-white">
-					<Icon name="info" size={14} class="text-zinc-400 shrink-0" />
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="info" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
 					IP addresses
 				</div>
-				<p class="text-sm text-zinc-400">
+				<p class="text-sm text-stone-600 dark:text-stone-400">
 					Your IP address is used only to prevent duplicate reports from the same device.
 					It is immediately converted to an HMAC-SHA-256 hash with a server-side secret before being
 					stored — the raw IP is never written to disk or logged. The hash cannot be reversed back to
 					your IP without the secret.
 				</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<div class="flex items-center gap-2 text-sm font-semibold text-white">
-					<Icon name="info" size={14} class="text-zinc-400 shrink-0" />
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="info" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
 					Cookies &amp; local storage
 				</div>
-				<p class="text-sm text-zinc-400">
-					This site sets no cookies. A single entry (<code class="text-zinc-300 bg-zinc-800 px-1 rounded text-xs">fth-home-intro-dismissed</code>)
+				<p class="text-sm text-stone-600 dark:text-stone-400">
+					This site sets no cookies. A single entry (<code class="text-stone-900 dark:text-stone-300 bg-stone-200 dark:bg-stone-800 px-1 rounded text-xs">fth-home-intro-dismissed</code>)
 					is stored in your browser's local storage to remember that you've dismissed the homepage introduction.
 					It contains no personal information and is never sent to any server.
 				</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<div class="flex items-center gap-2 text-sm font-semibold text-white">
-					<Icon name="globe" size={14} class="text-zinc-400 shrink-0" />
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="globe" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
 					Third-party services
 				</div>
-				<p class="text-sm text-zinc-400">
-					Map tiles are loaded from <a href="https://www.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">OpenStreetMap</a>.
+				<p class="text-sm text-stone-600 dark:text-stone-400">
+					Map tiles are loaded from <a href="https://www.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">OpenStreetMap</a>.
 					When you report a pothole, your coordinates are sent to
-					<a href="https://nominatim.org" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Nominatim</a> (OpenStreetMap's geocoder)
+					<a href="https://nominatim.org" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Nominatim</a> (OpenStreetMap's geocoder)
 					to look up the street address. Report data is stored in
-					<a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Supabase</a>.
+					<a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Supabase</a>.
 					Each of these services has its own privacy policy.
 				</p>
-				<p class="text-sm text-zinc-400">
+				<p class="text-sm text-stone-600 dark:text-stone-400">
 					On individual pothole pages, the pothole's coordinates (rounded to ~11 m precision)
 					are sent to
-					<a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline">Esri ArcGIS</a>
+					<a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Esri ArcGIS</a>
 					to check whether Kitchener's 311 system has a matching repair request on file.
 					No personal information is included in this query — only the location.
 				</p>
 			</div>
 		</div>
 
-		<p class="text-sm text-zinc-400">
-			Questions? This is an <a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">open-source civic project</a> with no commercial interest in your data.
+		<p class="text-sm text-stone-600 dark:text-stone-400">
+			Questions? This is an <a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">open-source civic project</a> with no commercial interest in your data.
 		</p>
 	</section>
 
-	<section class="space-y-4 text-zinc-300 leading-relaxed" id="disclaimer">
-		<h2 class="section-title text-xl text-white">Disclaimer</h2>
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-3 text-sm text-zinc-400 leading-relaxed">
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed" id="disclaimer">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Disclaimer</h2>
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-5 space-y-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			<p>
-				fillthehole.ca is an independent community tool. It is <strong class="text-zinc-300">not affiliated with, endorsed by, or operated by</strong> the City of Kitchener, City of Waterloo, City of Cambridge, the Region of Waterloo, or any other government body.
+				fillthehole.ca is an independent community tool. It is <strong class="text-stone-900 dark:text-stone-300">not affiliated with, endorsed by, or operated by</strong> the City of Kitchener, City of Waterloo, City of Cambridge, the Region of Waterloo, or any other government body.
 			</p>
 			<p>
-				All pothole data is <strong class="text-zinc-300">community-sourced and unverified</strong>.
+				All pothole data is <strong class="text-stone-900 dark:text-stone-300">community-sourced and unverified</strong>.
 				Reports may be inaccurate, outdated, or mislocated. A pothole marked "filled" may have been re-reported in error.
 				Do not rely on this map as a definitive record of road conditions.
 			</p>
 			<p>
-				This site is provided <strong class="text-zinc-300">as-is, without warranty of any kind</strong>.
+				This site is provided <strong class="text-stone-900 dark:text-stone-300">as-is, without warranty of any kind</strong>.
 				The operator is not liable for any damage to vehicles, injuries, or losses arising from reliance on information displayed here.
 			</p>
 			<p>
@@ -225,9 +225,9 @@
 		</div>
 	</section>
 
-	<section class="space-y-3 text-zinc-300 leading-relaxed">
-		<h2 class="section-title text-xl text-white">Open source</h2>
-		<p class="text-zinc-400 text-sm">
+	<section class="space-y-3 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Open source</h2>
+		<p class="text-stone-600 dark:text-stone-400 text-sm">
 			fillthehole.ca is free, open-source software built for the public good. No ads, no investors, no data harvesting.
 			Read the code, file an issue, or contribute a fix.
 		</p>
@@ -235,7 +235,7 @@
 			href="https://github.com/BreakableHoodie/filltheholedotca"
 			target="_blank"
 			rel="noopener noreferrer"
-			class="inline-flex items-center gap-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+			class="inline-flex items-center gap-2 bg-stone-200 dark:bg-stone-800 hover:bg-stone-300 dark:hover:bg-stone-700 border border-stone-300 dark:border-stone-700 text-stone-900 dark:text-stone-300 text-sm font-semibold px-4 py-2 rounded-md transition-colors"
 		>
 			<Icon name="github" size={16} class="shrink-0" />
 			BreakableHoodie/filltheholedotca
@@ -243,38 +243,38 @@
 	</section>
 
 	<section class="space-y-4" id="open-data">
-		<h2 class="section-title text-xl text-white">Open data</h2>
-		<p class="text-zinc-400 text-sm">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Open data</h2>
+		<p class="text-stone-600 dark:text-stone-400 text-sm">
 			All confirmed pothole data is freely available for research, journalism, or civic apps.
 			No API key required.
 		</p>
 		<div class="grid gap-3 sm:grid-cols-2">
 			<a
 				href="/api/export.csv"
-				class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4 hover:border-sky-600 transition-colors group"
+				class="flex items-start gap-3 bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 hover:border-amber-500 dark:hover:border-amber-500 transition-colors group"
 			>
-				<Icon name="download" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+				<Icon name="download" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm group-hover:text-sky-300 transition-colors">CSV export</div>
-					<p class="text-xs text-zinc-400 mt-0.5">All reported, filled &amp; expired potholes — id, lat/lng, address, status, dates.</p>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">CSV export</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">All reported, filled &amp; expired potholes — id, lat/lng, address, status, dates.</p>
 				</div>
 			</a>
 			<a
 				href="/api/feed.xml"
-				class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4 hover:border-sky-600 transition-colors group"
+				class="flex items-start gap-3 bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 hover:border-amber-500 dark:hover:border-amber-500 transition-colors group"
 			>
-				<Icon name="rss" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+				<Icon name="rss" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm group-hover:text-sky-300 transition-colors">RSS feed</div>
-					<p class="text-xs text-zinc-400 mt-0.5">Recently reported and filled potholes, ordered by event time. Subscribe in any RSS reader.</p>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">RSS feed</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">Recently reported and filled potholes, ordered by event time. Subscribe in any RSS reader.</p>
 				</div>
 			</a>
 		</div>
 	</section>
 
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white">Spread the word</h2>
-		<p class="text-zinc-400 text-sm">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Spread the word</h2>
+		<p class="text-stone-600 dark:text-stone-400 text-sm">
 			This project runs on word of mouth — no ads, no algorithm. If the map helped you,
 			share it with your neighbours, your local community group, or anywhere people talk about
 			life in Waterloo Region.
@@ -283,7 +283,7 @@
 	</section>
 
 	<div class="text-center pt-4">
-		<a href="/" class="inline-flex items-center gap-1.5 text-zinc-400 hover:text-white text-sm transition-colors">
+		<a href="/" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors">
 			<Icon name="arrow-left" size={14} />
 			Back to the map
 		</a>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -27,7 +27,7 @@
 			fillthehole.ca makes the problem visible. Every reported pothole goes on a public map.
 			Every day it stays unfilled is tracked. Your councillor's contact is one tap away.
 		</p>
-		<p class="text-amber-600 dark:text-amber-400 font-medium">
+		<p class="text-amber-700 dark:text-amber-400 font-medium">
 			Sunlight is the best disinfectant. A public map is hard to ignore.
 		</p>
 	</section>
@@ -47,7 +47,7 @@
 					href={link.href}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex items-center gap-2 text-white text-sm font-semibold px-4 py-2 rounded-md transition-colors {link.id === 'kitchener' ? 'bg-amber-600 hover:bg-amber-500' : 'bg-stone-300 dark:bg-stone-700 hover:bg-stone-200 dark:hover:bg-stone-600 text-stone-900 dark:text-white'}"
+					class="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-md transition-colors {link.id === 'kitchener' ? 'bg-amber-600 hover:bg-amber-500 text-stone-900' : 'bg-stone-300 dark:bg-stone-700 hover:bg-stone-200 dark:hover:bg-stone-600 text-stone-900 dark:text-white'}"
 				>
 					<Icon name="external-link" size={14} class="shrink-0" />
 					{link.label}
@@ -61,7 +61,7 @@
 				</a>
 			{/each}
 		</div>
-		<div class="bg-stone-100 dark:bg-stone-800 rounded-md p-3 text-xs text-stone-600 dark:text-stone-400 leading-relaxed space-y-2">
+		<div class="bg-stone-50 dark:bg-stone-800 rounded-md p-3 text-xs text-stone-600 dark:text-stone-400 leading-relaxed space-y-2">
 			<p>
 				<strong class="text-stone-900 dark:text-stone-300">Not sure who maintains the road?</strong> Major roads like
 				King St, Victoria St, Weber St, and Erb St are <em>Regional roads</em> maintained by the
@@ -71,7 +71,7 @@
 			<p>
 				<strong class="text-stone-900 dark:text-stone-300">Provincial highways (401, 7/8, 85) are MTO's responsibility</strong>,
 				not the city or Region. Report those to the
-				<a href="https://www.ontario.ca/page/report-problem-provincial-highway" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Ministry of Transportation Ontario</a>.
+				<a href="https://www.ontario.ca/page/report-problem-provincial-highway" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Ministry of Transportation Ontario</a>.
 			</p>
 		</div>
 	</section>
@@ -80,7 +80,7 @@
 		<h2 class="section-title text-xl text-stone-900 dark:text-white">How it works</h2>
 		<p class="text-sm text-stone-600 dark:text-stone-400">
 			The basics are below.
-			<a href="/how-to" class="text-amber-600 dark:text-amber-400 underline hover:text-amber-500 dark:hover:text-amber-300 transition-colors">Full how-to guide →</a>
+			<a href="/how-to" class="text-amber-700 dark:text-amber-400 underline hover:text-amber-600 dark:hover:text-amber-300 transition-colors">Full how-to guide →</a>
 		</p>
 
 		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-md p-4 text-sm text-amber-200/90">
@@ -182,17 +182,17 @@
 					Third-party services
 				</div>
 				<p class="text-sm text-stone-600 dark:text-stone-400">
-					Map tiles are loaded from <a href="https://www.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">OpenStreetMap</a>.
+					Map tiles are loaded from <a href="https://www.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">OpenStreetMap</a>.
 					When you report a pothole, your coordinates are sent to
-					<a href="https://nominatim.org" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Nominatim</a> (OpenStreetMap's geocoder)
+					<a href="https://nominatim.org" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Nominatim</a> (OpenStreetMap's geocoder)
 					to look up the street address. Report data is stored in
-					<a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Supabase</a>.
+					<a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Supabase</a>.
 					Each of these services has its own privacy policy.
 				</p>
 				<p class="text-sm text-stone-600 dark:text-stone-400">
 					On individual pothole pages, the pothole's coordinates (rounded to ~11 m precision)
 					are sent to
-					<a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-amber-600 dark:text-amber-400 underline">Esri ArcGIS</a>
+					<a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Esri ArcGIS</a>
 					to check whether Kitchener's 311 system has a matching repair request on file.
 					No personal information is included in this query — only the location.
 				</p>
@@ -255,7 +255,7 @@
 			>
 				<Icon name="download" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">CSV export</div>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">CSV export</div>
 					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">All reported, filled &amp; expired potholes — id, lat/lng, address, status, dates.</p>
 				</div>
 			</a>
@@ -265,7 +265,7 @@
 			>
 				<Icon name="rss" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">RSS feed</div>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">RSS feed</div>
 					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">Recently reported and filled potholes, ordered by event time. Subscribe in any RSS reader.</p>
 				</div>
 			</a>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -83,10 +83,10 @@
 			<a href="/how-to" class="text-amber-700 dark:text-amber-400 underline hover:text-amber-600 dark:hover:text-amber-300 transition-colors">Full how-to guide →</a>
 		</p>
 
-		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-md p-4 text-sm text-amber-200/90">
-			<Icon name="alert-triangle" size={18} class="text-amber-400 shrink-0 mt-0.5" />
+		<div class="flex gap-3 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-700/40 rounded-md p-4 text-sm text-amber-900 dark:text-amber-200/90">
+			<Icon name="alert-triangle" size={18} class="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
 			<p>
-				<strong class="text-amber-300">Stay safe when reporting.</strong>
+				<strong class="text-amber-800 dark:text-amber-300">Stay safe when reporting.</strong>
 				Never stop in traffic or step onto a road to report a pothole. Report from the sidewalk,
 				parking lot, or after you've safely parked. If you're driving, let a passenger report
 				or wait until you've stopped somewhere safe. No pothole is worth an injury.

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -112,7 +112,7 @@
 			<!-- Brand -->
 			<div class="px-4 py-4 border-b border-zinc-800">
 				<a href="/admin" class="block" onclick={close}>
-					<span class="text-sky-400 font-bold text-sm">fillthehole.ca</span>
+					<span class="text-amber-500 font-bold text-sm">fillthehole.ca</span>
 					<span class="block text-zinc-500 text-xs mt-0.5">Admin Panel</span>
 				</a>
 			</div>
@@ -122,7 +122,7 @@
 				<a
 					href="/admin"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {currentPath === '/admin' ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {currentPath === '/admin' ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
@@ -133,7 +133,7 @@
 				<a
 					href="/admin/photos"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/photos') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/photos') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -144,7 +144,7 @@
 				<a
 					href="/admin/potholes"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/potholes') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/potholes') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -157,7 +157,7 @@
 					<a
 						href="/admin/users"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/users') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/users') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
@@ -169,7 +169,7 @@
 				<a
 					href="/admin/audit"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/audit') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/audit') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
@@ -182,7 +182,7 @@
 						<a
 							href="/admin/settings/site"
 							onclick={close}
-							class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/site') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+							class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/site') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 						>
 							<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
@@ -193,7 +193,7 @@
 					<a
 						href="/admin/settings/password"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/password') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/password') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
@@ -203,7 +203,7 @@
 					<a
 						href="/admin/settings/mfa"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/mfa') ? 'bg-sky-600/20 text-sky-400' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/mfa') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -217,7 +217,7 @@
 			<!-- User + Logout -->
 			<div class="px-2 py-3 border-t border-zinc-800">
 				<div class="flex items-center gap-2.5 px-2 mb-2">
-					<div class="w-7 h-7 rounded-full bg-sky-700 flex items-center justify-center text-xs font-semibold text-white flex-shrink-0">
+					<div class="w-7 h-7 rounded-full bg-amber-500 flex items-center justify-center text-xs font-semibold text-white flex-shrink-0">
 						{user.firstName[0]}{user.lastName[0]}
 					</div>
 					<div class="min-w-0 flex-1">
@@ -263,7 +263,7 @@
 				<div class="flex-1 min-w-0">
 					<span class="text-sm font-semibold text-zinc-100">{pageTitle}</span>
 				</div>
-				<a href="/admin" class="text-sky-400 text-xs font-bold flex-shrink-0" onclick={close}>fillthehole.ca</a>
+				<a href="/admin" class="text-amber-500 text-xs font-bold flex-shrink-0" onclick={close}>fillthehole.ca</a>
 			</header>
 
 			<!-- Main -->

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -90,7 +90,7 @@
 </script>
 
 {#if user}
-	<div class="min-h-screen bg-zinc-950 text-zinc-100 flex flex-col md:flex-row">
+	<div class="min-h-screen bg-stone-950 text-stone-100 flex flex-col md:flex-row">
 		<!-- Mobile backdrop -->
 		{#if sidebarOpen}
 			<div
@@ -103,17 +103,17 @@
 		<!-- Sidebar -->
 		<aside
 			bind:this={sidebarEl}
-			class="fixed inset-y-0 left-0 z-50 w-64 flex-shrink-0 bg-zinc-900 border-r border-zinc-800 flex flex-col transition-transform duration-200 md:static md:inset-auto md:w-52 md:translate-x-0 {sidebarOpen
+			class="fixed inset-y-0 left-0 z-50 w-64 flex-shrink-0 bg-stone-900 border-r border-stone-800 flex flex-col transition-transform duration-200 md:static md:inset-auto md:w-52 md:translate-x-0 {sidebarOpen
 				? 'translate-x-0'
 				: '-translate-x-full'}"
 			aria-label="Admin navigation"
 			inert={isMobile && !sidebarOpen}
 		>
 			<!-- Brand -->
-			<div class="px-4 py-4 border-b border-zinc-800">
+			<div class="px-4 py-4 border-b border-stone-800">
 				<a href="/admin" class="block" onclick={close}>
 					<span class="text-amber-500 font-bold text-sm">fillthehole.ca</span>
-					<span class="block text-zinc-500 text-xs mt-0.5">Admin Panel</span>
+					<span class="block text-stone-500 text-xs mt-0.5">Admin Panel</span>
 				</a>
 			</div>
 
@@ -122,7 +122,7 @@
 				<a
 					href="/admin"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {currentPath === '/admin' ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {currentPath === '/admin' ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
@@ -133,7 +133,7 @@
 				<a
 					href="/admin/photos"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/photos') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/photos') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -144,7 +144,7 @@
 				<a
 					href="/admin/potholes"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/potholes') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/potholes') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -157,7 +157,7 @@
 					<a
 						href="/admin/users"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/users') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/users') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
@@ -169,7 +169,7 @@
 				<a
 					href="/admin/audit"
 					onclick={close}
-					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/audit') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+					class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/audit') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 				>
 					<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
@@ -177,12 +177,12 @@
 					Audit Log
 				</a>
 
-				<div class="pt-2 mt-1 border-t border-zinc-800 space-y-0.5">
+				<div class="pt-2 mt-1 border-t border-stone-800 space-y-0.5">
 					{#if user.role === 'admin'}
 						<a
 							href="/admin/settings/site"
 							onclick={close}
-							class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/site') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+							class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/site') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 						>
 							<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
@@ -193,7 +193,7 @@
 					<a
 						href="/admin/settings/password"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/password') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/password') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
@@ -203,7 +203,7 @@
 					<a
 						href="/admin/settings/mfa"
 						onclick={close}
-						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/mfa') ? 'bg-amber-500/15 text-amber-500' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800'}"
+						class="flex items-center gap-2.5 px-3 py-2.5 md:py-2 rounded text-sm transition-colors {isActive('/admin/settings/mfa') ? 'bg-amber-500/15 text-amber-500' : 'text-stone-400 hover:text-stone-100 hover:bg-stone-800'}"
 					>
 						<svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -215,20 +215,20 @@
 			</nav>
 
 			<!-- User + Logout -->
-			<div class="px-2 py-3 border-t border-zinc-800">
+			<div class="px-2 py-3 border-t border-stone-800">
 				<div class="flex items-center gap-2.5 px-2 mb-2">
 					<div class="w-7 h-7 rounded-full bg-amber-500 flex items-center justify-center text-xs font-semibold text-white flex-shrink-0">
 						{user.firstName[0]}{user.lastName[0]}
 					</div>
 					<div class="min-w-0 flex-1">
-						<p class="text-xs font-medium truncate text-zinc-200">{user.firstName} {user.lastName}</p>
-						<p class="text-zinc-500 text-xs capitalize">{user.role}</p>
+						<p class="text-xs font-medium truncate text-stone-200">{user.firstName} {user.lastName}</p>
+						<p class="text-stone-500 text-xs capitalize">{user.role}</p>
 					</div>
 				</div>
 				<form method="post" action="/admin/logout">
 					<button
 						type="submit"
-						class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 rounded transition-colors"
+						class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-stone-400 hover:text-stone-100 hover:bg-stone-800 rounded transition-colors"
 					>
 						<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
@@ -242,13 +242,13 @@
 		<!-- Content column -->
 		<div class="flex-1 min-w-0 flex flex-col">
 			<!-- Mobile top bar -->
-			<header class="md:hidden sticky top-0 z-30 flex items-center gap-3 px-4 py-3 bg-zinc-900 border-b border-zinc-800">
+			<header class="md:hidden sticky top-0 z-30 flex items-center gap-3 px-4 py-3 bg-stone-900 border-b border-stone-800">
 				<button
 					type="button"
 					onclick={toggle}
 					aria-label="Toggle navigation"
 					aria-expanded={sidebarOpen}
-					class="p-1.5 rounded text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors flex-shrink-0"
+					class="p-1.5 rounded text-stone-400 hover:text-stone-100 hover:bg-stone-800 transition-colors flex-shrink-0"
 				>
 					{#if sidebarOpen}
 						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -261,7 +261,7 @@
 					{/if}
 				</button>
 				<div class="flex-1 min-w-0">
-					<span class="text-sm font-semibold text-zinc-100">{pageTitle}</span>
+					<span class="text-sm font-semibold text-stone-100">{pageTitle}</span>
 				</div>
 				<a href="/admin" class="text-amber-500 text-xs font-bold flex-shrink-0" onclick={close}>fillthehole.ca</a>
 			</header>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -16,7 +16,7 @@
 			return 'text-amber-400 bg-amber-500/10 border border-amber-500/20';
 		if (/approve|activate|enable|confirm|create|login/.test(action))
 			return 'text-emerald-400 bg-emerald-500/10 border border-emerald-500/20';
-		return 'text-sky-400 bg-sky-500/10 border border-sky-500/20';
+		return 'text-amber-400 bg-amber-500/10 border border-amber-500/20';
 	}
 
 	function actorLabel(entry: RecentEntry): string {
@@ -30,19 +30,19 @@
 </svelte:head>
 
 <div class="p-6 max-w-4xl">
-	<h1 class="text-xl font-semibold text-zinc-100 mb-6">Dashboard</h1>
+	<h1 class="text-xl font-semibold text-stone-100 mb-6">Dashboard</h1>
 
 	<!-- ─── Stat cards ─── -->
 	<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
 		<!-- Pending photos — actionable if > 0 -->
 		<a
 			href="/admin/photos"
-			class="bg-zinc-900 border {data.counts.pendingPhotos > 0 ? 'border-amber-600/40 hover:border-amber-500/60' : 'border-zinc-800 hover:border-zinc-700'} rounded-lg p-4 transition-colors group"
+			class="bg-stone-900 border {data.counts.pendingPhotos > 0 ? 'border-amber-600/40 hover:border-amber-500/60' : 'border-stone-800 hover:border-stone-700'} rounded-lg p-4 transition-colors group"
 		>
-			<p class="text-xs text-zinc-500 mb-1 group-hover:text-zinc-400 transition-colors">
+			<p class="text-xs text-stone-500 mb-1 group-hover:text-stone-400 transition-colors">
 				Photos pending
 			</p>
-			<p class="text-2xl font-semibold {data.counts.pendingPhotos > 0 ? 'text-amber-400' : 'text-zinc-300'}">
+			<p class="text-2xl font-semibold {data.counts.pendingPhotos > 0 ? 'text-amber-400' : 'text-stone-300'}">
 				{data.counts.pendingPhotos}
 			</p>
 		</a>
@@ -50,20 +50,20 @@
 		<!-- Pending potholes -->
 		<a
 			href="/admin/potholes?status=pending"
-			class="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-lg p-4 transition-colors group"
+			class="bg-stone-900 border border-stone-800 hover:border-stone-700 rounded-lg p-4 transition-colors group"
 		>
-			<p class="text-xs text-zinc-500 mb-1 group-hover:text-zinc-400 transition-colors">
+			<p class="text-xs text-stone-500 mb-1 group-hover:text-stone-400 transition-colors">
 				Potholes pending
 			</p>
-			<p class="text-2xl font-semibold text-zinc-300">{data.counts.pendingPotholes}</p>
+			<p class="text-2xl font-semibold text-stone-300">{data.counts.pendingPotholes}</p>
 		</a>
 
 		<!-- Reported (live) potholes -->
 		<a
 			href="/admin/potholes?status=reported"
-			class="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-lg p-4 transition-colors group"
+			class="bg-stone-900 border border-stone-800 hover:border-stone-700 rounded-lg p-4 transition-colors group"
 		>
-			<p class="text-xs text-zinc-500 mb-1 group-hover:text-zinc-400 transition-colors">
+			<p class="text-xs text-stone-500 mb-1 group-hover:text-stone-400 transition-colors">
 				Reported (live)
 			</p>
 			<p class="text-2xl font-semibold text-sky-400">{data.counts.reportedPotholes}</p>
@@ -72,9 +72,9 @@
 		<!-- Filled potholes -->
 		<a
 			href="/admin/potholes?status=filled"
-			class="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-lg p-4 transition-colors group"
+			class="bg-stone-900 border border-stone-800 hover:border-stone-700 rounded-lg p-4 transition-colors group"
 		>
-			<p class="text-xs text-zinc-500 mb-1 group-hover:text-zinc-400 transition-colors">
+			<p class="text-xs text-stone-500 mb-1 group-hover:text-stone-400 transition-colors">
 				Filled
 			</p>
 			<p class="text-2xl font-semibold text-emerald-400">{data.counts.filledPotholes}</p>
@@ -83,25 +83,25 @@
 		<!-- Expired potholes -->
 		<a
 			href="/admin/potholes?status=expired"
-			class="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-lg p-4 transition-colors group"
+			class="bg-stone-900 border border-stone-800 hover:border-stone-700 rounded-lg p-4 transition-colors group"
 		>
-			<p class="text-xs text-zinc-500 mb-1 group-hover:text-zinc-400 transition-colors">
+			<p class="text-xs text-stone-500 mb-1 group-hover:text-stone-400 transition-colors">
 				Expired
 			</p>
-			<p class="text-2xl font-semibold text-zinc-500">{data.counts.expiredPotholes}</p>
+			<p class="text-2xl font-semibold text-stone-500">{data.counts.expiredPotholes}</p>
 		</a>
 	</div>
 
 	<!-- ─── Recent audit activity ─── -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg">
-		<div class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between">
-			<h2 class="text-sm font-medium text-zinc-300">Recent activity</h2>
-			<a href="/admin/audit" class="text-xs text-zinc-500 hover:text-zinc-300 transition-colors">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg">
+		<div class="px-4 py-3 border-b border-stone-800 flex items-center justify-between">
+			<h2 class="text-sm font-medium text-stone-300">Recent activity</h2>
+			<a href="/admin/audit" class="text-xs text-stone-500 hover:text-stone-300 transition-colors">
 				View all →
 			</a>
 		</div>
 
-		<div class="divide-y divide-zinc-800">
+		<div class="divide-y divide-stone-800">
 			{#each data.recentAudit as entry (entry.id)}
 				<div class="px-4 py-3 flex items-start gap-3">
 					<div class="flex-1 min-w-0">
@@ -110,18 +110,18 @@
 								{entry.action}
 							</span>
 							{#if entry.resource_type}
-								<span class="text-zinc-500 text-xs capitalize">{entry.resource_type}</span>
+								<span class="text-stone-500 text-xs capitalize">{entry.resource_type}</span>
 								{#if entry.resource_type === 'pothole' && entry.resource_id}
 									<a
 										href="/admin/potholes/{entry.resource_id}"
-										class="text-sky-500 text-xs font-mono hover:text-sky-400 transition-colors"
+										class="text-amber-500 text-xs font-mono hover:text-amber-400 transition-colors"
 									>
 										{entry.resource_id.slice(0, 8)}…
 									</a>
 								{/if}
 							{/if}
 						</div>
-						<p class="text-zinc-600 text-xs mt-1">
+						<p class="text-stone-600 text-xs mt-1">
 							{actorLabel(entry)}
 							·
 							{formatDistanceToNow(new Date(entry.created_at), { addSuffix: true })}
@@ -129,7 +129,7 @@
 					</div>
 				</div>
 			{:else}
-				<div class="px-4 py-8 text-center text-zinc-600 text-sm">No activity yet.</div>
+				<div class="px-4 py-8 text-center text-stone-600 text-sm">No activity yet.</div>
 			{/each}
 		</div>
 	</div>

--- a/src/routes/admin/audit/+page.svelte
+++ b/src/routes/admin/audit/+page.svelte
@@ -26,7 +26,7 @@
 			return 'text-amber-400 bg-amber-500/10 border border-amber-500/20';
 		if (/approve|activate|enable|confirm|create|login/.test(action))
 			return 'text-emerald-400 bg-emerald-500/10 border border-emerald-500/20';
-		return 'text-sky-400 bg-sky-500/10 border border-sky-500/20';
+		return 'text-amber-400 bg-amber-500/10 border border-amber-500/20';
 	}
 
 	function resourceLink(entry: AuditEntry): string | null {
@@ -62,8 +62,8 @@
 <div class="p-6">
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Audit Log</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Audit Log</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{#if data.totalCount > 0}
 					Showing {data.firstEntry}–{data.lastEntry} of {data.totalCount} entries
 				{:else}
@@ -75,7 +75,7 @@
 		{#if hasFilters}
 			<a
 				href="/admin/audit"
-				class="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+				class="text-xs text-stone-500 hover:text-stone-300 transition-colors"
 			>
 				Clear filters
 			</a>
@@ -85,12 +85,12 @@
 	<!-- Filters -->
 	<form method="get" class="flex flex-wrap items-end gap-3 mb-5">
 		<div>
-			<label for="filter-user" class="block text-xs text-zinc-500 mb-1">Actor</label>
+			<label for="filter-user" class="block text-xs text-stone-500 mb-1">Actor</label>
 			<select
 				id="filter-user"
 				name="user"
 				onchange={(e) => (e.currentTarget as HTMLSelectElement).form?.submit()}
-				class="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 cursor-pointer"
+				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 cursor-pointer"
 			>
 				<option value="">All users</option>
 				{#each data.users as u (u.id)}
@@ -102,12 +102,12 @@
 		</div>
 
 		<div>
-			<label for="filter-resource" class="block text-xs text-zinc-500 mb-1">Resource type</label>
+			<label for="filter-resource" class="block text-xs text-stone-500 mb-1">Resource type</label>
 			<select
 				id="filter-resource"
 				name="resource_type"
 				onchange={(e) => (e.currentTarget as HTMLSelectElement).form?.submit()}
-				class="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 cursor-pointer"
+				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 cursor-pointer"
 			>
 				{#each RESOURCE_TYPES as rt (rt.value)}
 					<option value={rt.value} selected={data.filterResourceType === rt.value}>
@@ -118,7 +118,7 @@
 		</div>
 
 		<div>
-			<label for="filter-action" class="block text-xs text-zinc-500 mb-1">Action</label>
+			<label for="filter-action" class="block text-xs text-stone-500 mb-1">Action</label>
 			<div class="flex gap-2">
 				<input
 					id="filter-action"
@@ -126,14 +126,14 @@
 					type="text"
 					value={data.filterAction ?? ''}
 					placeholder="e.g. photo.approve"
-					class="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 w-48"
+					class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 w-48"
 				/>
 				<!-- Preserve other filter values when submitting the text input -->
 				{#if data.filterUser}<input type="hidden" name="user" value={data.filterUser} />{/if}
 				{#if data.filterResourceType}<input type="hidden" name="resource_type" value={data.filterResourceType} />{/if}
 				<button
 					type="submit"
-					class="px-3 py-2 text-sm font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 rounded-lg transition-colors"
+					class="px-3 py-2 text-sm font-medium bg-stone-800 hover:bg-stone-700 text-stone-300 border border-stone-700 rounded-lg transition-colors"
 				>
 					Search
 				</button>
@@ -142,40 +142,40 @@
 	</form>
 
 	<!-- Log table -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
 		<div class="overflow-x-auto">
 		<table class="w-full text-sm min-w-[640px]">
 			<thead>
-				<tr class="border-b border-zinc-800 text-left">
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide w-44">Time</th>
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Actor</th>
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Action</th>
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Resource</th>
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Details</th>
-					<th class="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide w-32">IP</th>
+				<tr class="border-b border-stone-800 text-left">
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide w-44">Time</th>
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide">Actor</th>
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide">Action</th>
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide">Resource</th>
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide">Details</th>
+					<th class="px-4 py-3 text-xs font-medium text-stone-500 uppercase tracking-wide w-32">IP</th>
 				</tr>
 			</thead>
-			<tbody class="divide-y divide-zinc-800">
+			<tbody class="divide-y divide-stone-800">
 				{#each data.entries as entry (entry.id)}
-					<tr class="hover:bg-zinc-800/40 transition-colors">
+					<tr class="hover:bg-stone-800/40 transition-colors">
 						<!-- Time -->
 						<td class="px-4 py-3 whitespace-nowrap">
 							<span
-								class="text-zinc-300 text-xs"
+								class="text-stone-300 text-xs"
 								title={format(new Date(entry.created_at), 'PPpp')}
 							>
 								{formatDistanceToNow(new Date(entry.created_at), { addSuffix: true })}
 							</span>
-							<span class="block text-zinc-600 text-xs mt-0.5">
+							<span class="block text-stone-600 text-xs mt-0.5">
 								{format(new Date(entry.created_at), 'MMM d, HH:mm')}
 							</span>
 						</td>
 
 						<!-- Actor -->
 						<td class="px-4 py-3">
-							<span class="text-zinc-200 text-xs font-medium">{actorLabel(entry)}</span>
+							<span class="text-stone-200 text-xs font-medium">{actorLabel(entry)}</span>
 							{#if actorEmail(entry)}
-								<span class="block text-zinc-600 text-xs">{actorEmail(entry)}</span>
+								<span class="block text-stone-600 text-xs">{actorEmail(entry)}</span>
 							{/if}
 						</td>
 
@@ -189,46 +189,46 @@
 						<!-- Resource -->
 						<td class="px-4 py-3">
 							{#if entry.resource_type}
-								<span class="text-zinc-400 text-xs capitalize">{entry.resource_type}</span>
+								<span class="text-stone-400 text-xs capitalize">{entry.resource_type}</span>
 								{#if entry.resource_id}
 									{@const link = resourceLink(entry)}
 									{#if link}
 										<a
 											href={link}
-											class="block text-sky-500 text-xs font-mono hover:text-sky-400 transition-colors mt-0.5"
+											class="block text-amber-500 text-xs font-mono hover:text-amber-400 transition-colors mt-0.5"
 										>
 											{entry.resource_id.slice(0, 8)}…
 										</a>
 									{:else}
-										<span class="block text-zinc-600 text-xs font-mono mt-0.5">
+										<span class="block text-stone-600 text-xs font-mono mt-0.5">
 											{entry.resource_id.slice(0, 8)}…
 										</span>
 									{/if}
 								{/if}
 							{:else}
-								<span class="text-zinc-700 text-xs">—</span>
+								<span class="text-stone-700 text-xs">—</span>
 							{/if}
 						</td>
 
 						<!-- Details -->
 						<td class="px-4 py-3 max-w-xs">
 							{#if entry.details}
-								<span class="text-zinc-600 text-xs font-mono break-all" title={JSON.stringify(entry.details, null, 2)}>
+								<span class="text-stone-600 text-xs font-mono break-all" title={JSON.stringify(entry.details, null, 2)}>
 									{detailsSnippet(entry.details)}
 								</span>
 							{:else}
-								<span class="text-zinc-700 text-xs">—</span>
+								<span class="text-stone-700 text-xs">—</span>
 							{/if}
 						</td>
 
 						<!-- IP hash (stored as HMAC-SHA-256, not shown to avoid confusion) -->
 						<td class="px-4 py-3">
-							<span class="text-zinc-700 text-xs">—</span>
+							<span class="text-stone-700 text-xs">—</span>
 						</td>
 					</tr>
 				{:else}
 					<tr>
-						<td colspan="6" class="px-4 py-10 text-center text-zinc-600 text-sm">
+						<td colspan="6" class="px-4 py-10 text-center text-stone-600 text-sm">
 							{hasFilters ? 'No entries match your filters.' : 'No audit entries yet.'}
 						</td>
 					</tr>
@@ -245,18 +245,18 @@
 				{#if data.prevUrl}
 					<a
 						href={data.prevUrl}
-						class="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-100 border border-zinc-700 hover:border-zinc-600 rounded transition-colors"
+						class="px-3 py-1.5 text-sm text-stone-400 hover:text-stone-100 border border-stone-700 hover:border-stone-600 rounded transition-colors"
 					>
 						← Previous
 					</a>
 				{:else}
-					<span class="px-3 py-1.5 text-sm text-zinc-700 border border-zinc-800 rounded cursor-not-allowed">
+					<span class="px-3 py-1.5 text-sm text-stone-700 border border-stone-800 rounded cursor-not-allowed">
 						← Previous
 					</span>
 				{/if}
 			</div>
 
-			<span class="text-sm text-zinc-500">
+			<span class="text-sm text-stone-500">
 				Page {data.page} of {data.totalPages}
 			</span>
 
@@ -264,12 +264,12 @@
 				{#if data.nextUrl}
 					<a
 						href={data.nextUrl}
-						class="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-100 border border-zinc-700 hover:border-zinc-600 rounded transition-colors"
+						class="px-3 py-1.5 text-sm text-stone-400 hover:text-stone-100 border border-stone-700 hover:border-stone-600 rounded transition-colors"
 					>
 						Next →
 					</a>
 				{:else}
-					<span class="px-3 py-1.5 text-sm text-zinc-700 border border-zinc-800 rounded cursor-not-allowed">
+					<span class="px-3 py-1.5 text-sm text-stone-700 border border-stone-800 rounded cursor-not-allowed">
 						Next →
 					</span>
 				{/if}

--- a/src/routes/admin/audit/+page.svelte
+++ b/src/routes/admin/audit/+page.svelte
@@ -90,7 +90,7 @@
 				id="filter-user"
 				name="user"
 				onchange={(e) => (e.currentTarget as HTMLSelectElement).form?.submit()}
-				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 cursor-pointer"
+				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-amber-500 cursor-pointer"
 			>
 				<option value="">All users</option>
 				{#each data.users as u (u.id)}
@@ -107,7 +107,7 @@
 				id="filter-resource"
 				name="resource_type"
 				onchange={(e) => (e.currentTarget as HTMLSelectElement).form?.submit()}
-				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 cursor-pointer"
+				class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-amber-500 cursor-pointer"
 			>
 				{#each RESOURCE_TYPES as rt (rt.value)}
 					<option value={rt.value} selected={data.filterResourceType === rt.value}>
@@ -126,7 +126,7 @@
 					type="text"
 					value={data.filterAction ?? ''}
 					placeholder="e.g. photo.approve"
-					class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-sky-500 w-48"
+					class="bg-stone-900 border border-stone-700 rounded-lg px-3 py-2 text-sm text-stone-100 focus:outline-none focus:border-amber-500 w-48"
 				/>
 				<!-- Preserve other filter values when submitting the text input -->
 				{#if data.filterUser}<input type="hidden" name="user" value={data.filterUser} />{/if}

--- a/src/routes/admin/login/+page.svelte
+++ b/src/routes/admin/login/+page.svelte
@@ -53,7 +53,7 @@
 							value={form?.email ?? ''}
 							required
 							autocomplete="email"
-							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
+							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/30 transition-colors"
 							placeholder="you@example.com"
 						/>
 					</div>
@@ -68,7 +68,7 @@
 							name="password"
 							required
 							autocomplete="current-password"
-							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
+							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/30 transition-colors"
 							placeholder="••••••••"
 						/>
 					</div>

--- a/src/routes/admin/login/+page.svelte
+++ b/src/routes/admin/login/+page.svelte
@@ -15,15 +15,15 @@
 	<title>Sign in — fillthehole.ca Admin</title>
 </svelte:head>
 
-<div class="min-h-screen bg-zinc-950 flex items-center justify-center px-4">
+<div class="min-h-screen bg-stone-950 flex items-center justify-center px-4">
 	<div class="w-full max-w-sm">
 		<div class="text-center mb-8">
-			<p class="text-sky-400 font-bold text-xl">fillthehole.ca</p>
-			<p class="text-zinc-500 text-sm mt-1">Admin Panel</p>
+			<p class="text-amber-400 font-bold text-xl">fillthehole.ca</p>
+			<p class="text-stone-500 text-sm mt-1">Admin Panel</p>
 		</div>
 
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
-			<h1 class="text-lg font-semibold text-zinc-100 mb-5">Sign in</h1>
+		<div class="bg-stone-900 border border-stone-800 rounded-lg p-6">
+			<h1 class="text-lg font-semibold text-stone-100 mb-5">Sign in</h1>
 
 			{#if form?.error}
 				<div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-red-400 text-sm">
@@ -45,7 +45,7 @@
 
 				<div class="space-y-4">
 					<div>
-						<label for="email" class="block text-xs font-medium text-zinc-400 mb-1.5">Email</label>
+						<label for="email" class="block text-xs font-medium text-stone-400 mb-1.5">Email</label>
 						<input
 							id="email"
 							type="email"
@@ -53,13 +53,13 @@
 							value={form?.email ?? ''}
 							required
 							autocomplete="email"
-							class="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
+							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
 							placeholder="you@example.com"
 						/>
 					</div>
 
 					<div>
-						<label for="password" class="block text-xs font-medium text-zinc-400 mb-1.5"
+						<label for="password" class="block text-xs font-medium text-stone-400 mb-1.5"
 							>Password</label
 						>
 						<input
@@ -68,7 +68,7 @@
 							name="password"
 							required
 							autocomplete="current-password"
-							class="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
+							class="w-full px-3 py-2 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-colors"
 							placeholder="••••••••"
 						/>
 					</div>
@@ -77,13 +77,13 @@
 				<button
 					type="submit"
 					disabled={submitting}
-					class="mt-5 w-full py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded transition-colors"
+					class="mt-5 w-full py-2.5 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded transition-colors"
 				>
 					{submitting ? 'Signing in…' : 'Sign in'}
 				</button>
 			</form>
 
-			<p class="mt-5 text-center text-xs text-zinc-600">
+			<p class="mt-5 text-center text-xs text-stone-600">
 				Forgot your password? Contact an administrator.
 			</p>
 		</div>

--- a/src/routes/admin/login/mfa/+page.svelte
+++ b/src/routes/admin/login/mfa/+page.svelte
@@ -75,7 +75,7 @@
 							autocomplete="one-time-code"
 							spellcheck="false"
 							maxlength="8"
-							class="w-full px-3 py-2.5 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-widest uppercase transition-colors"
+							class="w-full px-3 py-2.5 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/30 font-mono tracking-widest uppercase transition-colors"
 							placeholder="XXXXXXXX"
 						/>
 					{:else}
@@ -91,7 +91,7 @@
 							inputmode="numeric"
 							autocomplete="one-time-code"
 							maxlength="6"
-							class="w-full px-4 py-3 bg-stone-800 border border-stone-700 rounded text-2xl text-center text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-[0.5em] transition-colors"
+							class="w-full px-4 py-3 bg-stone-800 border border-stone-700 rounded text-2xl text-center text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/30 font-mono tracking-[0.5em] transition-colors"
 							placeholder="000000"
 						/>
 					{/if}
@@ -101,7 +101,7 @@
 					<input
 						type="checkbox"
 						name="rememberDevice"
-						class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-stone-900 focus:ring-1"
+						class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
 					/>
 					<span class="text-sm text-stone-400">Remember this device for 30 days</span>
 				</label>

--- a/src/routes/admin/login/mfa/+page.svelte
+++ b/src/routes/admin/login/mfa/+page.svelte
@@ -25,18 +25,18 @@
 	<title>Two-factor authentication — fillthehole.ca Admin</title>
 </svelte:head>
 
-<div class="min-h-screen bg-zinc-950 flex items-center justify-center px-4">
+<div class="min-h-screen bg-stone-950 flex items-center justify-center px-4">
 	<div class="w-full max-w-sm">
 		<div class="text-center mb-8">
-			<p class="text-sky-400 font-bold text-xl">fillthehole.ca</p>
-			<p class="text-zinc-500 text-sm mt-1">Admin Panel</p>
+			<p class="text-amber-400 font-bold text-xl">fillthehole.ca</p>
+			<p class="text-stone-500 text-sm mt-1">Admin Panel</p>
 		</div>
 
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
-			<h1 class="text-lg font-semibold text-zinc-100 mb-1">
+		<div class="bg-stone-900 border border-stone-800 rounded-lg p-6">
+			<h1 class="text-lg font-semibold text-stone-100 mb-1">
 				{useBackupCode ? 'Enter backup code' : 'Two-factor authentication'}
 			</h1>
-			<p class="text-zinc-500 text-sm mb-5">
+			<p class="text-stone-500 text-sm mb-5">
 				{useBackupCode
 					? 'Enter one of your 8-character backup codes.'
 					: 'Enter the 6-digit code from your authenticator app.'}
@@ -63,7 +63,7 @@
 
 				<div class="mb-4">
 					{#if useBackupCode}
-						<label for="code" class="block text-xs font-medium text-zinc-400 mb-1.5"
+						<label for="code" class="block text-xs font-medium text-stone-400 mb-1.5"
 							>Backup code</label
 						>
 						<input
@@ -75,11 +75,11 @@
 							autocomplete="one-time-code"
 							spellcheck="false"
 							maxlength="8"
-							class="w-full px-3 py-2.5 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-widest uppercase transition-colors"
+							class="w-full px-3 py-2.5 bg-stone-800 border border-stone-700 rounded text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-widest uppercase transition-colors"
 							placeholder="XXXXXXXX"
 						/>
 					{:else}
-						<label for="code" class="block text-xs font-medium text-zinc-400 mb-1.5"
+						<label for="code" class="block text-xs font-medium text-stone-400 mb-1.5"
 							>Authenticator code</label
 						>
 						<input
@@ -91,7 +91,7 @@
 							inputmode="numeric"
 							autocomplete="one-time-code"
 							maxlength="6"
-							class="w-full px-4 py-3 bg-zinc-800 border border-zinc-700 rounded text-2xl text-center text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-[0.5em] transition-colors"
+							class="w-full px-4 py-3 bg-stone-800 border border-stone-700 rounded text-2xl text-center text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 font-mono tracking-[0.5em] transition-colors"
 							placeholder="000000"
 						/>
 					{/if}
@@ -101,15 +101,15 @@
 					<input
 						type="checkbox"
 						name="rememberDevice"
-						class="rounded border-zinc-600 bg-zinc-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-zinc-900 focus:ring-1"
+						class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-stone-900 focus:ring-1"
 					/>
-					<span class="text-sm text-zinc-400">Remember this device for 30 days</span>
+					<span class="text-sm text-stone-400">Remember this device for 30 days</span>
 				</label>
 
 				<button
 					type="submit"
 					disabled={submitting}
-					class="w-full py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded transition-colors"
+					class="w-full py-2.5 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded transition-colors"
 				>
 					{submitting ? 'Verifying…' : 'Verify'}
 				</button>
@@ -121,15 +121,15 @@
 					useBackupCode = !useBackupCode;
 					code = '';
 				}}
-				class="mt-3 w-full text-center text-xs text-zinc-500 hover:text-zinc-300 transition-colors py-1"
+				class="mt-3 w-full text-center text-xs text-stone-500 hover:text-stone-300 transition-colors py-1"
 			>
 				{useBackupCode ? 'Use authenticator code instead' : 'Use a backup code instead'}
 			</button>
 
-			<div class="mt-3 pt-3 border-t border-zinc-800">
+			<div class="mt-3 pt-3 border-t border-stone-800">
 				<a
 					href="/admin/login"
-					class="block text-center text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+					class="block text-center text-xs text-stone-500 hover:text-stone-300 transition-colors"
 				>
 					← Back to sign in
 				</a>

--- a/src/routes/admin/login/mfa/+page.svelte
+++ b/src/routes/admin/login/mfa/+page.svelte
@@ -101,7 +101,7 @@
 					<input
 						type="checkbox"
 						name="rememberDevice"
-						class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
+						class="rounded border-stone-600 bg-stone-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
 					/>
 					<span class="text-sm text-stone-400">Remember this device for 30 days</span>
 				</label>

--- a/src/routes/admin/photos/+page.svelte
+++ b/src/routes/admin/photos/+page.svelte
@@ -29,7 +29,7 @@
 	}
 
 	function scoreColor(score: number | null): string {
-		if (score === null) return 'text-zinc-500 bg-zinc-800';
+		if (score === null) return 'text-stone-500 bg-stone-800';
 		if (score < 0.3) return 'text-emerald-400 bg-emerald-500/10';
 		if (score < 0.7) return 'text-amber-400 bg-amber-500/10';
 		return 'text-red-400 bg-red-500/10';
@@ -51,7 +51,7 @@
 			case 'expired':
 				return 'text-amber-400 bg-amber-500/10';
 			default:
-				return 'text-zinc-400 bg-zinc-700/50';
+				return 'text-stone-400 bg-stone-700/50';
 		}
 	}
 </script>
@@ -64,8 +64,8 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Photo Review</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Photo Review</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{#if data.photos.length === 0}
 					No photos awaiting review
 				{:else}
@@ -79,22 +79,22 @@
 		<!-- Empty state -->
 		<div class="text-center py-20">
 			<div class="text-4xl mb-3">📷</div>
-			<p class="text-zinc-400 font-medium">All caught up</p>
-			<p class="text-zinc-600 text-sm mt-1">No photos are waiting for moderation.</p>
+			<p class="text-stone-400 font-medium">All caught up</p>
+			<p class="text-stone-600 text-sm mt-1">No photos are waiting for moderation.</p>
 		</div>
 	{:else}
 		<!-- Bulk action toolbar -->
 		<div
-			class="flex items-center gap-3 mb-5 p-3 bg-zinc-900 border border-zinc-800 rounded-lg sticky top-4 z-10"
+			class="flex items-center gap-3 mb-5 p-3 bg-stone-900 border border-stone-800 rounded-lg sticky top-4 z-10"
 		>
 			<label class="flex items-center gap-2 cursor-pointer">
 				<input
 					type="checkbox"
 					checked={allSelected}
 					onchange={toggleAll}
-					class="rounded border-zinc-600 bg-zinc-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-zinc-900 focus:ring-1"
+					class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-stone-900 focus:ring-1"
 				/>
-				<span class="text-sm text-zinc-400">
+				<span class="text-sm text-stone-400">
 					{#if someSelected}
 						{selected.size} selected
 					{:else}
@@ -118,7 +118,7 @@
 				class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded transition-colors
 				       {someSelected
 					? 'bg-emerald-600/20 text-emerald-400 hover:bg-emerald-600/30 border border-emerald-600/30'
-					: 'text-zinc-600 cursor-not-allowed border border-zinc-800'}"
+					: 'text-stone-600 cursor-not-allowed border border-stone-800'}"
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
@@ -134,7 +134,7 @@
 				class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded transition-colors
 				       {someSelected
 					? 'bg-red-600/20 text-red-400 hover:bg-red-600/30 border border-red-600/30'
-					: 'text-zinc-600 cursor-not-allowed border border-zinc-800'}"
+					: 'text-stone-600 cursor-not-allowed border border-stone-800'}"
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
@@ -148,8 +148,8 @@
 			{#each data.photos as photo (photo.id)}
 				{@const pothole = photo.potholes}
 				<div
-					class="bg-zinc-900 border rounded-lg overflow-hidden transition-colors
-					       {selected.has(photo.id) ? 'border-sky-500/50' : 'border-zinc-800'}"
+					class="bg-stone-900 border rounded-lg overflow-hidden transition-colors
+					       {selected.has(photo.id) ? 'border-sky-500/50' : 'border-stone-800'}"
 				>
 					<!-- Thumbnail -->
 					<div class="relative">
@@ -163,7 +163,7 @@
 								type="checkbox"
 								checked={selected.has(photo.id)}
 								onchange={() => toggleSelect(photo.id)}
-								class="rounded border-zinc-500 bg-zinc-800/80 text-sky-500 focus:ring-sky-500 focus:ring-1"
+								class="rounded border-stone-500 bg-stone-800/80 text-sky-500 focus:ring-sky-500 focus:ring-1"
 								onclick={(e) => e.stopPropagation()}
 							/>
 						</button>
@@ -174,11 +174,11 @@
 									src={photo.url}
 									alt={pothole?.address ?? 'Pothole photo'}
 									loading="lazy"
-									class="w-full h-48 object-cover bg-zinc-800"
+									class="w-full h-48 object-cover bg-stone-800"
 								/>
 							</a>
 						{:else}
-							<div class="w-full h-48 bg-zinc-800 flex items-center justify-center text-zinc-600 text-sm">
+							<div class="w-full h-48 bg-stone-800 flex items-center justify-center text-stone-600 text-sm">
 								Image unavailable
 							</div>
 						{/if}
@@ -186,7 +186,7 @@
 
 					<!-- Info -->
 					<div class="p-3">
-						<p class="text-sm text-zinc-200 truncate font-medium" title={pothole?.address ?? ''}>
+						<p class="text-sm text-stone-200 truncate font-medium" title={pothole?.address ?? ''}>
 							{pothole?.address ?? 'Unknown address'}
 						</p>
 
@@ -197,8 +197,8 @@
 								>
 									{pothole.status}
 								</span>
-								<span class="text-zinc-600 text-xs">·</span>
-								<span class="text-zinc-500 text-xs">{pothole.confirmed_count} confirmation{pothole.confirmed_count !== 1 ? 's' : ''}</span>
+								<span class="text-stone-600 text-xs">·</span>
+								<span class="text-stone-500 text-xs">{pothole.confirmed_count} confirmation{pothole.confirmed_count !== 1 ? 's' : ''}</span>
 							{/if}
 						</div>
 
@@ -216,7 +216,7 @@
 							>
 								{scoreLabel(photo.moderation_score)}
 							</span>
-							<span class="text-zinc-600 text-xs">
+							<span class="text-stone-600 text-xs">
 								{formatDistanceToNow(new Date(photo.created_at), { addSuffix: true })}
 							</span>
 						</div>

--- a/src/routes/admin/photos/+page.svelte
+++ b/src/routes/admin/photos/+page.svelte
@@ -92,7 +92,7 @@
 					type="checkbox"
 					checked={allSelected}
 					onchange={toggleAll}
-					class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
+					class="rounded border-stone-600 bg-stone-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
 				/>
 				<span class="text-sm text-stone-400">
 					{#if someSelected}
@@ -149,7 +149,7 @@
 				{@const pothole = photo.potholes}
 				<div
 					class="bg-stone-900 border rounded-lg overflow-hidden transition-colors
-					       {selected.has(photo.id) ? 'border-sky-500/50' : 'border-stone-800'}"
+					       {selected.has(photo.id) ? 'border-amber-500/50' : 'border-stone-800'}"
 				>
 					<!-- Thumbnail -->
 					<div class="relative">
@@ -163,7 +163,7 @@
 								type="checkbox"
 								checked={selected.has(photo.id)}
 								onchange={() => toggleSelect(photo.id)}
-								class="rounded border-stone-500 bg-stone-800/80 text-sky-500 focus:ring-amber-500 focus:ring-1"
+								class="rounded border-stone-500 bg-stone-800/80 text-amber-500 focus:ring-amber-500 focus:ring-1"
 								onclick={(e) => e.stopPropagation()}
 							/>
 						</button>

--- a/src/routes/admin/photos/+page.svelte
+++ b/src/routes/admin/photos/+page.svelte
@@ -92,7 +92,7 @@
 					type="checkbox"
 					checked={allSelected}
 					onchange={toggleAll}
-					class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-stone-900 focus:ring-1"
+					class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500 focus:ring-offset-stone-900 focus:ring-1"
 				/>
 				<span class="text-sm text-stone-400">
 					{#if someSelected}
@@ -163,7 +163,7 @@
 								type="checkbox"
 								checked={selected.has(photo.id)}
 								onchange={() => toggleSelect(photo.id)}
-								class="rounded border-stone-500 bg-stone-800/80 text-sky-500 focus:ring-sky-500 focus:ring-1"
+								class="rounded border-stone-500 bg-stone-800/80 text-sky-500 focus:ring-amber-500 focus:ring-1"
 								onclick={(e) => e.stopPropagation()}
 							/>
 						</button>

--- a/src/routes/admin/potholes/+page.svelte
+++ b/src/routes/admin/potholes/+page.svelte
@@ -385,7 +385,7 @@
 									checked={allSelected}
 									indeterminate={someSelected && !allSelected}
 									onchange={toggleAll}
-									class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500/20"
+									class="rounded border-stone-600 bg-stone-800 text-amber-500 focus:ring-amber-500/20"
 									aria-label="Select all"
 								/>
 							</th>
@@ -418,7 +418,7 @@
 						{#each data.potholes as pothole (pothole.id)}
 							{@const photoCount = pothole.pothole_photos?.length ?? 0}
 							<tr
-								class="hover:bg-stone-800/40 transition-colors {selected.has(pothole.id) ? 'bg-sky-500/5' : ''}"
+								class="hover:bg-stone-800/40 transition-colors {selected.has(pothole.id) ? 'bg-amber-500/5' : ''}"
 							>
 								<td class="px-4 py-3">
 									<input
@@ -428,7 +428,7 @@
 											if (selected.has(pothole.id)) selected.delete(pothole.id);
 											else selected.add(pothole.id);
 										}}
-										class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500/20"
+										class="rounded border-stone-600 bg-stone-800 text-amber-500 focus:ring-amber-500/20"
 										aria-label="Select {pothole.address ?? pothole.id}"
 									/>
 								</td>

--- a/src/routes/admin/potholes/+page.svelte
+++ b/src/routes/admin/potholes/+page.svelte
@@ -215,7 +215,7 @@
 				type="text"
 				bind:value={filterSearch}
 				placeholder="e.g. King St"
-				class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500"
+				class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-500"
 			/>
 		</div>
 		<div>
@@ -224,7 +224,7 @@
 				id="filter-status"
 				name="status"
 				bind:value={filterStatus}
-				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-amber-500"
 			>
 				<option value="">All statuses</option>
 				{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
@@ -238,7 +238,7 @@
 				id="filter-photos"
 				name="photosPublished"
 				bind:value={filterPhotos}
-				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-amber-500"
 			>
 				<option value="">Any</option>
 				<option value="true">Published</option>
@@ -252,7 +252,7 @@
 				name="dateFrom"
 				type="date"
 				bind:value={filterDateFrom}
-				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-amber-500"
 			/>
 		</div>
 		<div>
@@ -262,7 +262,7 @@
 				name="dateTo"
 				type="date"
 				bind:value={filterDateTo}
-				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-amber-500"
 			/>
 		</div>
 		<!-- Preserve sort/dir/pageSize across filter changes -->
@@ -296,7 +296,7 @@
 				<select
 					bind:value={bulkStatus}
 					aria-label="Bulk status"
-					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-amber-500"
 				>
 					{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
 						<option value={s}>{s}</option>
@@ -385,7 +385,7 @@
 									checked={allSelected}
 									indeterminate={someSelected && !allSelected}
 									onchange={toggleAll}
-									class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500/20"
+									class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500/20"
 									aria-label="Select all"
 								/>
 							</th>
@@ -428,7 +428,7 @@
 											if (selected.has(pothole.id)) selected.delete(pothole.id);
 											else selected.add(pothole.id);
 										}}
-										class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500/20"
+										class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-amber-500/20"
 										aria-label="Select {pothole.address ?? pothole.id}"
 									/>
 								</td>
@@ -538,7 +538,7 @@
 					id="page-size"
 					name="pageSize"
 					onchange={(e) => (e.currentTarget.form as HTMLFormElement).submit()}
-					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-amber-500"
 				>
 					{#each [25, 50, 100] as size (size)}
 						<option value={size} selected={data.pageSize === size}>{size}</option>

--- a/src/routes/admin/potholes/+page.svelte
+++ b/src/routes/admin/potholes/+page.svelte
@@ -138,7 +138,7 @@
 			case 'reported': return 'text-sky-400 bg-sky-500/10';
 			case 'filled':   return 'text-emerald-400 bg-emerald-500/10';
 			case 'expired':  return 'text-amber-400 bg-amber-500/10';
-			default:         return 'text-zinc-400 bg-zinc-700/50';
+			default:         return 'text-stone-400 bg-stone-700/50';
 		}
 	}
 
@@ -175,8 +175,8 @@
 	<!-- Header -->
 	<div class="flex items-start justify-between gap-4 flex-wrap">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Potholes</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Potholes</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{data.total} pothole{data.total !== 1 ? 's' : ''}
 				{data.filterStatus ? `with status "${data.filterStatus}"` : data.search ? `matching "${data.search}"` : 'total'}
 			</p>
@@ -184,7 +184,7 @@
 		<div class="flex items-center gap-2">
 			<a
 				href={exportUrl('csv')}
-				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors"
+				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-stone-700 text-stone-400 hover:text-stone-200 hover:border-stone-600 transition-colors"
 				title={someSelected ? `Export ${selected.size} selected` : 'Export current filters'}
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -194,7 +194,7 @@
 			</a>
 			<a
 				href={exportUrl('json')}
-				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors"
+				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-stone-700 text-stone-400 hover:text-stone-200 hover:border-stone-600 transition-colors"
 				title={someSelected ? `Export ${selected.size} selected` : 'Export current filters'}
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -208,23 +208,23 @@
 	<!-- Filter bar -->
 	<form method="get" class="flex flex-wrap gap-2 items-end">
 		<div class="flex-1 min-w-[180px]">
-			<label for="search" class="block text-xs text-zinc-500 mb-1">Search address</label>
+			<label for="search" class="block text-xs text-stone-500 mb-1">Search address</label>
 			<input
 				id="search"
 				name="search"
 				type="text"
 				bind:value={filterSearch}
 				placeholder="e.g. King St"
-				class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-sky-500"
+				class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500"
 			/>
 		</div>
 		<div>
-			<label for="filter-status" class="block text-xs text-zinc-500 mb-1">Status</label>
+			<label for="filter-status" class="block text-xs text-stone-500 mb-1">Status</label>
 			<select
 				id="filter-status"
 				name="status"
 				bind:value={filterStatus}
-				class="bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
 			>
 				<option value="">All statuses</option>
 				{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
@@ -233,12 +233,12 @@
 			</select>
 		</div>
 		<div>
-			<label for="filter-photos" class="block text-xs text-zinc-500 mb-1">Photos</label>
+			<label for="filter-photos" class="block text-xs text-stone-500 mb-1">Photos</label>
 			<select
 				id="filter-photos"
 				name="photosPublished"
 				bind:value={filterPhotos}
-				class="bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
 			>
 				<option value="">Any</option>
 				<option value="true">Published</option>
@@ -246,23 +246,23 @@
 			</select>
 		</div>
 		<div>
-			<label for="date-from" class="block text-xs text-zinc-500 mb-1">From</label>
+			<label for="date-from" class="block text-xs text-stone-500 mb-1">From</label>
 			<input
 				id="date-from"
 				name="dateFrom"
 				type="date"
 				bind:value={filterDateFrom}
-				class="bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
 			/>
 		</div>
 		<div>
-			<label for="date-to" class="block text-xs text-zinc-500 mb-1">To</label>
+			<label for="date-to" class="block text-xs text-stone-500 mb-1">To</label>
 			<input
 				id="date-to"
 				name="dateTo"
 				type="date"
 				bind:value={filterDateTo}
-				class="bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-sky-500"
+				class="bg-stone-800 border border-stone-700 rounded px-3 py-1.5 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
 			/>
 		</div>
 		<!-- Preserve sort/dir/pageSize across filter changes -->
@@ -272,13 +272,13 @@
 		<div class="flex gap-2">
 			<button
 				type="submit"
-				class="px-3 py-1.5 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+				class="px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 			>
 				Filter
 			</button>
 			<a
 				href="/admin/potholes"
-				class="px-3 py-1.5 text-sm font-medium border border-zinc-700 text-zinc-400 hover:text-zinc-200 rounded transition-colors"
+				class="px-3 py-1.5 text-sm font-medium border border-stone-700 text-stone-400 hover:text-stone-200 rounded transition-colors"
 			>
 				Reset
 			</a>
@@ -287,16 +287,16 @@
 
 	<!-- Bulk toolbar (sticky, appears when items selected) -->
 	{#if someSelected}
-		<div class="sticky top-0 z-10 flex flex-wrap items-center gap-3 px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-lg shadow-lg">
-			<span class="text-sm text-zinc-300 font-medium tabular-nums">{selected.size} selected</span>
-			<div class="w-px h-4 bg-zinc-700"></div>
+		<div class="sticky top-0 z-10 flex flex-wrap items-center gap-3 px-4 py-3 bg-stone-900 border border-stone-700 rounded-lg shadow-lg">
+			<span class="text-sm text-stone-300 font-medium tabular-nums">{selected.size} selected</span>
+			<div class="w-px h-4 bg-stone-700"></div>
 
 			<!-- Change status -->
 			<div class="flex items-center gap-2">
 				<select
 					bind:value={bulkStatus}
 					aria-label="Bulk status"
-					class="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
 				>
 					{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
 						<option value={s}>{s}</option>
@@ -306,13 +306,13 @@
 					type="submit"
 					form="bulk-main"
 					formaction="?/bulkChangeStatus"
-					class="px-3 py-1 text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-200 rounded transition-colors"
+					class="px-3 py-1 text-xs font-medium bg-stone-700 hover:bg-stone-600 text-stone-200 rounded transition-colors"
 				>
 					Set status
 				</button>
 			</div>
 
-			<div class="w-px h-4 bg-zinc-700"></div>
+			<div class="w-px h-4 bg-stone-700"></div>
 
 			<!-- Photo visibility -->
 			<button
@@ -325,25 +325,25 @@
 			<button
 				type="submit"
 				form="bulk-unpub"
-				class="px-3 py-1 text-xs font-medium border border-zinc-600 text-zinc-400 bg-zinc-800 hover:bg-zinc-700 rounded transition-colors"
+				class="px-3 py-1 text-xs font-medium border border-stone-600 text-stone-400 bg-stone-800 hover:bg-stone-700 rounded transition-colors"
 			>
 				Hide photos
 			</button>
 
-			<div class="w-px h-4 bg-zinc-700"></div>
+			<div class="w-px h-4 bg-stone-700"></div>
 
 			<!-- Export selection -->
 			<a
 				href={exportUrl('csv')}
-				class="px-3 py-1 text-xs font-medium border border-zinc-700 text-zinc-400 hover:text-zinc-200 rounded transition-colors"
+				class="px-3 py-1 text-xs font-medium border border-stone-700 text-stone-400 hover:text-stone-200 rounded transition-colors"
 			>↓ CSV</a>
 			<a
 				href={exportUrl('json')}
-				class="px-3 py-1 text-xs font-medium border border-zinc-700 text-zinc-400 hover:text-zinc-200 rounded transition-colors"
+				class="px-3 py-1 text-xs font-medium border border-stone-700 text-stone-400 hover:text-stone-200 rounded transition-colors"
 			>↓ JSON</a>
 
 			{#if data.adminRole === 'admin'}
-				<div class="w-px h-4 bg-zinc-700"></div>
+				<div class="w-px h-4 bg-stone-700"></div>
 				<button
 					type="submit"
 					form="bulk-main"
@@ -360,7 +360,7 @@
 			<button
 				type="button"
 				onclick={() => selected.clear()}
-				class="ml-auto text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+				class="ml-auto text-xs text-stone-600 hover:text-stone-400 transition-colors"
 			>
 				Clear selection
 			</button>
@@ -370,55 +370,55 @@
 	{#if data.potholes.length === 0}
 		<div class="text-center py-20">
 			<div class="text-4xl mb-3">🕳️</div>
-			<p class="text-zinc-400 font-medium">No potholes found</p>
-			<p class="text-zinc-600 text-sm mt-1">Try adjusting your filters.</p>
+			<p class="text-stone-400 font-medium">No potholes found</p>
+			<p class="text-stone-600 text-sm mt-1">Try adjusting your filters.</p>
 		</div>
 	{:else}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+		<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
 			<div class="overflow-x-auto">
 				<table class="w-full text-sm min-w-[780px]">
 					<thead>
-						<tr class="border-b border-zinc-800 text-left">
+						<tr class="border-b border-stone-800 text-left">
 							<th class="px-4 py-3 w-10">
 								<input
 									type="checkbox"
 									checked={allSelected}
 									indeterminate={someSelected && !allSelected}
 									onchange={toggleAll}
-									class="rounded border-zinc-600 bg-zinc-800 text-sky-500 focus:ring-sky-500/20"
+									class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500/20"
 									aria-label="Select all"
 								/>
 							</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">
-								<a href={sortHref('address')} class="inline-flex items-center gap-1 hover:text-zinc-300 transition-colors">
-									Address <span class="text-zinc-600">{sortIcon('address')}</span>
+							<th class="px-4 py-3 text-stone-500 font-medium">
+								<a href={sortHref('address')} class="inline-flex items-center gap-1 hover:text-stone-300 transition-colors">
+									Address <span class="text-stone-600">{sortIcon('address')}</span>
 								</a>
 							</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">
-								<a href={sortHref('status')} class="inline-flex items-center gap-1 hover:text-zinc-300 transition-colors">
-									Status <span class="text-zinc-600">{sortIcon('status')}</span>
+							<th class="px-4 py-3 text-stone-500 font-medium">
+								<a href={sortHref('status')} class="inline-flex items-center gap-1 hover:text-stone-300 transition-colors">
+									Status <span class="text-stone-600">{sortIcon('status')}</span>
 								</a>
 							</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">
-								<a href={sortHref('confirmed_count')} class="inline-flex items-center gap-1 hover:text-zinc-300 transition-colors">
-									Conf. <span class="text-zinc-600">{sortIcon('confirmed_count')}</span>
+							<th class="px-4 py-3 text-stone-500 font-medium">
+								<a href={sortHref('confirmed_count')} class="inline-flex items-center gap-1 hover:text-stone-300 transition-colors">
+									Conf. <span class="text-stone-600">{sortIcon('confirmed_count')}</span>
 								</a>
 							</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">Photos</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">Visibility</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium">
-								<a href={sortHref('created_at')} class="inline-flex items-center gap-1 hover:text-zinc-300 transition-colors">
-									Reported <span class="text-zinc-600">{sortIcon('created_at')}</span>
+							<th class="px-4 py-3 text-stone-500 font-medium">Photos</th>
+							<th class="px-4 py-3 text-stone-500 font-medium">Visibility</th>
+							<th class="px-4 py-3 text-stone-500 font-medium">
+								<a href={sortHref('created_at')} class="inline-flex items-center gap-1 hover:text-stone-300 transition-colors">
+									Reported <span class="text-stone-600">{sortIcon('created_at')}</span>
 								</a>
 							</th>
-							<th class="px-4 py-3 text-zinc-500 font-medium sr-only">Actions</th>
+							<th class="px-4 py-3 text-stone-500 font-medium sr-only">Actions</th>
 						</tr>
 					</thead>
-					<tbody class="divide-y divide-zinc-800">
+					<tbody class="divide-y divide-stone-800">
 						{#each data.potholes as pothole (pothole.id)}
 							{@const photoCount = pothole.pothole_photos?.length ?? 0}
 							<tr
-								class="hover:bg-zinc-800/40 transition-colors {selected.has(pothole.id) ? 'bg-sky-500/5' : ''}"
+								class="hover:bg-stone-800/40 transition-colors {selected.has(pothole.id) ? 'bg-sky-500/5' : ''}"
 							>
 								<td class="px-4 py-3">
 									<input
@@ -428,15 +428,15 @@
 											if (selected.has(pothole.id)) selected.delete(pothole.id);
 											else selected.add(pothole.id);
 										}}
-										class="rounded border-zinc-600 bg-zinc-800 text-sky-500 focus:ring-sky-500/20"
+										class="rounded border-stone-600 bg-stone-800 text-sky-500 focus:ring-sky-500/20"
 										aria-label="Select {pothole.address ?? pothole.id}"
 									/>
 								</td>
 								<td class="px-4 py-3 max-w-xs">
-									<p class="text-zinc-200 truncate" title={pothole.address ?? ''}>
+									<p class="text-stone-200 truncate" title={pothole.address ?? ''}>
 										{pothole.address ?? 'No address'}
 									</p>
-									<p class="text-zinc-600 text-xs mt-0.5 font-mono">
+									<p class="text-stone-600 text-xs mt-0.5 font-mono">
 										{pothole.id.slice(0, 8)}…
 									</p>
 								</td>
@@ -447,20 +447,20 @@
 										{pothole.status}
 									</span>
 								</td>
-								<td class="px-4 py-3 text-zinc-400 tabular-nums">
+								<td class="px-4 py-3 text-stone-400 tabular-nums">
 									{pothole.confirmed_count}
 								</td>
 								<td class="px-4 py-3">
 									{#if photoCount > 0}
-										<span class="inline-flex items-center gap-1 text-xs text-zinc-300">
-											<svg class="w-3.5 h-3.5 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<span class="inline-flex items-center gap-1 text-xs text-stone-300">
+											<svg class="w-3.5 h-3.5 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
 											</svg>
 											{photoCount}
 										</span>
 									{:else}
-										<span class="text-zinc-700 text-xs">—</span>
+										<span class="text-stone-700 text-xs">—</span>
 									{/if}
 								</td>
 								<td class="px-4 py-3">
@@ -470,21 +470,21 @@
 											class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium border transition-colors
 											       {photosPublished[pothole.id]
 												? 'border-emerald-600/40 text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'
-												: 'border-zinc-700 text-zinc-500 bg-zinc-800/50 hover:bg-zinc-700 hover:text-zinc-300'}"
+												: 'border-stone-700 text-stone-500 bg-stone-800/50 hover:bg-stone-700 hover:text-stone-300'}"
 										>
 											{photosPublished[pothole.id] ? 'Published' : 'Hidden'}
 										</button>
 									{:else}
-										<span class="text-zinc-700 text-xs">—</span>
+										<span class="text-stone-700 text-xs">—</span>
 									{/if}
 								</td>
-								<td class="px-4 py-3 text-zinc-500 text-xs whitespace-nowrap">
+								<td class="px-4 py-3 text-stone-500 text-xs whitespace-nowrap">
 									{formatDistanceToNow(new Date(pothole.created_at), { addSuffix: true })}
 								</td>
 								<td class="px-4 py-3 text-right">
 									<a
 										href="/admin/potholes/{pothole.id}"
-										class="text-xs text-sky-400 hover:text-sky-300 hover:underline transition-colors"
+										class="text-xs text-amber-400 hover:text-amber-300 hover:underline transition-colors"
 									>
 										Manage →
 									</a>
@@ -498,7 +498,7 @@
 
 		<!-- Pagination -->
 		<div class="flex items-center justify-between gap-4 flex-wrap text-sm">
-			<p class="text-zinc-500 text-xs">
+			<p class="text-stone-500 text-xs">
 				{#if data.total > 0}
 					Showing {rangeFrom}–{rangeTo} of {data.total}
 				{/if}
@@ -507,18 +507,18 @@
 				{#if data.page > 1}
 					<a
 						href={pageHref(data.page - 1)}
-						class="px-3 py-1.5 text-xs font-medium border border-zinc-700 text-zinc-400 hover:text-zinc-200 rounded transition-colors"
+						class="px-3 py-1.5 text-xs font-medium border border-stone-700 text-stone-400 hover:text-stone-200 rounded transition-colors"
 					>
 						← Prev
 					</a>
 				{/if}
-				<span class="text-zinc-500 text-xs tabular-nums">
+				<span class="text-stone-500 text-xs tabular-nums">
 					Page {data.page} of {totalPages}
 				</span>
 				{#if data.page < totalPages}
 					<a
 						href={pageHref(data.page + 1)}
-						class="px-3 py-1.5 text-xs font-medium border border-zinc-700 text-zinc-400 hover:text-zinc-200 rounded transition-colors"
+						class="px-3 py-1.5 text-xs font-medium border border-stone-700 text-stone-400 hover:text-stone-200 rounded transition-colors"
 					>
 						Next →
 					</a>
@@ -533,12 +533,12 @@
 				{#if data.dateTo}<input type="hidden" name="dateTo" value={data.dateTo} />{/if}
 				<input type="hidden" name="sort" value={data.sort} />
 				<input type="hidden" name="dir" value={data.dir} />
-				<label for="page-size" class="text-xs text-zinc-500">Per page</label>
+				<label for="page-size" class="text-xs text-stone-500">Per page</label>
 				<select
 					id="page-size"
 					name="pageSize"
 					onchange={(e) => (e.currentTarget.form as HTMLFormElement).submit()}
-					class="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
 				>
 					{#each [25, 50, 100] as size (size)}
 						<option value={size} selected={data.pageSize === size}>{size}</option>

--- a/src/routes/admin/potholes/[id]/+page.svelte
+++ b/src/routes/admin/potholes/[id]/+page.svelte
@@ -154,7 +154,7 @@
 						<select
 							id="status"
 							name="status"
-							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 						>
 							{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
 								<option value={s} selected={pothole.status === s}>{s}</option>
@@ -184,7 +184,7 @@
 							name="address"
 							type="text"
 							bind:value={addressValue}
-							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							placeholder="e.g. 123 King St W, Kitchener"
 							maxlength="500"
 						/>

--- a/src/routes/admin/potholes/[id]/+page.svelte
+++ b/src/routes/admin/potholes/[id]/+page.svelte
@@ -25,7 +25,7 @@
 			case 'expired':
 				return 'text-amber-400 bg-amber-500/10 border border-amber-500/20';
 			default:
-				return 'text-zinc-300 bg-zinc-700/50 border border-zinc-600/30';
+				return 'text-stone-300 bg-stone-700/50 border border-stone-600/30';
 		}
 	}
 
@@ -52,10 +52,10 @@
 
 <div class="p-6 max-w-5xl">
 	<!-- Breadcrumb -->
-	<nav class="flex items-center gap-2 text-sm text-zinc-500 mb-5">
-		<a href="/admin/potholes" class="hover:text-zinc-300 transition-colors">Potholes</a>
+	<nav class="flex items-center gap-2 text-sm text-stone-500 mb-5">
+		<a href="/admin/potholes" class="hover:text-stone-300 transition-colors">Potholes</a>
 		<span>/</span>
-		<span class="text-zinc-300 font-mono">{pothole.id.slice(0, 8)}…</span>
+		<span class="text-stone-300 font-mono">{pothole.id.slice(0, 8)}…</span>
 	</nav>
 
 	<!-- Error / success flash -->
@@ -76,13 +76,13 @@
 		<div class="lg:col-span-2 space-y-5">
 
 			<!-- Info card -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
 				<div class="flex items-start justify-between gap-3 mb-4">
 					<div>
-						<h1 class="text-lg font-semibold text-zinc-100 leading-tight">
+						<h1 class="text-lg font-semibold text-stone-100 leading-tight">
 							{pothole.address ?? 'No address'}
 						</h1>
-						<p class="text-zinc-500 text-xs font-mono mt-1">{pothole.id}</p>
+						<p class="text-stone-500 text-xs font-mono mt-1">{pothole.id}</p>
 					</div>
 					<span class="inline-flex items-center px-2.5 py-1 rounded text-sm font-medium capitalize flex-shrink-0 {statusColor(pothole.status)}">
 						{pothole.status}
@@ -91,41 +91,41 @@
 
 				<dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
 					<div>
-						<dt class="text-zinc-500 text-xs">Coordinates</dt>
-						<dd class="text-zinc-300 font-mono text-xs mt-0.5">
+						<dt class="text-stone-500 text-xs">Coordinates</dt>
+						<dd class="text-stone-300 font-mono text-xs mt-0.5">
 							{pothole.lat.toFixed(6)}, {pothole.lng.toFixed(6)}
 						</dd>
 					</div>
 					<div>
-						<dt class="text-zinc-500 text-xs">Confirmations</dt>
-						<dd class="text-zinc-300 mt-0.5">{pothole.confirmed_count}</dd>
+						<dt class="text-stone-500 text-xs">Confirmations</dt>
+						<dd class="text-stone-300 mt-0.5">{pothole.confirmed_count}</dd>
 					</div>
 					<div>
-						<dt class="text-zinc-500 text-xs">Reported</dt>
-						<dd class="text-zinc-300 mt-0.5 text-xs">
+						<dt class="text-stone-500 text-xs">Reported</dt>
+						<dd class="text-stone-300 mt-0.5 text-xs">
 							{format(new Date(pothole.created_at), 'PPp')}
 						</dd>
 					</div>
 					{#if pothole.filled_at}
 						<div>
-							<dt class="text-zinc-500 text-xs">Filled</dt>
-							<dd class="text-zinc-300 mt-0.5 text-xs">
+							<dt class="text-stone-500 text-xs">Filled</dt>
+							<dd class="text-stone-300 mt-0.5 text-xs">
 								{format(new Date(pothole.filled_at), 'PPp')}
 							</dd>
 						</div>
 					{/if}
 					{#if pothole.expired_at}
 						<div>
-							<dt class="text-zinc-500 text-xs">Expired</dt>
-							<dd class="text-zinc-300 mt-0.5 text-xs">
+							<dt class="text-stone-500 text-xs">Expired</dt>
+							<dd class="text-stone-300 mt-0.5 text-xs">
 								{format(new Date(pothole.expired_at), 'PPp')}
 							</dd>
 						</div>
 					{/if}
 					{#if pothole.description}
 						<div class="col-span-2">
-							<dt class="text-zinc-500 text-xs">Description</dt>
-							<dd class="text-zinc-300 mt-0.5">{pothole.description}</dd>
+							<dt class="text-stone-500 text-xs">Description</dt>
+							<dd class="text-stone-300 mt-0.5">{pothole.description}</dd>
 						</div>
 					{/if}
 				</dl>
@@ -135,7 +135,7 @@
 					href="https://www.openstreetmap.org/?mlat={pothole.lat}&mlon={pothole.lng}&zoom=17"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="inline-flex items-center gap-1.5 mt-4 text-xs text-sky-400 hover:text-sky-300 transition-colors"
+					class="inline-flex items-center gap-1.5 mt-4 text-xs text-amber-400 hover:text-amber-300 transition-colors"
 				>
 					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -146,15 +146,15 @@
 			</div>
 
 			<!-- Status override -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
-				<h2 class="text-sm font-medium text-zinc-300 mb-3">Override Status</h2>
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
+				<h2 class="text-sm font-medium text-stone-300 mb-3">Override Status</h2>
 				<form method="post" action="?/updateStatus" use:enhance class="flex items-end gap-3">
 					<div class="flex-1">
-						<label for="status" class="block text-xs text-zinc-500 mb-1.5">Status</label>
+						<label for="status" class="block text-xs text-stone-500 mb-1.5">Status</label>
 						<select
 							id="status"
 							name="status"
-							class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 						>
 							{#each ['pending', 'reported', 'filled', 'expired'] as s (s)}
 								<option value={s} selected={pothole.status === s}>{s}</option>
@@ -163,35 +163,35 @@
 					</div>
 					<button
 						type="submit"
-						class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+						class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 					>
 						Save
 					</button>
 				</form>
-				<p class="text-zinc-600 text-xs mt-2">
+				<p class="text-stone-600 text-xs mt-2">
 					Setting to "filled" or "expired" updates the corresponding timestamp. Other transitions clear it.
 				</p>
 			</div>
 
 			<!-- Address edit -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
-				<h2 class="text-sm font-medium text-zinc-300 mb-3">Edit Address</h2>
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
+				<h2 class="text-sm font-medium text-stone-300 mb-3">Edit Address</h2>
 				<form method="post" action="?/updateAddress" use:enhance class="flex items-end gap-3">
 					<div class="flex-1">
-						<label for="address" class="block text-xs text-zinc-500 mb-1.5">Address</label>
+						<label for="address" class="block text-xs text-stone-500 mb-1.5">Address</label>
 						<input
 							id="address"
 							name="address"
 							type="text"
 							bind:value={addressValue}
-							class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							placeholder="e.g. 123 King St W, Kitchener"
 							maxlength="500"
 						/>
 					</div>
 					<button
 						type="submit"
-						class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+						class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 					>
 						Save
 					</button>
@@ -199,32 +199,32 @@
 			</div>
 
 			<!-- Confirmations -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
-				<div class="px-4 py-3 border-b border-zinc-800">
-					<h2 class="text-sm font-medium text-zinc-300">
+			<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
+				<div class="px-4 py-3 border-b border-stone-800">
+					<h2 class="text-sm font-medium text-stone-300">
 						Confirmations
-						<span class="ml-1.5 text-zinc-500 font-normal">({data.confirmations.length})</span>
+						<span class="ml-1.5 text-stone-500 font-normal">({data.confirmations.length})</span>
 					</h2>
 				</div>
 
 				{#if data.confirmations.length === 0}
-					<p class="text-zinc-600 text-sm px-4 py-4">No confirmations yet.</p>
+					<p class="text-stone-600 text-sm px-4 py-4">No confirmations yet.</p>
 				{:else}
 					<div class="overflow-x-auto">
 					<table class="w-full text-sm min-w-[400px]">
 						<thead>
-							<tr class="border-b border-zinc-800 text-left">
-								<th class="px-4 py-2.5 text-zinc-500 font-medium text-xs">#</th>
-								<th class="px-4 py-2.5 text-zinc-500 font-medium text-xs">IP Hash</th>
-								<th class="px-4 py-2.5 text-zinc-500 font-medium text-xs">When</th>
+							<tr class="border-b border-stone-800 text-left">
+								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">#</th>
+								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">IP Hash</th>
+								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">When</th>
 							</tr>
 						</thead>
-						<tbody class="divide-y divide-zinc-800/60">
+						<tbody class="divide-y divide-stone-800/60">
 							{#each data.confirmations as c, i (c.id)}
 								<tr>
-									<td class="px-4 py-2.5 text-zinc-500 text-xs">{i + 1}</td>
-									<td class="px-4 py-2.5 text-zinc-400 font-mono text-xs">{maskHash(c.ip_hash)}</td>
-									<td class="px-4 py-2.5 text-zinc-500 text-xs">
+									<td class="px-4 py-2.5 text-stone-500 text-xs">{i + 1}</td>
+									<td class="px-4 py-2.5 text-stone-400 font-mono text-xs">{maskHash(c.ip_hash)}</td>
+									<td class="px-4 py-2.5 text-stone-500 text-xs">
 										{formatDistanceToNow(new Date(c.created_at), { addSuffix: true })}
 									</td>
 								</tr>
@@ -240,11 +240,11 @@
 		<div class="space-y-5">
 
 			<!-- Photos -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
-				<div class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between gap-3 flex-wrap">
-					<h2 class="text-sm font-medium text-zinc-300">
+			<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
+				<div class="px-4 py-3 border-b border-stone-800 flex items-center justify-between gap-3 flex-wrap">
+					<h2 class="text-sm font-medium text-stone-300">
 						Photos
-						<span class="ml-1.5 text-zinc-500 font-normal">({data.photos.length})</span>
+						<span class="ml-1.5 text-stone-500 font-normal">({data.photos.length})</span>
 					</h2>
 					<div class="flex items-center gap-2 ml-auto">
 						{#if data.photos.length > 0}
@@ -255,7 +255,7 @@
 									class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border transition-colors
 									       {pothole.photos_published
 										? 'border-emerald-600/40 text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'
-										: 'border-zinc-600 text-zinc-400 bg-zinc-800 hover:bg-zinc-700'}"
+										: 'border-stone-600 text-stone-400 bg-stone-800 hover:bg-stone-700'}"
 								>
 									<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -266,7 +266,7 @@
 							</form>
 							<a
 								href="/admin/photos"
-								class="text-xs text-sky-400 hover:text-sky-300 transition-colors"
+								class="text-xs text-amber-400 hover:text-amber-300 transition-colors"
 							>
 								Review queue →
 							</a>
@@ -275,7 +275,7 @@
 				</div>
 
 				{#if data.photos.length === 0}
-					<p class="text-zinc-600 text-sm px-4 py-4">No photos uploaded.</p>
+					<p class="text-stone-600 text-sm px-4 py-4">No photos uploaded.</p>
 				{:else}
 					<div class="p-3 space-y-2">
 						{#each data.photos as photo (photo.id)}
@@ -286,11 +286,11 @@
 											src={photo.url}
 											alt="Pothole"
 											loading="lazy"
-											class="w-16 h-16 object-cover rounded bg-zinc-800"
+											class="w-16 h-16 object-cover rounded bg-stone-800"
 										/>
 									</a>
 								{:else}
-									<div class="w-16 h-16 rounded bg-zinc-800 flex items-center justify-center text-zinc-600 flex-shrink-0">
+									<div class="w-16 h-16 rounded bg-stone-800 flex items-center justify-center text-stone-600 flex-shrink-0">
 										<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
 										</svg>
@@ -300,11 +300,11 @@
 									<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium capitalize {photoStatusColor(photo.moderation_status)}">
 										{photo.moderation_status}
 									</span>
-									<p class="text-zinc-600 text-xs mt-1">
+									<p class="text-stone-600 text-xs mt-1">
 										{formatDistanceToNow(new Date(photo.created_at), { addSuffix: true })}
 									</p>
 									{#if photo.moderation_score !== null}
-										<p class="text-zinc-600 text-xs">
+										<p class="text-stone-600 text-xs">
 											Score: {Math.round(photo.moderation_score * 100)}%
 										</p>
 									{/if}
@@ -317,9 +317,9 @@
 
 			<!-- Danger zone (admin only) -->
 			{#if isAdmin}
-				<div class="bg-zinc-900 border border-red-900/40 rounded-lg p-4">
+				<div class="bg-stone-900 border border-red-900/40 rounded-lg p-4">
 					<h2 class="text-sm font-medium text-red-400 mb-1">Danger Zone</h2>
-					<p class="text-zinc-500 text-xs mb-3">
+					<p class="text-stone-500 text-xs mb-3">
 						Permanently deletes this pothole, all confirmations, and photos. This cannot be undone.
 					</p>
 					<form

--- a/src/routes/admin/settings/mfa/+page.svelte
+++ b/src/routes/admin/settings/mfa/+page.svelte
@@ -24,13 +24,13 @@
 </svelte:head>
 
 <div class="p-6 max-w-2xl">
-	<nav class="flex items-center gap-2 text-sm text-zinc-500 mb-5">
-		<span class="text-zinc-300">Settings</span>
+	<nav class="flex items-center gap-2 text-sm text-stone-500 mb-5">
+		<span class="text-stone-300">Settings</span>
 		<span>/</span>
-		<span class="text-zinc-300">Two-Factor Auth</span>
+		<span class="text-stone-300">Two-Factor Auth</span>
 	</nav>
 
-	<h1 class="text-xl font-semibold text-zinc-100 mb-6">Two-Factor Authentication</h1>
+	<h1 class="text-xl font-semibold text-stone-100 mb-6">Two-Factor Authentication</h1>
 
 	{#if form?.error && !form?.pendingSetup}
 		<div class="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
@@ -42,28 +42,28 @@
 	{#if form?.confirmed && form.backupCodes}
 		<div class="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-5 mb-5">
 			<h2 class="text-emerald-400 font-semibold mb-1">MFA enabled!</h2>
-			<p class="text-zinc-300 text-sm mb-4">
+			<p class="text-stone-300 text-sm mb-4">
 				Save these backup codes somewhere safe. Each can only be used once if you lose access to
 				your authenticator.
 			</p>
 			<div class="grid grid-cols-2 gap-2">
 				{#each form.backupCodes as code (code)}
-					<code class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm font-mono text-zinc-200 text-center">
+					<code class="bg-stone-900 border border-stone-700 rounded px-3 py-1.5 text-sm font-mono text-stone-200 text-center">
 						{formatCode(code)}
 					</code>
 				{/each}
 			</div>
-			<p class="text-zinc-500 text-xs mt-3">These codes are shown once and cannot be retrieved later.</p>
+			<p class="text-stone-500 text-xs mt-3">These codes are shown once and cannot be retrieved later.</p>
 		</div>
 
 	<!-- ─── Just regenerated backup codes ─── -->
 	{:else if form?.newBackupCodes}
 		<div class="bg-amber-500/10 border border-amber-500/30 rounded-lg p-5 mb-5">
 			<h2 class="text-amber-400 font-semibold mb-1">New backup codes</h2>
-			<p class="text-zinc-300 text-sm mb-4">Your old codes are now invalid. Save these new ones.</p>
+			<p class="text-stone-300 text-sm mb-4">Your old codes are now invalid. Save these new ones.</p>
 			<div class="grid grid-cols-2 gap-2">
 				{#each form.newBackupCodes as code (code)}
-					<code class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm font-mono text-zinc-200 text-center">
+					<code class="bg-stone-900 border border-stone-700 rounded px-3 py-1.5 text-sm font-mono text-stone-200 text-center">
 						{formatCode(code)}
 					</code>
 				{/each}
@@ -72,34 +72,34 @@
 
 	<!-- ─── MFA disabled this session ─── -->
 	{:else if form?.disabled}
-		<div class="mb-5 px-4 py-3 bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-300 text-sm">
+		<div class="mb-5 px-4 py-3 bg-stone-800 border border-stone-700 rounded-lg text-stone-300 text-sm">
 			MFA has been disabled on your account.
 		</div>
 	{/if}
 
 	<!-- ─── Pending setup: show secret + confirm form ─── -->
 	{#if form?.pendingSetup}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5 space-y-4">
+		<div class="bg-stone-900 border border-stone-800 rounded-lg p-5 space-y-4">
 			<div>
-				<h2 class="text-sm font-medium text-zinc-300 mb-1">Scan or enter your secret</h2>
-				<p class="text-zinc-500 text-xs mb-3">
+				<h2 class="text-sm font-medium text-stone-300 mb-1">Scan or enter your secret</h2>
+				<p class="text-stone-500 text-xs mb-3">
 					Open your authenticator app and add a new TOTP account using the secret below,
 					or use the URI to import it directly.
 				</p>
 
 				<div class="space-y-2">
 					<div>
-						<p class="text-zinc-500 text-xs mb-1">Secret key</p>
-						<code class="block bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm font-mono text-zinc-200 break-all select-all">
+						<p class="text-stone-500 text-xs mb-1">Secret key</p>
+						<code class="block bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm font-mono text-stone-200 break-all select-all">
 							{form.displaySecret ?? ''}
 						</code>
 					</div>
 					{#if form.totpUri}
 						<details class="group">
-							<summary class="text-xs text-zinc-500 cursor-pointer hover:text-zinc-300 transition-colors">
+							<summary class="text-xs text-stone-500 cursor-pointer hover:text-stone-300 transition-colors">
 								Show TOTP URI
 							</summary>
-							<code class="block mt-1 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-xs font-mono text-zinc-400 break-all select-all">
+							<code class="block mt-1 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-xs font-mono text-stone-400 break-all select-all">
 								{form.totpUri}
 							</code>
 						</details>
@@ -110,7 +110,7 @@
 			<form method="post" action="?/confirmMfa" use:enhance class="space-y-3">
 				<input type="hidden" name="encryptedSecret" value={form.encryptedSecret ?? ''} />
 				<div>
-					<label for="code" class="block text-xs text-zinc-500 mb-1.5">
+					<label for="code" class="block text-xs text-stone-500 mb-1.5">
 						Verify — enter the 6-digit code from your app
 					</label>
 					{#if pendingSetupError}
@@ -124,17 +124,17 @@
 						autocomplete="one-time-code"
 						maxlength="6"
 						placeholder="000000"
-						class="w-32 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 font-mono text-center focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+						class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 					/>
 				</div>
 				<div class="flex items-center gap-3">
 					<button
 						type="submit"
-						class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+						class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 					>
 						Verify & Enable
 					</button>
-					<a href="/admin/settings/mfa" class="text-sm text-zinc-500 hover:text-zinc-300 transition-colors">
+					<a href="/admin/settings/mfa" class="text-sm text-stone-500 hover:text-stone-300 transition-colors">
 						Cancel
 					</a>
 				</div>
@@ -143,7 +143,7 @@
 
 	<!-- ─── MFA not enabled, no pending setup ─── -->
 	{:else if !data.totpEnabled && !form?.confirmed}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+		<div class="bg-stone-900 border border-stone-800 rounded-lg p-5">
 			<div class="flex items-start gap-3 mb-4">
 				<div class="w-8 h-8 rounded-full bg-amber-500/10 flex items-center justify-center flex-shrink-0 mt-0.5">
 					<svg class="w-4 h-4 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -151,14 +151,14 @@
 					</svg>
 				</div>
 				<div>
-					<p class="text-zinc-200 font-medium">MFA is not enabled</p>
-					<p class="text-zinc-500 text-sm mt-0.5">Add a second factor to protect your account.</p>
+					<p class="text-stone-200 font-medium">MFA is not enabled</p>
+					<p class="text-stone-500 text-sm mt-0.5">Add a second factor to protect your account.</p>
 				</div>
 			</div>
 			<form method="post" action="?/initMfa" use:enhance>
 				<button
 					type="submit"
-					class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+					class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 				>
 					Set up authenticator app
 				</button>
@@ -169,7 +169,7 @@
 	{:else if data.totpEnabled || form?.confirmed}
 		<div class="space-y-4">
 			<!-- Status card -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-5">
 				<div class="flex items-center gap-3 mb-4">
 					<div class="w-8 h-8 rounded-full bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
 						<svg class="w-4 h-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -177,18 +177,18 @@
 						</svg>
 					</div>
 					<div>
-						<p class="text-zinc-200 font-medium">MFA is enabled</p>
-						<p class="text-zinc-500 text-sm mt-0.5">Your account is protected with TOTP.</p>
+						<p class="text-stone-200 font-medium">MFA is enabled</p>
+						<p class="text-stone-500 text-sm mt-0.5">Your account is protected with TOTP.</p>
 					</div>
 				</div>
 
 				<!-- Disable form -->
 				<details class="group">
-					<summary class="text-xs text-zinc-500 cursor-pointer hover:text-red-400 transition-colors">
+					<summary class="text-xs text-stone-500 cursor-pointer hover:text-red-400 transition-colors">
 						Disable MFA…
 					</summary>
 					<form method="post" action="?/disableMfa" use:enhance class="mt-3 space-y-2">
-						<label for="disable-code" class="block text-xs text-zinc-500">
+						<label for="disable-code" class="block text-xs text-stone-500">
 							Enter your TOTP or backup code to confirm
 						</label>
 						<div class="flex items-center gap-2">
@@ -200,7 +200,7 @@
 								autocomplete="one-time-code"
 								maxlength="8"
 								placeholder="000000"
-								class="w-32 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 font-mono text-center focus:outline-none focus:border-sky-500"
+								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500"
 							/>
 							<button
 								type="submit"
@@ -215,9 +215,9 @@
 			</div>
 
 			<!-- Backup codes card -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
-				<h2 class="text-sm font-medium text-zinc-300 mb-1">Backup codes</h2>
-				<p class="text-zinc-500 text-sm mb-3">
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-5">
+				<h2 class="text-sm font-medium text-stone-300 mb-1">Backup codes</h2>
+				<p class="text-stone-500 text-sm mb-3">
 					Generate a fresh set of single-use backup codes. Your old codes will be invalidated.
 				</p>
 
@@ -225,13 +225,13 @@
 					<button
 						type="button"
 						onclick={() => showRegenForm = true}
-						class="px-3 py-1.5 text-xs font-medium text-zinc-400 border border-zinc-700 rounded hover:text-zinc-200 hover:border-zinc-600 transition-colors"
+						class="px-3 py-1.5 text-xs font-medium text-stone-400 border border-stone-700 rounded hover:text-stone-200 hover:border-stone-600 transition-colors"
 					>
 						Regenerate backup codes…
 					</button>
 				{:else}
 					<form method="post" action="?/regenBackupCodes" use:enhance class="space-y-2">
-						<label for="regen-code" class="block text-xs text-zinc-500">
+						<label for="regen-code" class="block text-xs text-stone-500">
 							Confirm with your current TOTP code
 						</label>
 						<div class="flex items-center gap-2">
@@ -243,7 +243,7 @@
 								autocomplete="one-time-code"
 								maxlength="6"
 								placeholder="000000"
-								class="w-32 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 font-mono text-center focus:outline-none focus:border-sky-500"
+								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500"
 							/>
 							<button
 								type="submit"
@@ -254,7 +254,7 @@
 							<button
 								type="button"
 								onclick={() => showRegenForm = false}
-								class="text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+								class="text-xs text-stone-600 hover:text-stone-400 transition-colors"
 							>
 								Cancel
 							</button>

--- a/src/routes/admin/settings/mfa/+page.svelte
+++ b/src/routes/admin/settings/mfa/+page.svelte
@@ -124,7 +124,7 @@
 						autocomplete="one-time-code"
 						maxlength="6"
 						placeholder="000000"
-						class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+						class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 					/>
 				</div>
 				<div class="flex items-center gap-3">
@@ -200,7 +200,7 @@
 								autocomplete="one-time-code"
 								maxlength="8"
 								placeholder="000000"
-								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500"
+								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-amber-500"
 							/>
 							<button
 								type="submit"
@@ -243,7 +243,7 @@
 								autocomplete="one-time-code"
 								maxlength="6"
 								placeholder="000000"
-								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-sky-500"
+								class="w-32 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 font-mono text-center focus:outline-none focus:border-amber-500"
 							/>
 							<button
 								type="submit"

--- a/src/routes/admin/settings/password/+page.svelte
+++ b/src/routes/admin/settings/password/+page.svelte
@@ -57,7 +57,7 @@
 					type="password"
 					autocomplete="current-password"
 					required
-					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 				/>
 			</div>
 
@@ -70,7 +70,7 @@
 					autocomplete="new-password"
 					minlength="12"
 					required
-					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 				/>
 				<p class="text-stone-600 text-xs mt-1">At least 12 characters.</p>
 			</div>
@@ -84,7 +84,7 @@
 					autocomplete="new-password"
 					minlength="12"
 					required
-					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 				/>
 			</div>
 

--- a/src/routes/admin/settings/password/+page.svelte
+++ b/src/routes/admin/settings/password/+page.svelte
@@ -17,13 +17,13 @@
 </svelte:head>
 
 <div class="p-6 max-w-md">
-	<nav class="flex items-center gap-2 text-sm text-zinc-500 mb-5">
-		<span class="text-zinc-300">Settings</span>
+	<nav class="flex items-center gap-2 text-sm text-stone-500 mb-5">
+		<span class="text-stone-300">Settings</span>
 		<span>/</span>
-		<span class="text-zinc-300">Change Password</span>
+		<span class="text-stone-300">Change Password</span>
 	</nav>
 
-	<h1 class="text-xl font-semibold text-zinc-100 mb-6">Change Password</h1>
+	<h1 class="text-xl font-semibold text-stone-100 mb-6">Change Password</h1>
 
 	{#if form?.success}
 		<div class="mb-5 px-4 py-3 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-emerald-400 text-sm">
@@ -37,7 +37,7 @@
 		</div>
 	{/if}
 
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg p-5">
 		<form
 			method="post"
 			use:enhance={() => {
@@ -50,19 +50,19 @@
 			class="space-y-4"
 		>
 			<div>
-				<label for="current" class="block text-xs text-zinc-500 mb-1.5">Current password</label>
+				<label for="current" class="block text-xs text-stone-500 mb-1.5">Current password</label>
 				<input
 					id="current"
 					name="current"
 					type="password"
 					autocomplete="current-password"
 					required
-					class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 				/>
 			</div>
 
 			<div>
-				<label for="password" class="block text-xs text-zinc-500 mb-1.5">New password</label>
+				<label for="password" class="block text-xs text-stone-500 mb-1.5">New password</label>
 				<input
 					id="password"
 					name="password"
@@ -70,13 +70,13 @@
 					autocomplete="new-password"
 					minlength="12"
 					required
-					class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 				/>
-				<p class="text-zinc-600 text-xs mt-1">At least 12 characters.</p>
+				<p class="text-stone-600 text-xs mt-1">At least 12 characters.</p>
 			</div>
 
 			<div>
-				<label for="confirm" class="block text-xs text-zinc-500 mb-1.5">Confirm new password</label>
+				<label for="confirm" class="block text-xs text-stone-500 mb-1.5">Confirm new password</label>
 				<input
 					id="confirm"
 					name="confirm"
@@ -84,14 +84,14 @@
 					autocomplete="new-password"
 					minlength="12"
 					required
-					class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+					class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 				/>
 			</div>
 
 			<button
 				type="submit"
 				disabled={submitting}
-				class="w-full py-2.5 text-sm font-medium bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+				class="w-full py-2.5 text-sm font-medium bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
 			>
 				{submitting ? 'Updating…' : 'Update password'}
 			</button>

--- a/src/routes/admin/settings/sessions/+page.svelte
+++ b/src/routes/admin/settings/sessions/+page.svelte
@@ -27,16 +27,16 @@
 </svelte:head>
 
 <div class="p-6 max-w-2xl">
-	<nav class="flex items-center gap-2 text-sm text-zinc-500 mb-5">
-		<span class="text-zinc-300">Settings</span>
+	<nav class="flex items-center gap-2 text-sm text-stone-500 mb-5">
+		<span class="text-stone-300">Settings</span>
 		<span>/</span>
-		<span class="text-zinc-300">Sessions</span>
+		<span class="text-stone-300">Sessions</span>
 	</nav>
 
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Active Sessions</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Active Sessions</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{data.sessions.length} session{data.sessions.length !== 1 ? 's' : ''} for your account
 			</p>
 		</div>
@@ -62,41 +62,41 @@
 		</div>
 	{/if}
 
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg divide-y divide-zinc-800">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg divide-y divide-stone-800">
 		{#each data.sessions as session (session.id)}
 			<div class="px-4 py-4 flex items-start gap-3">
 				<!-- Browser icon -->
-				<div class="w-8 h-8 rounded-full bg-zinc-800 flex items-center justify-center flex-shrink-0 mt-0.5">
-					<svg class="w-4 h-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<div class="w-8 h-8 rounded-full bg-stone-800 flex items-center justify-center flex-shrink-0 mt-0.5">
+					<svg class="w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
 					</svg>
 				</div>
 
 				<div class="flex-1 min-w-0">
 					<div class="flex items-center gap-2 flex-wrap">
-						<p class="text-zinc-200 text-sm font-medium">
+						<p class="text-stone-200 text-sm font-medium">
 							{parseUA(session.user_agent)}
 						</p>
 						{#if session.isCurrent}
-							<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-sky-400 bg-sky-500/10">
+							<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-amber-400 bg-amber-500/10">
 								This session
 							</span>
 						{/if}
 					</div>
 
 					<div class="flex items-center gap-3 mt-0.5 flex-wrap">
-						<span class="text-zinc-500 text-xs">
+						<span class="text-stone-500 text-xs">
 							Active {formatDistanceToNow(new Date(session.last_activity_at), { addSuffix: true })}
 						</span>
-						<span class="text-zinc-700">·</span>
-						<span class="text-zinc-600 text-xs">
+						<span class="text-stone-700">·</span>
+						<span class="text-stone-600 text-xs">
 							Created {format(new Date(session.created_at), 'PPP')}
 						</span>
 					</div>
 				</div>
 			</div>
 		{:else}
-			<div class="px-4 py-8 text-center text-zinc-600 text-sm">No active sessions.</div>
+			<div class="px-4 py-8 text-center text-stone-600 text-sm">No active sessions.</div>
 		{/each}
 	</div>
 </div>

--- a/src/routes/admin/settings/site/+page.svelte
+++ b/src/routes/admin/settings/site/+page.svelte
@@ -92,7 +92,7 @@
 					value={threshold}
 					min="1"
 					max="20"
-					class="w-24 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20 tabular-nums"
+					class="w-24 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 tabular-nums"
 				/>
 			</div>
 			<button

--- a/src/routes/admin/settings/site/+page.svelte
+++ b/src/routes/admin/settings/site/+page.svelte
@@ -40,8 +40,8 @@
 
 <div class="p-6 max-w-2xl space-y-6">
 	<div>
-		<h1 class="text-xl font-semibold text-zinc-100">Site Settings</h1>
-		<p class="text-zinc-500 text-sm mt-0.5">App-wide configuration. Changes take effect immediately.</p>
+		<h1 class="text-xl font-semibold text-stone-100">Site Settings</h1>
+		<p class="text-stone-500 text-sm mt-0.5">App-wide configuration. Changes take effect immediately.</p>
 	</div>
 
 	{#if form?.error}
@@ -51,16 +51,16 @@
 	{/if}
 
 	<!-- Confirmation threshold -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg p-5">
 		<div class="mb-4">
-			<h2 class="text-sm font-medium text-zinc-200">Confirmation threshold</h2>
-			<p class="text-zinc-500 text-xs mt-1 leading-relaxed">
+			<h2 class="text-sm font-medium text-stone-200">Confirmation threshold</h2>
+			<p class="text-stone-500 text-xs mt-1 leading-relaxed">
 				How many independent reports from distinct IPs are required before a pothole goes live on
 				the public map. Raise this when data quality is high and engagement is strong; lower it
 				when you want more potholes to surface quickly.
 			</p>
 			{#if thresholdUpdatedAt}
-				<p class="text-zinc-700 text-xs mt-1">Last changed: {formatDate(thresholdUpdatedAt)}</p>
+				<p class="text-stone-700 text-xs mt-1">Last changed: {formatDate(thresholdUpdatedAt)}</p>
 			{/if}
 		</div>
 
@@ -81,7 +81,7 @@
 		>
 			<input type="hidden" name="key" value="confirmation_threshold" />
 			<div>
-				<label for="threshold" class="block text-xs text-zinc-500 mb-1.5">
+				<label for="threshold" class="block text-xs text-stone-500 mb-1.5">
 					Reports required
 				</label>
 				<input
@@ -92,20 +92,20 @@
 					value={threshold}
 					min="1"
 					max="20"
-					class="w-24 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20 tabular-nums"
+					class="w-24 bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20 tabular-nums"
 				/>
 			</div>
 			<button
 				type="submit"
-				class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+				class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 			>
 				Save
 			</button>
 		</form>
 
-		<div class="mt-4 pt-4 border-t border-zinc-800">
-			<p class="text-zinc-600 text-xs">
-				Current value: <span class="text-zinc-400 font-medium tabular-nums">{threshold}</span>
+		<div class="mt-4 pt-4 border-t border-stone-800">
+			<p class="text-stone-600 text-xs">
+				Current value: <span class="text-stone-400 font-medium tabular-nums">{threshold}</span>
 				confirmation{threshold !== 1 ? 's' : ''} required
 			</p>
 			<div class="flex gap-3 mt-2 flex-wrap">
@@ -115,8 +115,8 @@
 						onclick={() => { if (thresholdInputEl) thresholdInputEl.value = String(preset); }}
 						class="text-xs px-2 py-0.5 rounded border transition-colors
 						       {threshold === preset
-							? 'border-sky-500/50 text-sky-400 bg-sky-500/10'
-							: 'border-zinc-700 text-zinc-500 hover:text-zinc-300 hover:border-zinc-600'}"
+							? 'border-amber-500/50 text-amber-400 bg-amber-500/10'
+							: 'border-stone-700 text-stone-500 hover:text-stone-300 hover:border-stone-600'}"
 					>
 						{preset}
 					</button>
@@ -126,14 +126,14 @@
 	</div>
 
 	<!-- Pushover notifications -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-5 space-y-4">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg p-5 space-y-4">
 		<div>
-			<h2 class="text-sm font-medium text-zinc-200">Pushover notifications</h2>
-			<p class="text-zinc-500 text-xs mt-1 leading-relaxed">
+			<h2 class="text-sm font-medium text-stone-200">Pushover notifications</h2>
+			<p class="text-stone-500 text-xs mt-1 leading-relaxed">
 				Controls whether push notifications are sent via Pushover. The master switch must be on
 				for any notifications to fire. Individual categories can be muted independently.
-				Credentials (<code class="text-zinc-400">PUSHOVER_APP_TOKEN</code> /
-				<code class="text-zinc-400">PUSHOVER_USER_KEY</code>) must still be set in the environment.
+				Credentials (<code class="text-stone-400">PUSHOVER_APP_TOKEN</code> /
+				<code class="text-stone-400">PUSHOVER_USER_KEY</code>) must still be set in the environment.
 			</p>
 		</div>
 
@@ -141,7 +141,7 @@
 		{@render toggle('pushover_enabled', pushoverEnabled, 'All notifications', 'Send any Pushover notification')}
 
 		<!-- Per-category toggles -->
-		<div class="pl-4 border-l border-zinc-800 space-y-3" class:opacity-40={!pushoverEnabled} class:pointer-events-none={!pushoverEnabled}>
+		<div class="pl-4 border-l border-stone-800 space-y-3" class:opacity-40={!pushoverEnabled} class:pointer-events-none={!pushoverEnabled}>
 			{@render toggle('pushover_notify_photos', pushoverNotifyPhotos, 'Photo uploads', 'New photos awaiting moderation, including deferred reviews when SightEngine is down')}
 			{@render toggle('pushover_notify_community', pushoverNotifyCommunity, 'Community events', 'Pothole confirmed and live, pothole marked filled')}
 			{@render toggle('pushover_notify_security', pushoverNotifySecurity, 'Security & logins', 'Admin login events and login rate-limit alerts')}
@@ -171,14 +171,14 @@
 			class="w-full flex items-center justify-between gap-4 py-2 text-left group"
 		>
 			<div>
-				<p class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</p>
-				<p class="text-xs text-zinc-600 leading-relaxed">{description}</p>
+				<p class="text-sm text-stone-300 group-hover:text-stone-100 transition-colors">{label}</p>
+				<p class="text-xs text-stone-600 leading-relaxed">{description}</p>
 			</div>
 			<!-- Toggle pill -->
 			<div
 				class="relative shrink-0 w-10 h-5 rounded-full transition-colors {current
-					? 'bg-sky-600'
-					: 'bg-zinc-700'}"
+					? 'bg-amber-600'
+					: 'bg-stone-700'}"
 			>
 				<div
 					class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {current

--- a/src/routes/admin/signup/+page.svelte
+++ b/src/routes/admin/signup/+page.svelte
@@ -88,7 +88,7 @@
 									autocomplete="given-name"
 									value={form?.firstName ?? ''}
 									required
-									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 								/>
 							</div>
 							<div>
@@ -100,7 +100,7 @@
 									autocomplete="family-name"
 									value={form?.lastName ?? ''}
 									required
-									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 								/>
 							</div>
 						</div>
@@ -114,7 +114,7 @@
 								autocomplete="email"
 								value={form?.email ?? ''}
 								required
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 						</div>
 
@@ -127,7 +127,7 @@
 								autocomplete="new-password"
 								required
 								minlength="12"
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 							<p class="text-stone-600 text-xs mt-1">
 								At least 12 chars with uppercase, lowercase, number, and symbol.
@@ -144,7 +144,7 @@
 								type="password"
 								autocomplete="new-password"
 								required
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 						</div>
 
@@ -158,7 +158,7 @@
 								type="password"
 								autocomplete="off"
 								required
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 						</div>
 
@@ -213,7 +213,7 @@
 								autocomplete="given-name"
 								value={form?.firstName ?? ''}
 								required
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 						</div>
 						<div>
@@ -225,7 +225,7 @@
 								autocomplete="family-name"
 								value={form?.lastName ?? ''}
 								required
-								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 							/>
 						</div>
 					</div>
@@ -240,7 +240,7 @@
 							value={form?.email ?? data.invite.email ?? ''}
 							readonly={!!data.invite.email}
 							required
-							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20
 							       {data.invite.email ? 'opacity-60 cursor-not-allowed' : ''}"
 						/>
 						{#if data.invite.email}
@@ -257,7 +257,7 @@
 							autocomplete="new-password"
 							required
 							minlength="12"
-							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 						/>
 						<p class="text-stone-600 text-xs mt-1">
 							At least 12 chars with uppercase, lowercase, number, and symbol.
@@ -274,7 +274,7 @@
 							type="password"
 							autocomplete="new-password"
 							required
-							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20"
 						/>
 					</div>
 

--- a/src/routes/admin/signup/+page.svelte
+++ b/src/routes/admin/signup/+page.svelte
@@ -17,21 +17,21 @@
 	<title>Create Account — fillthehole.ca Admin</title>
 </svelte:head>
 
-<div class="min-h-screen bg-zinc-950 flex items-center justify-center px-4 py-12">
+<div class="min-h-screen bg-stone-950 flex items-center justify-center px-4 py-12">
 	<div class="w-full max-w-md">
 		<div class="mb-8 text-center">
-			<span class="text-sky-400 font-bold text-lg">fillthehole.ca</span>
-			<p class="text-zinc-500 text-sm mt-1">Admin Panel</p>
+			<span class="text-amber-400 font-bold text-lg">fillthehole.ca</span>
+			<p class="text-stone-500 text-sm mt-1">Admin Panel</p>
 		</div>
 
 		{#if form?.registered}
 			<!-- Success state -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center">
+			<div class="bg-stone-900 border border-stone-800 rounded-md p-8 text-center">
 				<div class="text-4xl mb-4">✅</div>
-				<h1 class="text-xl font-semibold text-zinc-100 mb-2">Account Created</h1>
-				<p class="text-zinc-400 text-sm leading-relaxed">
+				<h1 class="text-xl font-semibold text-stone-100 mb-2">Account Created</h1>
+				<p class="text-stone-400 text-sm leading-relaxed">
 					Your account has been created with the
-					<strong class="text-zinc-300 capitalize">{createdRole}</strong>
+					<strong class="text-stone-300 capitalize">{createdRole}</strong>
 					role.
 					{#if form.requiresActivation}
 						An administrator must activate it before you can log in.
@@ -41,15 +41,15 @@
 				</p>
 				<a
 					href="/admin/login"
-					class="inline-block mt-6 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+					class="inline-block mt-6 text-sm text-amber-400 hover:text-amber-300 transition-colors"
 				>
 					Go to login →
 				</a>
 			</div>
 		{:else if data.bootstrap}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-8">
-				<h1 class="text-xl font-semibold text-zinc-100 mb-1">Create first admin account</h1>
-				<p class="text-zinc-500 text-sm mb-6">
+			<div class="bg-stone-900 border border-stone-800 rounded-md p-8">
+				<h1 class="text-xl font-semibold text-stone-100 mb-1">Create first admin account</h1>
+				<p class="text-stone-500 text-sm mb-6">
 					Bootstrap mode is only available while no admin users exist.
 				</p>
 
@@ -80,7 +80,7 @@
 					>
 						<div class="grid grid-cols-2 gap-3">
 							<div>
-								<label for="firstName" class="block text-xs text-zinc-500 mb-1.5">First name</label>
+								<label for="firstName" class="block text-xs text-stone-500 mb-1.5">First name</label>
 								<input
 									id="firstName"
 									name="firstName"
@@ -88,11 +88,11 @@
 									autocomplete="given-name"
 									value={form?.firstName ?? ''}
 									required
-									class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 								/>
 							</div>
 							<div>
-								<label for="lastName" class="block text-xs text-zinc-500 mb-1.5">Last name</label>
+								<label for="lastName" class="block text-xs text-stone-500 mb-1.5">Last name</label>
 								<input
 									id="lastName"
 									name="lastName"
@@ -100,13 +100,13 @@
 									autocomplete="family-name"
 									value={form?.lastName ?? ''}
 									required
-									class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+									class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 								/>
 							</div>
 						</div>
 
 						<div>
-							<label for="email" class="block text-xs text-zinc-500 mb-1.5">Email</label>
+							<label for="email" class="block text-xs text-stone-500 mb-1.5">Email</label>
 							<input
 								id="email"
 								name="email"
@@ -114,12 +114,12 @@
 								autocomplete="email"
 								value={form?.email ?? ''}
 								required
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
 						</div>
 
 						<div>
-							<label for="password" class="block text-xs text-zinc-500 mb-1.5">Password</label>
+							<label for="password" class="block text-xs text-stone-500 mb-1.5">Password</label>
 							<input
 								id="password"
 								name="password"
@@ -127,15 +127,15 @@
 								autocomplete="new-password"
 								required
 								minlength="12"
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
-							<p class="text-zinc-600 text-xs mt-1">
+							<p class="text-stone-600 text-xs mt-1">
 								At least 12 chars with uppercase, lowercase, number, and symbol.
 							</p>
 						</div>
 
 						<div>
-							<label for="confirmPassword" class="block text-xs text-zinc-500 mb-1.5"
+							<label for="confirmPassword" class="block text-xs text-stone-500 mb-1.5"
 								>Confirm password</label
 							>
 							<input
@@ -144,12 +144,12 @@
 								type="password"
 								autocomplete="new-password"
 								required
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
 						</div>
 
 						<div>
-							<label for="bootstrapSecret" class="block text-xs text-zinc-500 mb-1.5"
+							<label for="bootstrapSecret" class="block text-xs text-stone-500 mb-1.5"
 								>Bootstrap secret</label
 							>
 							<input
@@ -158,14 +158,14 @@
 								type="password"
 								autocomplete="off"
 								required
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
 						</div>
 
 						<button
 							type="submit"
 							disabled={submitting}
-							class="w-full mt-2 py-2.5 px-4 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg text-sm transition-colors"
+							class="w-full mt-2 py-2.5 px-4 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg text-sm transition-colors"
 						>
 							{submitting ? 'Creating admin account…' : 'Create first admin account'}
 						</button>
@@ -174,11 +174,11 @@
 			</div>
 		{:else if data.invite}
 			<!-- Signup form -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-8">
-				<h1 class="text-xl font-semibold text-zinc-100 mb-1">Create your account</h1>
-				<p class="text-zinc-500 text-sm mb-6">
+			<div class="bg-stone-900 border border-stone-800 rounded-md p-8">
+				<h1 class="text-xl font-semibold text-stone-100 mb-1">Create your account</h1>
+				<p class="text-stone-500 text-sm mb-6">
 					You've been invited as a
-					<span class="text-zinc-300 font-medium capitalize">{data.invite.role}</span>.
+					<span class="text-stone-300 font-medium capitalize">{data.invite.role}</span>.
 				</p>
 
 				{#if form?.error}
@@ -205,7 +205,7 @@
 
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label for="firstName" class="block text-xs text-zinc-500 mb-1.5">First name</label>
+							<label for="firstName" class="block text-xs text-stone-500 mb-1.5">First name</label>
 							<input
 								id="firstName"
 								name="firstName"
@@ -213,11 +213,11 @@
 								autocomplete="given-name"
 								value={form?.firstName ?? ''}
 								required
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
 						</div>
 						<div>
-							<label for="lastName" class="block text-xs text-zinc-500 mb-1.5">Last name</label>
+							<label for="lastName" class="block text-xs text-stone-500 mb-1.5">Last name</label>
 							<input
 								id="lastName"
 								name="lastName"
@@ -225,13 +225,13 @@
 								autocomplete="family-name"
 								value={form?.lastName ?? ''}
 								required
-								class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+								class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 							/>
 						</div>
 					</div>
 
 					<div>
-						<label for="email" class="block text-xs text-zinc-500 mb-1.5">Email</label>
+						<label for="email" class="block text-xs text-stone-500 mb-1.5">Email</label>
 						<input
 							id="email"
 							name="email"
@@ -240,16 +240,16 @@
 							value={form?.email ?? data.invite.email ?? ''}
 							readonly={!!data.invite.email}
 							required
-							class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20
 							       {data.invite.email ? 'opacity-60 cursor-not-allowed' : ''}"
 						/>
 						{#if data.invite.email}
-							<p class="text-zinc-600 text-xs mt-1">Email locked to this invite.</p>
+							<p class="text-stone-600 text-xs mt-1">Email locked to this invite.</p>
 						{/if}
 					</div>
 
 					<div>
-						<label for="password" class="block text-xs text-zinc-500 mb-1.5">Password</label>
+						<label for="password" class="block text-xs text-stone-500 mb-1.5">Password</label>
 						<input
 							id="password"
 							name="password"
@@ -257,15 +257,15 @@
 							autocomplete="new-password"
 							required
 							minlength="12"
-							class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 						/>
-						<p class="text-zinc-600 text-xs mt-1">
+						<p class="text-stone-600 text-xs mt-1">
 							At least 12 chars with uppercase, lowercase, number, and symbol.
 						</p>
 					</div>
 
 					<div>
-						<label for="confirmPassword" class="block text-xs text-zinc-500 mb-1.5"
+						<label for="confirmPassword" class="block text-xs text-stone-500 mb-1.5"
 							>Confirm password</label
 						>
 						<input
@@ -274,14 +274,14 @@
 							type="password"
 							autocomplete="new-password"
 							required
-							class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
+							class="w-full bg-stone-800 border border-stone-700 rounded-lg px-3 py-2.5 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20"
 						/>
 					</div>
 
 					<button
 						type="submit"
 						disabled={submitting}
-						class="w-full mt-2 py-2.5 px-4 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg text-sm transition-colors"
+						class="w-full mt-2 py-2.5 px-4 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg text-sm transition-colors"
 					>
 						{submitting ? 'Creating account…' : 'Create account'}
 					</button>
@@ -289,13 +289,13 @@
 			</div>
 		{:else}
 			<!-- Invalid invite -->
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center">
+			<div class="bg-stone-900 border border-stone-800 rounded-md p-8 text-center">
 				<div class="text-4xl mb-4">⛔</div>
-				<h1 class="text-xl font-semibold text-zinc-100 mb-2">Invalid Invite</h1>
-				<p class="text-zinc-400 text-sm">
+				<h1 class="text-xl font-semibold text-stone-100 mb-2">Invalid Invite</h1>
+				<p class="text-stone-400 text-sm">
 					{data.error ?? 'This invite link is not valid.'}
 				</p>
-				<p class="text-zinc-600 text-xs mt-3">
+				<p class="text-stone-600 text-xs mt-3">
 					Ask an administrator to generate a new invite link.
 				</p>
 			</div>

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -114,7 +114,7 @@
 									<input type="hidden" name="userId" value={user.id} />
 									<select
 										name="role"
-										class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
+										class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-amber-500"
 									>
 										{#each ['admin', 'editor', 'viewer'] as r (r)}
 											<option value={r} selected={user.role === r}>{r}</option>

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -15,9 +15,9 @@
 			case 'admin':
 				return 'text-red-400 bg-red-500/10';
 			case 'editor':
-				return 'text-sky-400 bg-sky-500/10';
+				return 'text-amber-400 bg-amber-500/10';
 			default:
-				return 'text-zinc-400 bg-zinc-700/50';
+				return 'text-stone-400 bg-stone-700/50';
 		}
 	}
 </script>
@@ -30,14 +30,14 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Users</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Users</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{data.users.length} admin account{data.users.length !== 1 ? 's' : ''}
 			</p>
 		</div>
 		<a
 			href="/admin/users/invites"
-			class="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-sky-400 border border-sky-600/30 rounded hover:bg-sky-600/10 transition-colors"
+			class="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-amber-400 border border-amber-600/30 rounded hover:bg-amber-600/10 transition-colors"
 		>
 			<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path
@@ -66,34 +66,34 @@
 		</div>
 	{/if}
 
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+	<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
 		<div class="overflow-x-auto">
 		<table class="w-full text-sm min-w-[560px]">
 			<thead>
-				<tr class="border-b border-zinc-800 text-left">
-					<th class="px-4 py-3 text-zinc-500 font-medium">User</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">Role</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">Status</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">MFA</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">Sessions</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">Last login</th>
-					<th class="px-4 py-3 text-zinc-500 font-medium">Actions</th>
+				<tr class="border-b border-stone-800 text-left">
+					<th class="px-4 py-3 text-stone-500 font-medium">User</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">Role</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">Status</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">MFA</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">Sessions</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">Last login</th>
+					<th class="px-4 py-3 text-stone-500 font-medium">Actions</th>
 				</tr>
 			</thead>
-			<tbody class="divide-y divide-zinc-800">
+			<tbody class="divide-y divide-stone-800">
 				{#each data.users as user (user.id)}
 					{@const isSelf = user.id === data.currentUserId}
-					<tr class="hover:bg-zinc-800/30 transition-colors">
+					<tr class="hover:bg-stone-800/30 transition-colors">
 						<!-- Name + email -->
 						<td class="px-4 py-3">
-							<p class="text-zinc-200 font-medium">
+							<p class="text-stone-200 font-medium">
 								{user.first_name}
 								{user.last_name}
 								{#if isSelf}
-									<span class="text-xs text-zinc-500 font-normal">(you)</span>
+									<span class="text-xs text-stone-500 font-normal">(you)</span>
 								{/if}
 							</p>
-							<p class="text-zinc-500 text-xs mt-0.5">{user.email}</p>
+							<p class="text-stone-500 text-xs mt-0.5">{user.email}</p>
 						</td>
 
 						<!-- Role (with change form) -->
@@ -114,7 +114,7 @@
 									<input type="hidden" name="userId" value={user.id} />
 									<select
 										name="role"
-										class="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-sky-500"
+										class="bg-stone-800 border border-stone-700 rounded px-2 py-1 text-xs text-stone-200 focus:outline-none focus:border-sky-500"
 									>
 										{#each ['admin', 'editor', 'viewer'] as r (r)}
 											<option value={r} selected={user.role === r}>{r}</option>
@@ -122,7 +122,7 @@
 									</select>
 									<button
 										type="submit"
-										class="text-xs text-zinc-400 hover:text-zinc-100 transition-colors px-1 py-0.5"
+										class="text-xs text-stone-400 hover:text-stone-100 transition-colors px-1 py-0.5"
 										title="Save role"
 									>
 										Save
@@ -145,7 +145,7 @@
 								>
 							{:else}
 								<span
-									class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-zinc-400 bg-zinc-700/50"
+									class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-stone-400 bg-stone-700/50"
 									>Pending</span
 								>
 							{/if}
@@ -156,17 +156,17 @@
 							{#if user.totp_enabled}
 								<span class="text-emerald-400 text-xs">Enabled</span>
 							{:else}
-								<span class="text-zinc-600 text-xs">—</span>
+								<span class="text-stone-600 text-xs">—</span>
 							{/if}
 						</td>
 
 						<!-- Active sessions -->
-						<td class="px-4 py-3 text-zinc-400 tabular-nums text-xs">
+						<td class="px-4 py-3 text-stone-400 tabular-nums text-xs">
 							{user.activeSessions}
 						</td>
 
 						<!-- Last login -->
-						<td class="px-4 py-3 text-zinc-500 text-xs">
+						<td class="px-4 py-3 text-stone-500 text-xs">
 							{#if user.last_login_at}
 								{formatDistanceToNow(new Date(user.last_login_at), { addSuffix: true })}
 							{:else}
@@ -207,12 +207,12 @@
 
 									<!-- Revoke sessions -->
 									{#if user.activeSessions > 0}
-										<span class="text-zinc-700">·</span>
+										<span class="text-stone-700">·</span>
 										<form method="post" action="?/revokeAll" use:enhance>
 											<input type="hidden" name="userId" value={user.id} />
 											<button
 												type="submit"
-												class="text-xs text-zinc-500 hover:text-red-400 transition-colors"
+												class="text-xs text-stone-500 hover:text-red-400 transition-colors"
 												onclick={(e) => {
 													if (!confirm('Revoke all sessions for this user?')) e.preventDefault();
 												}}
@@ -223,7 +223,7 @@
 									{/if}
 								</div>
 							{:else}
-								<span class="text-zinc-700 text-xs">—</span>
+								<span class="text-stone-700 text-xs">—</span>
 							{/if}
 						</td>
 					</tr>

--- a/src/routes/admin/users/invites/+page.svelte
+++ b/src/routes/admin/users/invites/+page.svelte
@@ -31,9 +31,9 @@
 			case 'admin':
 				return 'text-red-400 bg-red-500/10';
 			case 'editor':
-				return 'text-sky-400 bg-sky-500/10';
+				return 'text-amber-400 bg-amber-500/10';
 			default:
-				return 'text-zinc-400 bg-zinc-700/50';
+				return 'text-stone-400 bg-stone-700/50';
 		}
 	}
 </script>
@@ -44,16 +44,16 @@
 
 <div class="p-6 max-w-4xl">
 	<!-- Breadcrumb -->
-	<nav class="flex items-center gap-2 text-sm text-zinc-500 mb-5">
-		<a href="/admin/users" class="hover:text-zinc-300 transition-colors">Users</a>
+	<nav class="flex items-center gap-2 text-sm text-stone-500 mb-5">
+		<a href="/admin/users" class="hover:text-stone-300 transition-colors">Users</a>
 		<span>/</span>
-		<span class="text-zinc-300">Invite Codes</span>
+		<span class="text-stone-300">Invite Codes</span>
 	</nav>
 
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-xl font-semibold text-zinc-100">Invite Codes</h1>
-			<p class="text-zinc-500 text-sm mt-0.5">
+			<h1 class="text-xl font-semibold text-stone-100">Invite Codes</h1>
+			<p class="text-stone-500 text-sm mt-0.5">
 				{activeInvites.length} active · {inactiveInvites.length} expired/used
 			</p>
 		</div>
@@ -75,15 +75,15 @@
 	{/if}
 
 	<!-- Create invite form -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-lg p-4 mb-6">
-		<h2 class="text-sm font-medium text-zinc-300 mb-3">Create Invite</h2>
+	<div class="bg-stone-900 border border-stone-800 rounded-lg p-4 mb-6">
+		<h2 class="text-sm font-medium text-stone-300 mb-3">Create Invite</h2>
 		<form method="post" action="?/createInvite" use:enhance class="flex items-end gap-3 flex-wrap">
 			<div>
-				<label for="role" class="block text-xs text-zinc-500 mb-1.5">Role</label>
+				<label for="role" class="block text-xs text-stone-500 mb-1.5">Role</label>
 				<select
 					id="role"
 					name="role"
-					class="bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
 				>
 					<option value="editor" selected>editor</option>
 					<option value="viewer">viewer</option>
@@ -91,34 +91,34 @@
 				</select>
 			</div>
 			<div class="flex-1 min-w-48">
-				<label for="email" class="block text-xs text-zinc-500 mb-1.5">
-					Restrict to email <span class="text-zinc-700">(optional)</span>
+				<label for="email" class="block text-xs text-stone-500 mb-1.5">
+					Restrict to email <span class="text-stone-700">(optional)</span>
 				</label>
 				<input
 					id="email"
 					name="email"
 					type="email"
 					placeholder="someone@example.com"
-					class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-sky-500"
+					class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500"
 				/>
 			</div>
 			<button
 				type="submit"
-				class="px-4 py-2 text-sm font-medium bg-sky-600 hover:bg-sky-500 text-white rounded transition-colors"
+				class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
 			>
 				Generate
 			</button>
 		</form>
-		<p class="text-zinc-600 text-xs mt-2">Codes expire in 7 days and are single-use.</p>
+		<p class="text-stone-600 text-xs mt-2">Codes expire in 7 days and are single-use.</p>
 	</div>
 
 	<!-- Active invites -->
 	{#if activeInvites.length > 0}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden mb-5">
-			<div class="px-4 py-3 border-b border-zinc-800">
-				<h2 class="text-sm font-medium text-zinc-300">Active</h2>
+		<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden mb-5">
+			<div class="px-4 py-3 border-b border-stone-800">
+				<h2 class="text-sm font-medium text-stone-300">Active</h2>
 			</div>
-			<div class="divide-y divide-zinc-800">
+			<div class="divide-y divide-stone-800">
 				{#each activeInvites as invite (invite.id)}
 					<div class="px-4 py-3 flex items-center gap-4 flex-wrap">
 						<div class="flex-1 min-w-0">
@@ -129,19 +129,19 @@
 									{invite.role}
 								</span>
 								{#if invite.email}
-									<span class="text-zinc-400 text-xs">→ {invite.email}</span>
+									<span class="text-stone-400 text-xs">→ {invite.email}</span>
 								{/if}
-								<span class="text-zinc-600 text-xs font-mono"
+								<span class="text-stone-600 text-xs font-mono"
 									>{invite.code.slice(0, 8)}…</span
 								>
 							</div>
 							<div class="flex items-center gap-3 mt-1">
-								<span class="text-zinc-600 text-xs">
+								<span class="text-stone-600 text-xs">
 									Expires {formatDistanceToNow(new Date(invite.expires_at), { addSuffix: true })}
 								</span>
 								{#if invite.creator}
-									<span class="text-zinc-700 text-xs">·</span>
-									<span class="text-zinc-600 text-xs">
+									<span class="text-stone-700 text-xs">·</span>
+									<span class="text-stone-600 text-xs">
 										by {invite.creator.first_name}
 										{invite.creator.last_name}
 									</span>
@@ -153,7 +153,7 @@
 							<button
 								type="button"
 								onclick={() => copyInviteUrl(invite.code)}
-								class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-sky-400 border border-sky-600/30 rounded hover:bg-sky-600/10 transition-colors"
+								class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-amber-400 border border-amber-600/30 rounded hover:bg-amber-600/10 transition-colors"
 							>
 								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path
@@ -169,7 +169,7 @@
 								<input type="hidden" name="id" value={invite.id} />
 								<button
 									type="submit"
-									class="px-3 py-1.5 text-xs text-zinc-500 hover:text-red-400 border border-zinc-800 hover:border-red-900/40 rounded transition-colors"
+									class="px-3 py-1.5 text-xs text-stone-500 hover:text-red-400 border border-stone-800 hover:border-red-900/40 rounded transition-colors"
 								>
 									Revoke
 								</button>
@@ -183,11 +183,11 @@
 
 	<!-- Expired / used invites -->
 	{#if inactiveInvites.length > 0}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
-			<div class="px-4 py-3 border-b border-zinc-800">
-				<h2 class="text-sm font-medium text-zinc-500">Expired / Used</h2>
+		<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
+			<div class="px-4 py-3 border-b border-stone-800">
+				<h2 class="text-sm font-medium text-stone-500">Expired / Used</h2>
 			</div>
-			<div class="divide-y divide-zinc-800">
+			<div class="divide-y divide-stone-800">
 				{#each inactiveInvites as invite (invite.id)}
 					<div class="px-4 py-3 flex items-center gap-4 opacity-60">
 						<div class="flex-1 min-w-0">
@@ -198,22 +198,22 @@
 									{invite.role}
 								</span>
 								{#if invite.email}
-									<span class="text-zinc-400 text-xs">→ {invite.email}</span>
+									<span class="text-stone-400 text-xs">→ {invite.email}</span>
 								{/if}
 							</div>
 							<div class="flex items-center gap-3 mt-1">
 								{#if invite.used_at && invite.used_by_user}
-									<span class="text-zinc-600 text-xs">
+									<span class="text-stone-600 text-xs">
 										Used by {invite.used_by_user.first_name}
 										{invite.used_by_user.last_name}
 										{formatDistanceToNow(new Date(invite.used_at), { addSuffix: true })}
 									</span>
 								{:else if invite.used_at}
-									<span class="text-zinc-600 text-xs">
+									<span class="text-stone-600 text-xs">
 										Used {formatDistanceToNow(new Date(invite.used_at), { addSuffix: true })}
 									</span>
 								{:else}
-									<span class="text-zinc-600 text-xs">
+									<span class="text-stone-600 text-xs">
 										Expired {format(new Date(invite.expires_at), 'PPP')}
 									</span>
 								{/if}

--- a/src/routes/admin/users/invites/+page.svelte
+++ b/src/routes/admin/users/invites/+page.svelte
@@ -83,7 +83,7 @@
 				<select
 					id="role"
 					name="role"
-					class="bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-sky-500"
+					class="bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 focus:outline-none focus:border-amber-500"
 				>
 					<option value="editor" selected>editor</option>
 					<option value="viewer">viewer</option>
@@ -99,7 +99,7 @@
 					name="email"
 					type="email"
 					placeholder="someone@example.com"
-					class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-sky-500"
+					class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-500"
 				/>
 			</div>
 			<button

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -405,7 +405,7 @@
 	<!-- Header -->
 	<div>
 		<div class="flex items-center justify-between mb-3">
-			<a href={pothole.status === 'reported' ? `/?focus=${pothole.id}&lat=${pothole.lat}&lng=${pothole.lng}` : '/'} class="inline-flex items-center gap-1.5 text-zinc-500 hover:text-zinc-300 text-sm transition-colors">
+			<a href={pothole.status === 'reported' ? `/?focus=${pothole.id}&lat=${pothole.lat}&lng=${pothole.lng}` : '/'} class="inline-flex items-center gap-1.5 text-stone-500 hover:text-stone-700 dark:hover:text-stone-300 text-sm transition-colors">
 				<Icon name="arrow-left" size={14} />
 				Back to map
 			</a>
@@ -414,17 +414,17 @@
 					onclick={handleWatch}
 					aria-pressed={watching}
 					aria-label={watching ? 'Remove from watchlist' : 'Add to watchlist'}
-					class="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg border transition-colors
+					class="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-md border transition-colors
 						{watching
-							? 'bg-sky-900/40 border-sky-700 text-sky-400 hover:bg-sky-900/60'
-							: 'bg-zinc-800 border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200'}"
+							? 'bg-amber-50 dark:bg-amber-900/30 border-amber-500 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/50'
+							: 'bg-stone-100 dark:bg-stone-800 border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400 hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-700 dark:hover:text-stone-200'}"
 				>
 					<Icon name={watching ? 'bookmark-filled' : 'bookmark'} size={13} class="shrink-0" />
 					{watching ? 'Watching' : 'Watch'}
 				</button>
 			{/if}
 		</div>
-		<h1 class="page-title text-2xl sm:text-3xl text-white">
+		<h1 class="page-title text-2xl sm:text-3xl text-stone-900 dark:text-white">
 			{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 		</h1>
 		<div class="flex items-center gap-2 mt-1.5">
@@ -432,38 +432,38 @@
 				<Icon name={info.icon} size={16} class={info.colorClass} />
 				<span class="font-semibold {info.colorClass}">{info.label}</span>
 			{/if}
-			<span class="text-zinc-700">·</span>
-			<span class="text-zinc-500 text-sm">Reported {fmt(pothole.created_at)}</span>
+			<span class="text-stone-300 dark:text-stone-600">·</span>
+			<span class="text-stone-500 dark:text-stone-400 text-sm">Reported {fmt(pothole.created_at)}</span>
 		</div>
 	</div>
 
 	{#if submitted}
-		<div class="bg-sky-950/40 border border-sky-800 rounded-xl p-5 space-y-3">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-5 space-y-3">
 			<div class="flex items-start gap-3">
-				<div class="shrink-0 p-2 rounded-lg bg-sky-500/10">
-					<Icon name="check-circle" size={18} class="text-sky-400" />
+				<div class="shrink-0 p-2">
+					<Icon name="check-circle" size={18} class="text-amber-500" />
 				</div>
 				<div class="space-y-1.5">
-					<h2 id="submitted-card-heading" class="text-base font-semibold text-white">Report received</h2>
+					<h2 id="submitted-card-heading" class="text-base font-semibold text-stone-900 dark:text-white">Report received</h2>
 					{#if pothole.status === 'pending'}
-						<p class="text-sm text-zinc-300">
+						<p class="text-sm text-stone-600 dark:text-stone-300">
 							Your report is saved and waiting for independent confirmation before it appears on the public map.
 						</p>
 						<div class="space-y-1">
-							<div class="h-1.5 bg-zinc-800 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="submitted-card-heading">
+							<div class="h-1.5 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="submitted-card-heading">
 								<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 							</div>
-							<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
+							<div class="flex items-center justify-between text-xs text-stone-500 dark:text-stone-400 tabular-nums">
 								<span>{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</span>
 								<span>{remainingConfirmations} more needed</span>
 							</div>
 						</div>
 					{:else if pothole.status === 'reported'}
-						<p class="text-sm text-zinc-300">
+						<p class="text-sm text-stone-600 dark:text-stone-300">
 							This pothole is now live on the public map. Share the link or report it officially to help it get fixed faster.
 						</p>
 					{:else}
-						<p class="text-sm text-zinc-300">
+						<p class="text-sm text-stone-600 dark:text-stone-300">
 							Your report was received. This page will track what happens next.
 						</p>
 					{/if}
@@ -474,14 +474,14 @@
 					href={officialCityLink?.href ?? '/about'}
 					target={officialCityLink ? '_blank' : undefined}
 					rel={officialCityLink ? 'noopener noreferrer' : undefined}
-					class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
+					class="inline-flex items-center justify-center gap-1.5 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 px-3 py-2 text-sm font-semibold text-stone-600 dark:text-stone-300 transition-colors hover:bg-stone-200 dark:hover:bg-stone-700 hover:text-stone-900 dark:hover:text-white"
 				>
 					<Icon name="external-link" size={13} class="shrink-0" />
 					{officialCityLink ? `File with ${officialCityLink.label}` : 'Official reporting links'}
 				</a>
 				<button
 					onclick={() => share(pothole.address, pothole.lat, pothole.lng)}
-					class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
+					class="inline-flex items-center justify-center gap-1.5 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 px-3 py-2 text-sm font-semibold text-stone-600 dark:text-stone-300 transition-colors hover:bg-stone-200 dark:hover:bg-stone-700 hover:text-stone-900 dark:hover:text-white"
 				>
 					<Icon name="clipboard" size={13} class="shrink-0" />
 					Copy link
@@ -492,21 +492,21 @@
 
 	<!-- Pending notice -->
 	{#if pothole.status === 'pending'}
-		<div class="bg-zinc-800/50 border border-zinc-700 rounded-xl p-4 space-y-3">
-			<p id="pending-notice-heading" class="flex items-center gap-2 text-zinc-300 font-semibold">
-				<Icon name="clock" size={16} class="text-zinc-400 shrink-0" />
+		<div class="bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<p id="pending-notice-heading" class="flex items-center gap-2 text-stone-600 dark:text-stone-300 font-semibold">
+				<Icon name="clock" size={16} class="text-stone-500 dark:text-stone-400 shrink-0" />
 				Awaiting confirmation
 			</p>
-			<p class="text-zinc-500 text-sm">
+			<p class="text-stone-500 dark:text-stone-400 text-sm">
 				This pothole needs independent reports from others physically at this location before
 				it appears on the public map.
 			</p>
 			<div class="space-y-1.5">
-				<div class="flex items-center justify-between text-xs text-zinc-500 tabular-nums">
+				<div class="flex items-center justify-between text-xs text-stone-500 dark:text-stone-400 tabular-nums">
 					<span>{pothole.confirmed_count} of {confirmationThreshold} confirmation{confirmationThreshold === 1 ? '' : 's'}</span>
 					<span>{remainingConfirmations} more needed</span>
 				</div>
-				<div class="h-2 bg-zinc-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="pending-notice-heading">
+				<div class="h-2 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={clampedConfirmationCount} aria-valuemin={0} aria-valuemax={confirmationThreshold} aria-labelledby="pending-notice-heading">
 					<div class="h-full bg-sky-500 rounded-full transition-all" style="width:{confirmationProgressPct}%"></div>
 				</div>
 			</div>
@@ -515,23 +515,23 @@
 
 	<!-- Status pipeline -->
 	{#if pothole.status !== 'pending' && pothole.status !== 'expired'}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4">
 			<div class="flex items-center justify-between text-sm">
 				{#each (['reported', 'filled'] as const) as s (s)}
 					{@const cfg = STATUS_CONFIG[s]}
 					{@const isCurrent = pothole.status === s}
 					{@const isPast = s === 'reported' || pothole.status === 'filled'}
 					<div class="flex flex-col items-center gap-1.5 flex-1">
-						<div class="transition-colors {isPast ? cfg.colorClass : 'text-zinc-700'}">
+						<div class="transition-colors {isPast ? cfg.colorClass : 'text-stone-300 dark:text-stone-600'}">
 							<Icon name={cfg.icon} size={22} />
 						</div>
-						<span class="text-xs {isCurrent ? 'text-white font-semibold' : isPast ? 'text-zinc-300' : 'text-zinc-600'}">{cfg.label}</span>
+						<span class="text-xs {isCurrent ? 'text-stone-900 dark:text-white font-semibold' : isPast ? 'text-stone-600 dark:text-stone-300' : 'text-stone-400 dark:text-stone-600'}">{cfg.label}</span>
 						{#if isCurrent}
 							<div class="w-1.5 h-1.5 rounded-full bg-sky-500"></div>
 						{/if}
 					</div>
 					{#if s !== 'filled'}
-						<div class="flex-1 h-px bg-zinc-700 self-center mb-6 max-w-12"></div>
+						<div class="flex-1 h-px bg-stone-200 dark:bg-stone-700 self-center mb-6 max-w-12"></div>
 					{/if}
 				{/each}
 			</div>
@@ -540,14 +540,14 @@
 
 	<!-- "I hit this" signal -->
 	{#if pothole.status === 'reported'}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4">
 			<div class="flex items-center justify-between gap-3">
 				<div class="space-y-0.5">
-					<p class="text-sm font-semibold text-zinc-300 flex items-center gap-1.5">
+					<p class="text-sm font-semibold text-stone-600 dark:text-stone-300 flex items-center gap-1.5">
 						<Icon name="zap" size={14} class="text-orange-400 shrink-0" />
 						Hit this pothole?
 					</p>
-					<p class="text-xs text-zinc-500">
+					<p class="text-xs text-stone-500 dark:text-stone-400">
 						{hitCount === 0 ? 'No hits recorded yet.' : `${hitCount} driver${hitCount === 1 ? '' : 's'} hit this.`}
 					</p>
 				</div>
@@ -555,10 +555,10 @@
 					onclick={recordHit}
 					disabled={hitSubmitted || hittingIt}
 					aria-label={hitSubmitted ? 'Hit already recorded' : 'Record that you hit this pothole'}
-					class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors
+					class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-semibold transition-colors
 						{hitSubmitted
 							? 'bg-orange-900/30 border border-orange-800/60 text-orange-400 cursor-default'
-							: 'bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-orange-600 hover:text-orange-400'}"
+							: 'bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 text-stone-600 dark:text-stone-300 hover:border-orange-600 hover:text-orange-400'}"
 				>
 					{#if hittingIt}
 						<Icon name="loader" size={13} class="animate-spin shrink-0" />
@@ -573,14 +573,14 @@
 
 	<!-- Fill notification -->
 	{#if pothole.status === 'reported' && fillNotifState !== 'unsupported'}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4">
 			<div class="flex items-center justify-between gap-3">
 				<div class="space-y-0.5">
-					<p class="text-sm font-semibold text-zinc-300 flex items-center gap-1.5">
-						<Icon name="bell" size={14} class="text-sky-400 shrink-0" />
+					<p class="text-sm font-semibold text-stone-600 dark:text-stone-300 flex items-center gap-1.5">
+						<Icon name="bell" size={14} class="text-amber-500 shrink-0" />
 						Get notified when filled
 					</p>
-					<p class="text-xs text-zinc-500">
+					<p class="text-xs text-stone-500 dark:text-stone-400">
 						{#if fillNotifState === 'subscribed'}
 							You'll get a push notification when this pothole is marked as fixed.
 						{:else if fillNotifState === 'denied'}
@@ -594,7 +594,7 @@
 					<button
 						onclick={subscribeFillNotification}
 						aria-label="Notify me when this pothole is filled"
-						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-sky-600 hover:text-sky-400"
+						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-semibold transition-colors bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 text-stone-600 dark:text-stone-300 hover:border-amber-500 hover:text-amber-500"
 					>
 						<Icon name="bell" size={13} class="shrink-0" />
 						Notify me
@@ -603,18 +603,18 @@
 					<button
 						onclick={unsubscribeFillNotification}
 						aria-label="Subscribed — tap to cancel fill notification"
-						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold transition-colors bg-sky-900/30 border border-sky-800/60 text-sky-400 hover:border-zinc-600 hover:text-zinc-300"
+						class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-semibold transition-colors bg-amber-50 dark:bg-amber-900/30 border border-amber-500 text-amber-600 dark:text-amber-400 hover:border-stone-400 dark:hover:border-stone-600 hover:text-stone-500 dark:hover:text-stone-300"
 					>
 						<Icon name="bell" size={13} class="shrink-0" />
 						Subscribed
 					</button>
 				{:else if fillNotifState === 'pending'}
-					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-zinc-500">
+					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-stone-500 dark:text-stone-400">
 						<Icon name="loader" size={13} class="animate-spin shrink-0" />
 						…
 					</span>
 				{:else if fillNotifState === 'denied'}
-					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-zinc-600 cursor-not-allowed">
+					<span class="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm text-stone-400 dark:text-stone-600 cursor-not-allowed">
 						<Icon name="bell-off" size={13} class="shrink-0" />
 						Blocked
 					</span>
@@ -626,32 +626,32 @@
 	<!-- Repeat pothole notice -->
 	{#if nearbyFilled.length > 0}
 		{@const mostRecent = nearbyFilled[0]}
-		<div class="bg-amber-950/30 border border-amber-800/50 rounded-xl p-4 space-y-1.5">
-			<div class="flex items-center gap-2 text-sm font-semibold text-amber-400">
+		<div class="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800/50 rounded-md p-4 space-y-1.5">
+			<div class="flex items-center gap-2 text-sm font-semibold text-amber-600 dark:text-amber-400">
 				<Icon name="alert-triangle" size={14} class="shrink-0" />
 				Recurring road issue
 			</div>
-			<p class="text-xs text-zinc-300 leading-relaxed">
+			<p class="text-xs text-stone-600 dark:text-stone-300 leading-relaxed">
 				A nearby pothole
 				{#if mostRecent.address}
-					at <span class="text-zinc-300">{mostRecent.address}</span>
+					at <span class="text-stone-600 dark:text-stone-300">{mostRecent.address}</span>
 				{/if}
-				was previously filled on <span class="text-zinc-300">{format(new Date(mostRecent.filled_at), 'MMM d, yyyy')}</span>
+				was previously filled on <span class="text-stone-600 dark:text-stone-300">{format(new Date(mostRecent.filled_at), 'MMM d, yyyy')}</span>
 				— this location may need a permanent repair.
 			</p>
-			<p class="text-xs text-zinc-600">
+			<p class="text-xs text-stone-400 dark:text-stone-600">
 				{nearbyFilled.length === 1 ? '1 prior fill' : `${nearbyFilled.length} prior fills`} recorded within 110 m of this spot.
 			</p>
 		</div>
 	{/if}
 
 	{#if pothole.status !== 'filled'}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="flag" size={14} class="text-sky-400 shrink-0" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+				<Icon name="flag" size={14} class="text-amber-500 shrink-0" />
 				Report it officially too
 			</div>
-			<p class="text-zinc-300 text-sm">
+			<p class="text-stone-600 dark:text-stone-300 text-sm">
 				This page creates public visibility. Reporting it to the road owner through official channels can help start their repair or claims process.
 			</p>
 			<div class="grid gap-2 sm:grid-cols-2">
@@ -660,7 +660,7 @@
 						href={officialCityLink.href}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-sky-700 px-3 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-sky-600"
+						class="inline-flex items-center justify-center gap-1.5 rounded-md bg-amber-500 hover:bg-amber-600 px-3 py-2.5 text-sm font-semibold text-white transition-colors"
 					>
 						<Icon name="external-link" size={13} class="shrink-0" />
 						File with {officialCityLink.label}
@@ -670,13 +670,13 @@
 					href={REGION_REPORT_LINK.href}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2.5 text-sm font-semibold text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
+					class="inline-flex items-center justify-center gap-1.5 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 px-3 py-2.5 text-sm font-semibold text-stone-600 dark:text-stone-300 transition-colors hover:bg-stone-200 dark:hover:bg-stone-700 hover:text-stone-900 dark:hover:text-white"
 				>
 					<Icon name="external-link" size={13} class="shrink-0" />
 					Submit a claim — {REGION_REPORT_LINK.label}
 				</a>
 			</div>
-			<div class="rounded-lg bg-zinc-800/80 p-3 text-xs text-zinc-300 leading-relaxed space-y-1.5">
+			<div class="rounded-md bg-stone-100 dark:bg-stone-800 p-3 text-xs text-stone-600 dark:text-stone-300 leading-relaxed space-y-1.5">
 				<p>
 					Local residential streets usually belong to the city. Major roads like King, Weber, Victoria, and Erb are often Regional roads.
 				</p>
@@ -686,7 +686,7 @@
 						href={MTO_REPORT_LINK.href}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="text-sky-400 underline underline-offset-2 hover:text-sky-300"
+						class="text-amber-500 underline underline-offset-2 hover:text-amber-600"
 					>
 						Report those to the Ontario Ministry of Transportation
 					</a>.
@@ -697,16 +697,16 @@
 
 	<!-- Photos -->
 	{#if photos.length > 0}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="camera" size={14} class="text-sky-400 shrink-0" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+				<Icon name="camera" size={14} class="text-amber-500 shrink-0" />
 				{photos.length === 1 ? 'Photo' : 'Photos'}
 			</div>
 			<div class="grid grid-cols-2 gap-2">
 				{#each photos as photo, i (photo.id)}
 					<button
 						onclick={() => openLightbox(i)}
-						class="block rounded-lg overflow-hidden ring-1 ring-zinc-700 hover:ring-sky-500 transition-shadow cursor-zoom-in"
+						class="block rounded-md overflow-hidden ring-1 ring-stone-200 dark:ring-stone-700 hover:ring-amber-500 transition-shadow cursor-zoom-in"
 						aria-label="View photo {i + 1} of {photos.length}"
 					>
 						<img
@@ -721,19 +721,19 @@
 			</div>
 		</div>
 	{:else if canUploadPhoto}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="camera" size={14} class="text-sky-400 shrink-0" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+				<Icon name="camera" size={14} class="text-amber-500 shrink-0" />
 				Photo
 			</div>
 			{#if photoPreview}
 				<div class="relative">
-					<img src={photoPreview} alt="Selected pothole preview" class="w-full rounded-lg object-cover aspect-video" />
+					<img src={photoPreview} alt="Selected pothole preview" class="w-full rounded-md object-cover aspect-video" />
 					<button
 						type="button"
 						onclick={clearPhoto}
 						aria-label="Remove photo"
-						class="absolute top-2 right-2 bg-zinc-900/80 hover:bg-zinc-900 rounded-full p-1.5 text-zinc-400 hover:text-white transition-colors"
+						class="absolute top-2 right-2 bg-stone-900/80 hover:bg-stone-900 rounded-full p-1.5 text-stone-300 hover:text-white transition-colors"
 					>
 						<Icon name="x" size={14} />
 					</button>
@@ -741,7 +741,7 @@
 				<button
 					onclick={uploadPhoto}
 					disabled={uploadingPhoto}
-					class="w-full py-2.5 bg-sky-700 hover:bg-sky-600 disabled:bg-zinc-700 disabled:text-zinc-500 text-white font-semibold rounded-lg text-sm transition-colors flex items-center justify-center gap-1.5"
+					class="w-full py-2.5 bg-amber-500 hover:bg-amber-600 disabled:bg-stone-200 dark:disabled:bg-stone-700 disabled:text-stone-400 dark:disabled:text-stone-500 text-white font-semibold rounded-md text-sm transition-colors flex items-center justify-center gap-1.5"
 				>
 					{#if uploadingPhoto}
 						<Icon name="loader" size={13} class="animate-spin shrink-0" />
@@ -755,7 +755,7 @@
 				<button
 					type="button"
 					onclick={() => photoInput?.click()}
-					class="w-full py-3 rounded-lg border-2 border-dashed border-zinc-700 hover:border-sky-500 hover:bg-sky-500/5 text-zinc-400 hover:text-sky-400 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
+					class="w-full py-3 rounded-md border-2 border-dashed border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-50 dark:hover:bg-amber-500/5 text-stone-400 hover:text-amber-500 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
 				>
 					<Icon name="camera" size={15} class="shrink-0" />
 					Add a photo
@@ -771,18 +771,18 @@
 				aria-label="Upload a pothole photo"
 				onchange={handlePhotoSelect}
 			/>
-			<p class="text-xs text-zinc-500">Photos are reviewed before appearing publicly. Only snap one if you're safely off the road.</p>
+			<p class="text-xs text-stone-500 dark:text-stone-400">Photos are reviewed before appearing publicly. Only snap one if you're safely off the road.</p>
 		</div>
 	{/if}
 
 	<!-- Info -->
 	{#if pothole.description || pothole.filled_at}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-2 text-sm">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-2 text-sm">
 			{#if pothole.description}
-				<p class="text-zinc-300 italic">"{pothole.description}"</p>
+				<p class="text-stone-600 dark:text-stone-300 italic">"{pothole.description}"</p>
 			{/if}
 			{#if pothole.filled_at}
-				<p class="text-zinc-500">Filled on <span class="text-zinc-300">{fmt(pothole.filled_at)}</span></p>
+				<p class="text-stone-500 dark:text-stone-400">Filled on <span class="text-stone-700 dark:text-stone-200">{fmt(pothole.filled_at)}</span></p>
 			{/if}
 		</div>
 	{/if}
@@ -792,27 +792,27 @@
 		{#if !showFilledForm}
 			<button
 				onclick={() => (showFilledForm = true)}
-				class="w-full py-3 bg-green-700 hover:bg-green-600 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+				class="w-full py-3 bg-green-700 hover:bg-green-600 text-white font-bold rounded-md transition-colors flex items-center justify-center gap-2"
 			>
 				<Icon name="check-circle" size={16} class="shrink-0" />
 				Mark as filled
 			</button>
 		{:else}
-			<div class="bg-zinc-900 border border-green-800 rounded-xl p-4 space-y-3">
-				<h3 class="flex items-center gap-2 font-semibold text-green-400">
+			<div class="bg-white dark:bg-stone-900 border border-green-600 dark:border-green-800 rounded-md p-4 space-y-3">
+				<h3 class="flex items-center gap-2 font-semibold text-green-600 dark:text-green-400">
 					<Icon name="check-circle" size={15} class="shrink-0" />
 					It's been filled!
 				</h3>
-				<p class="text-zinc-300 text-sm">Confirm the city has patched this one up.</p>
+				<p class="text-stone-600 dark:text-stone-300 text-sm">Confirm the city has patched this one up.</p>
 				<div class="flex gap-2">
 					<button
 						onclick={() => (showFilledForm = false)}
-						class="flex-1 py-2 border border-zinc-700 text-zinc-300 rounded-lg text-sm hover:border-zinc-500 transition-colors"
+						class="flex-1 py-2 border border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-300 rounded-md text-sm hover:border-stone-400 dark:hover:border-stone-500 transition-colors"
 					>Cancel</button>
 					<button
 						onclick={markFilled}
 						disabled={submitting}
-						class="flex-1 py-2 bg-green-700 hover:bg-green-600 disabled:bg-zinc-700 disabled:text-zinc-500 text-white font-semibold rounded-lg text-sm transition-colors flex items-center justify-center gap-1.5"
+						class="flex-1 py-2 bg-green-700 hover:bg-green-600 disabled:bg-stone-200 dark:disabled:bg-stone-700 disabled:text-stone-400 dark:disabled:text-stone-500 text-white font-semibold rounded-md text-sm transition-colors flex items-center justify-center gap-1.5"
 					>
 						{#if submitting}
 							<Icon name="loader" size={13} class="animate-spin shrink-0" />
@@ -828,23 +828,23 @@
 	{/if}
 
 	{#if pothole.status === 'filled'}
-		<div class="bg-green-900/20 border border-green-800/60 rounded-xl p-5 text-center">
+		<div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/60 rounded-md p-5 text-center">
 			<div class="flex justify-center mb-3">
-				<Icon name="check-circle" size={36} class="text-green-400" />
+				<Icon name="check-circle" size={36} class="text-green-500 dark:text-green-400" />
 			</div>
-			<p class="text-green-300 font-semibold">This pothole has been filled!</p>
-			<p class="text-zinc-300 text-sm mt-1">The city responded. Accountability worked.</p>
+			<p class="text-green-700 dark:text-green-300 font-semibold">This pothole has been filled!</p>
+			<p class="text-stone-600 dark:text-stone-300 text-sm mt-1">The city responded. Accountability worked.</p>
 		</div>
 	{/if}
 
 	<!-- Expired state -->
 	{#if pothole.status === 'expired'}
-		<div class="bg-zinc-800/50 border border-zinc-700 rounded-xl p-4 text-center space-y-1">
+		<div class="bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-md p-4 text-center space-y-1">
 			<div class="flex justify-center mb-2">
-				<Icon name="clock" size={36} class="text-zinc-500" />
+				<Icon name="clock" size={36} class="text-stone-400 dark:text-stone-500" />
 			</div>
-			<p class="text-zinc-300 font-semibold">This report has expired</p>
-			<p class="text-zinc-500 text-sm mt-1">
+			<p class="text-stone-600 dark:text-stone-300 font-semibold">This report has expired</p>
+			<p class="text-stone-500 dark:text-stone-400 text-sm mt-1">
 				No activity for 3+ months. The pothole may have been filled — or may still be there.
 			</p>
 		</div>
@@ -854,31 +854,31 @@
 	{#if pothole.status === 'reported'}
 		{@const days = daysSince(pothole.created_at)}
 		{#if days !== null && days > 0}
-			<p class="text-center text-zinc-500 text-sm">
-				Reported <span class="text-orange-400 font-semibold tabular-nums">{days} day{days === 1 ? '' : 's'} ago</span> — still unfilled.
+			<p class="text-center text-stone-500 dark:text-stone-400 text-sm">
+				Reported <span class="text-orange-500 dark:text-orange-400 font-semibold tabular-nums">{days} day{days === 1 ? '' : 's'} ago</span> — still unfilled.
 			</p>
 		{/if}
 	{/if}
 
 	<!-- City repair requests (Kitchener CCC data) -->
 	{#if cityRepairRequests.length > 0}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="flag" size={14} class="text-sky-400 shrink-0" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+				<Icon name="flag" size={14} class="text-amber-500 shrink-0" />
 				City repair {cityRepairRequests.length === 1 ? 'request' : 'requests'} on file
 			</div>
-			<p class="text-zinc-300 text-sm">
+			<p class="text-stone-600 dark:text-stone-300 text-sm">
 				Kitchener's 311 system has
-				<span class="text-white font-semibold">{cityRepairRequests.length} official pothole repair {cityRepairRequests.length === 1 ? 'request' : 'requests'}</span>
+				<span class="text-stone-900 dark:text-white font-semibold">{cityRepairRequests.length} official pothole repair {cityRepairRequests.length === 1 ? 'request' : 'requests'}</span>
 				logged within 200 m of this location.
 			</p>
 			<ul class="space-y-1.5">
 				{#each cityRepairRequests as req (req.date + req.intersection)}
-					<li class="flex items-start gap-2 text-xs text-zinc-300">
-						<Icon name="clock" size={12} class="text-zinc-600 shrink-0 mt-0.5" />
+					<li class="flex items-start gap-2 text-xs text-stone-600 dark:text-stone-300">
+						<Icon name="clock" size={12} class="text-stone-400 dark:text-stone-600 shrink-0 mt-0.5" />
 						<span>
-							<span class="text-zinc-300">{req.intersection}</span>
-							<span class="text-zinc-600 ml-1.5 tabular-nums">{fmt(req.date)}</span>
+							<span class="text-stone-600 dark:text-stone-300">{req.intersection}</span>
+							<span class="text-stone-400 dark:text-stone-600 ml-1.5 tabular-nums">{fmt(req.date)}</span>
 						</span>
 					</li>
 				{/each}
@@ -888,18 +888,18 @@
 
 	<!-- Councillor contact -->
 	{#if councillor && pothole.status !== 'filled'}
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="mail" size={14} class="text-sky-400 shrink-0" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+				<Icon name="mail" size={14} class="text-amber-500 shrink-0" />
 				Contact your councillor
 			</div>
-			<p class="text-zinc-300 text-sm">
-				{councillor.city.charAt(0).toUpperCase() + councillor.city.slice(1)}, Ward {councillor.ward} — <span class="text-white">{councillor.name}</span>
+			<p class="text-stone-600 dark:text-stone-300 text-sm">
+				{councillor.city.charAt(0).toUpperCase() + councillor.city.slice(1)}, Ward {councillor.ward} — <span class="text-stone-900 dark:text-white">{councillor.name}</span>
 			</p>
 			<div class="flex flex-wrap gap-2">
 				<a
 					href={getPotholeEmailUrl(councillor, pothole)}
-					class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+					class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white text-sm rounded-md transition-colors"
 				>
 					<Icon name="mail" size={13} class="shrink-0" />
 					Email {councillor.name.split(' ')[0]}
@@ -908,7 +908,7 @@
 					href={councillor.url}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+					class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white text-sm rounded-md transition-colors"
 				>
 					<Icon name="external-link" size={13} class="shrink-0" />
 					Councillor page
@@ -918,9 +918,9 @@
 	{/if}
 
 	<!-- Links -->
-	<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-		<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-			<Icon name="share-2" size={14} class="text-zinc-400 shrink-0" />
+	<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+		<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
+			<Icon name="share-2" size={14} class="text-stone-500 dark:text-stone-400 shrink-0" />
 			Share & links
 		</div>
 		<div class="flex flex-wrap gap-2">
@@ -928,14 +928,14 @@
 				href={streetViewUrl(pothole.lat, pothole.lng)}
 				target="_blank"
 				rel="noopener noreferrer"
-				class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+				class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white text-sm rounded-md transition-colors"
 			>
 				<Icon name="map" size={13} class="shrink-0" />
 				Street View
 			</a>
 			<button
 				onclick={() => share(pothole.address, pothole.lat, pothole.lng)}
-				class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+				class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white text-sm rounded-md transition-colors"
 			>
 				<Icon name="clipboard" size={13} class="shrink-0" />
 				Copy link
@@ -961,7 +961,7 @@
 			bind:this={lightboxCloseBtn}
 			onclick={(e) => { e.stopPropagation(); closeLightbox(); }}
 			aria-label="Close photo viewer"
-			class="absolute top-4 right-4 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+			class="absolute top-4 right-4 p-2 rounded-md bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
 		>
 			<Icon name="x" size={20} />
 		</button>
@@ -971,7 +971,7 @@
 			<button
 				onclick={(e) => { e.stopPropagation(); prevPhoto(); }}
 				aria-label="Previous photo"
-				class="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+				class="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-md bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
 			>
 				<Icon name="arrow-left" size={20} />
 			</button>
@@ -984,7 +984,7 @@
 					<img
 						src={photo.url}
 						alt="Pothole at {pothole.address || 'this location'} — photo {i + 1} of {photos.length}"
-						class="max-w-full max-h-[90vh] object-contain rounded-lg shadow-2xl"
+						class="max-w-full max-h-[90vh] object-contain rounded-md shadow-2xl"
 						class:hidden={i !== lightboxIndex}
 						aria-hidden={i !== lightboxIndex}
 					/>
@@ -997,7 +997,7 @@
 			<button
 				onclick={(e) => { e.stopPropagation(); nextPhoto(); }}
 				aria-label="Next photo"
-				class="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
+				class="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-md bg-zinc-800/80 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors z-10"
 			>
 				<Icon name="arrow-right" size={20} />
 			</button>

--- a/src/routes/how-to/+page.svelte
+++ b/src/routes/how-to/+page.svelte
@@ -9,32 +9,32 @@
 
 <div class="max-w-2xl mx-auto px-4 py-12 space-y-10">
 	<div>
-		<h1 class="page-title text-4xl sm:text-5xl text-white mb-2">How to use</h1>
-		<p class="page-intro text-zinc-400 text-lg">Everything you can do on FillTheHole.ca.</p>
+		<h1 class="page-title text-4xl sm:text-5xl text-stone-900 dark:text-white mb-2">How to use</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-lg">Everything you can do on FillTheHole.ca.</p>
 	</div>
 
 	<!-- Reading the map -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="map" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="map" size={18} class="text-amber-500 shrink-0" />
 			Reading the map
 		</h2>
-		<div class="space-y-3 text-sm text-zinc-400 leading-relaxed">
+		<div class="space-y-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			<p>
 				The map shows every active pothole in Waterloo Region. Pins are colour-coded by status:
 			</p>
 			<div class="grid gap-2">
-				<div class="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3">
+				<div class="flex items-center gap-3 border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3">
 					<span class="w-3 h-3 rounded-full bg-orange-500 shrink-0"></span>
-					<span><strong class="text-zinc-200">Orange</strong> — reported and confirmed, waiting for the city to fix it</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Orange</strong> — reported and confirmed, waiting for the city to fix it</span>
 				</div>
-				<div class="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3">
+				<div class="flex items-center gap-3 border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3">
 					<span class="w-3 h-3 rounded-full bg-green-500 shrink-0"></span>
-					<span><strong class="text-zinc-200">Green</strong> — filled! The city patched it</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Green</strong> — filled! The city patched it</span>
 				</div>
-				<div class="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3">
+				<div class="flex items-center gap-3 border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3">
 					<span class="w-3 h-3 rounded-full bg-zinc-500 shrink-0"></span>
-					<span><strong class="text-zinc-200">Grey</strong> — expired after 90 days with no fill event</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Grey</strong> — expired after 90 days with no fill event</span>
 				</div>
 			</div>
 			<p>
@@ -42,7 +42,7 @@
 				the cluster to expand it and see individual pins.
 			</p>
 			<p>
-				Toggle the <strong class="text-zinc-200">ward heatmap</strong> from the map controls to see
+				Toggle the <strong class="text-stone-700 dark:text-stone-200">ward heatmap</strong> from the map controls to see
 				pothole density by ward. Hover a ward to see the councillor's name and the active hole count.
 			</p>
 		</div>
@@ -50,7 +50,7 @@
 
 	<!-- Reporting -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
 			<Icon name="map-pin" size={18} class="text-orange-400 shrink-0" />
 			Reporting a pothole
 		</h2>
@@ -64,24 +64,24 @@
 			</p>
 		</div>
 
-		<div class="space-y-3 text-sm text-zinc-400 leading-relaxed">
-			<p>Tap <strong class="text-zinc-200">Report a pothole</strong> in the top-right corner.</p>
+		<div class="space-y-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+			<p>Tap <strong class="text-stone-700 dark:text-stone-200">Report a pothole</strong> in the top-right corner.</p>
 			<ol class="space-y-3 list-none">
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">1</span>
-					<span><strong class="text-zinc-200">Lock your location.</strong> Tap the crosshair icon to use your device's GPS, or search by address and drop a pin manually.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Lock your location.</strong> Tap the crosshair icon to use your device's GPS, or search by address and drop a pin manually.</span>
 				</li>
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">2</span>
-					<span><strong class="text-zinc-200">Pick severity</strong> (optional). Minor, Moderate, Severe, or Hazardous. This helps prioritise which holes need attention first.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Pick severity</strong> (optional). Minor, Moderate, Severe, or Hazardous. This helps prioritise which holes need attention first.</span>
 				</li>
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">3</span>
-					<span><strong class="text-zinc-200">Attach a photo</strong> (optional). Photos are compressed automatically. They go through moderation before appearing publicly.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Attach a photo</strong> (optional). Photos are compressed automatically. They go through moderation before appearing publicly.</span>
 				</li>
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">4</span>
-					<span><strong class="text-zinc-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation from a different location before it shows up on the public map.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation from a different location before it shows up on the public map.</span>
 				</li>
 			</ol>
 		</div>
@@ -89,17 +89,17 @@
 
 	<!-- Confirming -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="check-circle" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="check-circle" size={18} class="text-amber-500 shrink-0" />
 			Confirming others' reports
 		</h2>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			Walk past a pothole that's already been reported nearby? Submit another report at the same
 			location — the app will detect the match and count your submission as a confirmation.
 			Once a pothole reaches the confirmation threshold (default: 2 independent reports), it
 			goes live on the public map.
 		</p>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			Each IP address can only confirm a given pothole once, so duplicate taps from the same device
 			won't inflate the count.
 		</p>
@@ -107,16 +107,16 @@
 
 	<!-- Watchlist -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="bookmark" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="bookmark" size={18} class="text-amber-500 shrink-0" />
 			Watchlist
 		</h2>
-		<p class="text-sm text-zinc-400 leading-relaxed">
-			On any pothole detail page, tap <strong class="text-zinc-200">Watch this hole</strong> to save
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+			On any pothole detail page, tap <strong class="text-stone-700 dark:text-stone-200">Watch this hole</strong> to save
 			it to your watchlist. Watched holes appear in a section on the homepage so you can quickly
 			see whether they've been filled.
 		</p>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			Your watchlist is stored in your browser's local storage — no account needed,
 			but it only persists on the device and browser you used to save it.
 		</p>
@@ -124,70 +124,70 @@
 
 	<!-- Pothole detail page -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="info" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="info" size={18} class="text-amber-500 shrink-0" />
 			Pothole detail page
 		</h2>
-		<div class="space-y-3 text-sm text-zinc-400 leading-relaxed">
+		<div class="space-y-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			<p>Tap any pin on the map, or the pothole list, to open its detail page. From there you can:</p>
 			<ul class="space-y-2 list-none">
 				<li class="flex gap-2.5">
 					<Icon name="zap" size={15} class="text-sky-400 shrink-0 mt-0.5" />
-					<span><strong class="text-zinc-200">I hit this</strong> — signal that you physically drove over the pothole. Hit counts are shown publicly and help surface the most dangerous holes.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">I hit this</strong> — signal that you physically drove over the pothole. Hit counts are shown publicly and help surface the most dangerous holes.</span>
 				</li>
 				<li class="flex gap-2.5">
 					<Icon name="check-circle" size={15} class="text-green-400 shrink-0 mt-0.5" />
-					<span><strong class="text-zinc-200">Mark as filled</strong> — if you can see the city has patched it, let the community know.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Mark as filled</strong> — if you can see the city has patched it, let the community know.</span>
 				</li>
 				<li class="flex gap-2.5">
 					<Icon name="mail" size={15} class="text-sky-400 shrink-0 mt-0.5" />
-					<span><strong class="text-zinc-200">Contact your councillor</strong> — each pothole shows the ward councillor's name and a direct email link pre-filled with the pothole address.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Contact your councillor</strong> — each pothole shows the ward councillor's name and a direct email link pre-filled with the pothole address.</span>
 				</li>
 				<li class="flex gap-2.5">
 					<Icon name="share-2" size={15} class="text-sky-400 shrink-0 mt-0.5" />
-					<span><strong class="text-zinc-200">Share</strong> — every pothole has a permanent URL. Share it to Reddit, Bluesky, Facebook, or copy the link to send directly.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Share</strong> — every pothole has a permanent URL. Share it to Reddit, Bluesky, Facebook, or copy the link to send directly.</span>
 				</li>
 			</ul>
-			<p class="text-xs text-zinc-500 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3">
+			<p class="text-xs text-stone-600 dark:text-stone-400 border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3">
 				If a pothole was recently filled nearby once before and re-opened, the detail page will flag it
-				as a <strong class="text-zinc-400">repeat pothole</strong> — useful for escalating recurring road issues to the city.
+				as a <strong class="text-stone-600 dark:text-stone-400">repeat pothole</strong> — useful for escalating recurring road issues to the city.
 			</p>
 		</div>
 	</section>
 
 	<!-- Status meanings -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="layers" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="layers" size={18} class="text-amber-500 shrink-0" />
 			Pothole statuses
 		</h2>
 		<div class="grid gap-2 text-sm">
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3 flex gap-3 items-start">
+			<div class="border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3 flex gap-3 items-start">
 				<span class="w-2.5 h-2.5 rounded-full bg-zinc-500 shrink-0 mt-1.5"></span>
 				<div>
-					<div class="font-semibold text-zinc-200">Pending</div>
-					<p class="text-zinc-500 mt-0.5">Only one report so far. Not yet on the public map. Expires in 14 days if no confirmation arrives.</p>
+					<div class="font-semibold text-stone-700 dark:text-stone-200">Pending</div>
+					<p class="text-stone-600 dark:text-stone-400 mt-0.5">Only one report so far. Not yet on the public map. Expires in 14 days if no confirmation arrives.</p>
 				</div>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3 flex gap-3 items-start">
+			<div class="border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3 flex gap-3 items-start">
 				<span class="w-2.5 h-2.5 rounded-full bg-orange-500 shrink-0 mt-1.5"></span>
 				<div>
-					<div class="font-semibold text-zinc-200">Reported</div>
-					<p class="text-zinc-500 mt-0.5">Confirmed by multiple people. Live on the public map. Waiting for the city to fix it.</p>
+					<div class="font-semibold text-stone-700 dark:text-stone-200">Reported</div>
+					<p class="text-stone-600 dark:text-stone-400 mt-0.5">Confirmed by multiple people. Live on the public map. Waiting for the city to fix it.</p>
 				</div>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3 flex gap-3 items-start">
+			<div class="border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3 flex gap-3 items-start">
 				<span class="w-2.5 h-2.5 rounded-full bg-green-500 shrink-0 mt-1.5"></span>
 				<div>
-					<div class="font-semibold text-zinc-200">Filled</div>
-					<p class="text-zinc-500 mt-0.5">Community confirmed the city patched it. Still on the map for accountability tracking.</p>
+					<div class="font-semibold text-stone-700 dark:text-stone-200">Filled</div>
+					<p class="text-stone-600 dark:text-stone-400 mt-0.5">Community confirmed the city patched it. Still on the map for accountability tracking.</p>
 				</div>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3 flex gap-3 items-start">
+			<div class="border border-stone-200 dark:border-stone-700 rounded-md px-4 py-3 flex gap-3 items-start">
 				<span class="w-2.5 h-2.5 rounded-full bg-zinc-600 shrink-0 mt-1.5"></span>
 				<div>
-					<div class="font-semibold text-zinc-200">Expired</div>
-					<p class="text-zinc-500 mt-0.5">No fill event after 90 days. Automatically closed to keep the map current.</p>
+					<div class="font-semibold text-stone-700 dark:text-stone-200">Expired</div>
+					<p class="text-stone-600 dark:text-stone-400 mt-0.5">No fill event after 90 days. Automatically closed to keep the map current.</p>
 				</div>
 			</div>
 		</div>
@@ -195,16 +195,16 @@
 
 	<!-- Push notifications -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="bell" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="bell" size={18} class="text-amber-500 shrink-0" />
 			Push notifications
 		</h2>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			Tap the bell icon in the top nav to subscribe to browser push notifications.
 			You'll get a ping whenever a pothole in the region gets filled — no app install required,
 			works on Android and desktop browsers that support web push.
 		</p>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			Tap the bell again to unsubscribe at any time. Notifications are sent server-side —
 			no personal data is stored beyond the push endpoint your browser provides.
 		</p>
@@ -212,15 +212,15 @@
 
 	<!-- Stats -->
 	<section class="space-y-4">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="bar-chart-2" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="bar-chart-2" size={18} class="text-amber-500 shrink-0" />
 			Stats page
 		</h2>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			The <a href="/stats" class="text-sky-400 underline hover:text-sky-300 transition-colors">Stats page</a>
 			shows accountability data across the whole region:
 		</p>
-		<ul class="space-y-1.5 text-sm text-zinc-400 list-none">
+		<ul class="space-y-1.5 text-sm text-stone-600 dark:text-stone-400 list-none">
 			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Ward leaderboards and letter grades (A–F) based on fill rate and response time</li>
 			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Average time from report to fill, across the whole dataset</li>
 			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Hotspot streets with the most active potholes</li>
@@ -230,51 +230,51 @@
 
 	<!-- For journalists / open data -->
 	<section class="space-y-4" id="open-data">
-		<h2 class="section-title text-xl text-white flex items-center gap-2">
-			<Icon name="download" size={18} class="text-sky-400 shrink-0" />
+		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
+			<Icon name="download" size={18} class="text-amber-500 shrink-0" />
 			For journalists &amp; developers
 		</h2>
-		<p class="text-sm text-zinc-400 leading-relaxed">
+		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
 			All pothole data is freely available — no API key, no account.
 		</p>
 		<div class="grid gap-3 sm:grid-cols-2">
 			<a
 				href="/api/feed.json"
-				class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4 hover:border-sky-600 transition-colors group"
+				class="flex items-start gap-3 border border-stone-200 dark:border-stone-700 rounded-md p-4 hover:border-amber-500 dark:hover:border-amber-500 transition-colors group"
 			>
-				<Icon name="globe" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+				<Icon name="globe" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm group-hover:text-sky-300 transition-colors">JSON feed</div>
-					<p class="text-xs text-zinc-400 mt-0.5">Recent confirmed potholes with coordinates, address, and status.</p>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">JSON feed</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">Recent confirmed potholes with coordinates, address, and status.</p>
 				</div>
 			</a>
 			<a
 				href="/api/export.csv"
-				class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4 hover:border-sky-600 transition-colors group"
+				class="flex items-start gap-3 border border-stone-200 dark:border-stone-700 rounded-md p-4 hover:border-amber-500 dark:hover:border-amber-500 transition-colors group"
 			>
-				<Icon name="download" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+				<Icon name="download" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm group-hover:text-sky-300 transition-colors">CSV export</div>
-					<p class="text-xs text-zinc-400 mt-0.5">Full dataset — id, lat/lng, address, status, dates. Opens in Excel or R.</p>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">CSV export</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">Full dataset — id, lat/lng, address, status, dates. Opens in Excel or R.</p>
 				</div>
 			</a>
 			<a
 				href="/api/feed.xml"
-				class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4 hover:border-sky-600 transition-colors group"
+				class="flex items-start gap-3 border border-stone-200 dark:border-stone-700 rounded-md p-4 hover:border-amber-500 dark:hover:border-amber-500 transition-colors group"
 			>
-				<Icon name="rss" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+				<Icon name="rss" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm group-hover:text-sky-300 transition-colors">RSS feed</div>
-					<p class="text-xs text-zinc-400 mt-0.5">Subscribe in any RSS reader to get notified of new confirmations and fills.</p>
+					<div class="font-semibold text-stone-900 dark:text-white text-sm group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">RSS feed</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">Subscribe in any RSS reader to get notified of new confirmations and fills.</p>
 				</div>
 			</a>
-			<div class="flex items-start gap-3 bg-zinc-900 border border-zinc-700 rounded-xl p-4">
-				<Icon name="code" size={18} class="text-sky-400 shrink-0 mt-0.5" />
+			<div class="flex items-start gap-3 border border-stone-200 dark:border-stone-700 rounded-md p-4">
+				<Icon name="code" size={18} class="text-amber-500 shrink-0 mt-0.5" />
 				<div>
-					<div class="font-semibold text-white text-sm">Embed widget</div>
-					<p class="text-xs text-zinc-400 mt-0.5">
+					<div class="font-semibold text-stone-900 dark:text-white text-sm">Embed widget</div>
+					<p class="text-xs text-stone-600 dark:text-stone-400 mt-0.5">
 						Embed any pothole card on your site via
-						<code class="text-zinc-300 bg-zinc-800 px-1 rounded">/api/embed/[id]</code>.
+						<code class="text-stone-600 dark:text-stone-300 bg-stone-100 dark:bg-stone-800 px-1 rounded">/api/embed/[id]</code>.
 						Returns a self-contained iframe-friendly card.
 					</p>
 				</div>
@@ -283,11 +283,11 @@
 	</section>
 
 	<div class="flex flex-wrap gap-4 pt-2">
-		<a href="/" class="inline-flex items-center gap-1.5 text-zinc-400 hover:text-white text-sm transition-colors">
+		<a href="/" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors">
 			<Icon name="arrow-left" size={14} />
 			Back to the map
 		</a>
-		<a href="/about" class="inline-flex items-center gap-1.5 text-zinc-400 hover:text-white text-sm transition-colors">
+		<a href="/about" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors">
 			About this project
 		</a>
 	</div>

--- a/src/routes/how-to/+page.svelte
+++ b/src/routes/how-to/+page.svelte
@@ -68,19 +68,19 @@
 			<p>Tap <strong class="text-stone-700 dark:text-stone-200">Report a pothole</strong> in the top-right corner.</p>
 			<ol class="space-y-3 list-none">
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">1</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Lock your location.</strong> Tap the crosshair icon to use your device's GPS, or search by address and drop a pin manually.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">2</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Pick severity</strong> (optional). Minor, Moderate, Severe, or Hazardous. This helps prioritise which holes need attention first.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">3</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">3</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Attach a photo</strong> (optional). Photos are compressed automatically. They go through moderation before appearing publicly.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">4</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation from a different location before it shows up on the public map.</span>
 				</li>
 			</ol>

--- a/src/routes/how-to/+page.svelte
+++ b/src/routes/how-to/+page.svelte
@@ -55,7 +55,7 @@
 			Reporting a pothole
 		</h2>
 
-		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-xl p-4 text-sm text-amber-200/90">
+		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-md p-4 text-sm text-amber-200/90">
 			<Icon name="alert-triangle" size={18} class="text-amber-400 shrink-0 mt-0.5" />
 			<p>
 				<strong class="text-amber-300">Stay safe.</strong>
@@ -68,19 +68,19 @@
 			<p>Tap <strong class="text-stone-700 dark:text-stone-200">Report a pothole</strong> in the top-right corner.</p>
 			<ol class="space-y-3 list-none">
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">1</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">1</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Lock your location.</strong> Tap the crosshair icon to use your device's GPS, or search by address and drop a pin manually.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">2</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">2</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Pick severity</strong> (optional). Minor, Moderate, Severe, or Hazardous. This helps prioritise which holes need attention first.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">3</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">3</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Attach a photo</strong> (optional). Photos are compressed automatically. They go through moderation before appearing publicly.</span>
 				</li>
 				<li class="flex gap-3">
-					<span class="shrink-0 w-6 h-6 rounded-full bg-sky-700 text-white text-xs font-bold flex items-center justify-center mt-0.5">4</span>
+					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center mt-0.5">4</span>
 					<span><strong class="text-stone-700 dark:text-stone-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation from a different location before it shows up on the public map.</span>
 				</li>
 			</ol>
@@ -132,7 +132,7 @@
 			<p>Tap any pin on the map, or the pothole list, to open its detail page. From there you can:</p>
 			<ul class="space-y-2 list-none">
 				<li class="flex gap-2.5">
-					<Icon name="zap" size={15} class="text-sky-400 shrink-0 mt-0.5" />
+					<Icon name="zap" size={15} class="text-amber-500 shrink-0 mt-0.5" />
 					<span><strong class="text-stone-700 dark:text-stone-200">I hit this</strong> — signal that you physically drove over the pothole. Hit counts are shown publicly and help surface the most dangerous holes.</span>
 				</li>
 				<li class="flex gap-2.5">
@@ -140,11 +140,11 @@
 					<span><strong class="text-stone-700 dark:text-stone-200">Mark as filled</strong> — if you can see the city has patched it, let the community know.</span>
 				</li>
 				<li class="flex gap-2.5">
-					<Icon name="mail" size={15} class="text-sky-400 shrink-0 mt-0.5" />
+					<Icon name="mail" size={15} class="text-amber-500 shrink-0 mt-0.5" />
 					<span><strong class="text-stone-700 dark:text-stone-200">Contact your councillor</strong> — each pothole shows the ward councillor's name and a direct email link pre-filled with the pothole address.</span>
 				</li>
 				<li class="flex gap-2.5">
-					<Icon name="share-2" size={15} class="text-sky-400 shrink-0 mt-0.5" />
+					<Icon name="share-2" size={15} class="text-amber-500 shrink-0 mt-0.5" />
 					<span><strong class="text-stone-700 dark:text-stone-200">Share</strong> — every pothole has a permanent URL. Share it to Reddit, Bluesky, Facebook, or copy the link to send directly.</span>
 				</li>
 			</ul>
@@ -217,14 +217,14 @@
 			Stats page
 		</h2>
 		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
-			The <a href="/stats" class="text-sky-400 underline hover:text-sky-300 transition-colors">Stats page</a>
+			The <a href="/stats" class="text-amber-500 underline hover:text-amber-400 transition-colors">Stats page</a>
 			shows accountability data across the whole region:
 		</p>
 		<ul class="space-y-1.5 text-sm text-stone-600 dark:text-stone-400 list-none">
-			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Ward leaderboards and letter grades (A–F) based on fill rate and response time</li>
-			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Average time from report to fill, across the whole dataset</li>
-			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Hotspot streets with the most active potholes</li>
-			<li class="flex gap-2"><Icon name="check" size={14} class="text-sky-500 shrink-0 mt-0.5" /> Monthly fill rate trends over time</li>
+			<li class="flex gap-2"><Icon name="check" size={14} class="text-amber-500 shrink-0 mt-0.5" /> Ward leaderboards and letter grades (A–F) based on fill rate and response time</li>
+			<li class="flex gap-2"><Icon name="check" size={14} class="text-amber-500 shrink-0 mt-0.5" /> Average time from report to fill, across the whole dataset</li>
+			<li class="flex gap-2"><Icon name="check" size={14} class="text-amber-500 shrink-0 mt-0.5" /> Hotspot streets with the most active potholes</li>
+			<li class="flex gap-2"><Icon name="check" size={14} class="text-amber-500 shrink-0 mt-0.5" /> Monthly fill rate trends over time</li>
 		</ul>
 	</section>
 

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -437,10 +437,10 @@
 
 <div class="max-w-lg mx-auto px-4 py-8">
 	<div class="mb-6">
-		<h1 class="page-title text-3xl sm:text-4xl text-white mb-1">Report a pothole</h1>
-		<p class="page-intro text-zinc-300 text-sm">Report the location in about 30 seconds. No account required.</p>
-		<p class="text-xs text-zinc-300 mt-2">Independent community tracker for Waterloo Region. For official repair action, report to the city too.</p>
-		<p class="flex items-start gap-1.5 text-xs text-zinc-300 mt-2">
+		<h1 class="page-title text-3xl sm:text-4xl text-stone-900 dark:text-white mb-1">Report a pothole</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-sm">Report the location in about 30 seconds. No account required.</p>
+		<p class="text-xs text-stone-600 dark:text-stone-400 mt-2">Independent community tracker for Waterloo Region. For official repair action, report to the city too.</p>
+		<p class="flex items-start gap-1.5 text-xs text-stone-600 dark:text-stone-400 mt-2">
 			<Icon name="alert-triangle" size={13} class="text-amber-500 shrink-0 mt-0.5" />
 			Stay safe — report from the sidewalk or after pulling over. Never stop in a live traffic lane.
 		</p>
@@ -448,15 +448,15 @@
 
 	<form onsubmit={handleSubmit} class="space-y-5">
 		<!-- Location -->
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="crosshair" size={14} class="text-sky-400" />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-400">
+				<Icon name="crosshair" size={14} class="text-amber-500 dark:text-amber-400" />
 				Location
 			</div>
-			<p class="text-xs text-zinc-300">Use your current location for the fastest report, or switch to address search or map pin if needed.</p>
+			<p class="text-xs text-stone-600 dark:text-stone-400">Use your current location for the fastest report, or switch to address search or map pin if needed.</p>
 
 			<!-- Tab bar -->
-			<div role="tablist" aria-label="Choose a location source" class="flex gap-1 bg-zinc-800 rounded-lg p-1">
+			<div role="tablist" aria-label="Choose a location source" class="flex gap-1 bg-stone-100 dark:bg-stone-800 rounded-md p-1">
 				{#each LOCATION_TABS as tab (tab.mode)}
 					<button
 						id={`location-tab-${tab.mode}`}
@@ -469,8 +469,8 @@
 						onkeydown={(event) => handleLocationTabKeydown(event, tab.mode)}
 						class="flex-1 min-h-[44px] py-1.5 px-2 rounded-md text-xs font-semibold transition-colors
 							{locationMode === tab.mode
-								? 'bg-zinc-700 text-white'
-								: 'text-zinc-400 hover:text-zinc-200'}"
+								? 'bg-white dark:bg-stone-700 text-stone-900 dark:text-white shadow-sm'
+								: 'text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'}"
 					>
 						{tab.label}
 					</button>
@@ -489,12 +489,12 @@
 					type="button"
 					onclick={getLocation}
 					disabled={gpsStatus === 'loading'}
-					class="w-full py-3 rounded-lg border-2 border-dashed font-semibold text-sm transition-colors flex items-center justify-center gap-2
+					class="w-full py-3 rounded-md border-2 border-dashed font-semibold text-sm transition-colors flex items-center justify-center gap-2
 						{gpsStatus === 'got'
 							? 'border-green-500 bg-green-500/10 text-green-400'
 							: gpsStatus === 'error'
 							? 'border-red-500 bg-red-500/10 text-red-400'
-							: 'border-zinc-700 hover:border-sky-500 hover:bg-sky-500/5 text-zinc-400 hover:text-sky-400'}"
+							: 'border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-500 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400'}"
 				>
 					{#if gpsStatus === 'loading'}
 						<Icon name="loader" size={15} class="animate-spin shrink-0" />
@@ -515,20 +515,20 @@
 					<p class="text-xs text-red-400" role="alert">
 						Could not get your location — signal may be weak. Try moving outside, or use address or map mode instead.
 					</p>
-					<p class="text-xs text-zinc-300">
-						No GPS? <button type="button" onclick={() => (locationMode = 'address')} class="underline hover:text-white transition-colors">Enter an address</button>
-						or <button type="button" onclick={() => (locationMode = 'map')} class="underline hover:text-white transition-colors">pin on the map</button>.
+					<p class="text-xs text-stone-600 dark:text-stone-400">
+						No GPS? <button type="button" onclick={() => (locationMode = 'address')} class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Enter an address</button>
+						or <button type="button" onclick={() => (locationMode = 'map')} class="underline hover:text-stone-900 dark:hover:text-white transition-colors">pin on the map</button>.
 					</p>
 				{/if}
 
 				{#if address}
-					<p class="flex items-center gap-1.5 text-xs text-zinc-300">
-						<Icon name="map-pin" size={11} class="shrink-0 text-zinc-400" />
+					<p class="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-400">
+						<Icon name="map-pin" size={11} class="shrink-0 text-stone-500 dark:text-stone-400" />
 						{address}
-						<span>· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">OpenStreetMap</a></span>
+						<span>· via <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white">OpenStreetMap</a></span>
 					</p>
 				{:else if gpsStatus === 'got'}
-					<p class="text-xs text-zinc-300">Looking up address via OpenStreetMap…</p>
+					<p class="text-xs text-stone-600 dark:text-stone-400">Looking up address via OpenStreetMap…</p>
 				{/if}
 			</div>
 
@@ -540,7 +540,7 @@
 				hidden={locationMode !== 'address'}
 				class="space-y-2"
 			>
-				<label for="address-search-input" class="block text-xs font-medium text-zinc-300">Address or intersection</label>
+				<label for="address-search-input" class="block text-xs font-medium text-stone-600 dark:text-stone-400">Address or intersection</label>
 				<div class="relative">
 					<input
 						id="address-search-input"
@@ -562,13 +562,13 @@
 								addressSuggestions = [];
 							}
 						}}
-						class="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-white placeholder-zinc-500 focus:outline-none focus:border-sky-500"
+						class="w-full bg-stone-100 dark:bg-stone-800 border border-stone-300 dark:border-stone-600 rounded-md px-3 py-2.5 text-sm text-stone-900 dark:text-white placeholder-stone-400 focus:outline-none focus:border-amber-500"
 						autocomplete="off"
 					/>
 					{#if addressSearching}
-						<p class="text-xs text-zinc-300 mt-1">Searching…</p>
+						<p class="text-xs text-stone-600 dark:text-stone-400 mt-1">Searching…</p>
 					{:else if addressQuery.length > 2 && addressSuggestions.length === 0 && lat === null}
-						<p class="text-xs text-zinc-300 mt-1" role="status" aria-live="polite">No results found — try a different address or street name.</p>
+						<p class="text-xs text-stone-600 dark:text-stone-400 mt-1" role="status" aria-live="polite">No results found — try a different address or street name.</p>
 					{/if}
 					{#if addressSuggestions.length > 0}
 						<ul
@@ -576,14 +576,14 @@
 							role="listbox"
 							aria-label="Address suggestions"
 							data-testid="address-suggestions"
-							class="absolute z-10 w-full mt-1 bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl overflow-hidden"
+							class="absolute z-10 w-full mt-1 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-md shadow-xl overflow-hidden"
 						>
 							{#each addressSuggestions as s, i (s.display_name)}
 								<li id="address-suggestion-{i}" role="option" aria-selected={i === addressActiveIndex}>
 									<button
 										type="button"
 										tabindex="-1"
-										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-zinc-200 hover:bg-zinc-700 {i === addressActiveIndex ? 'bg-zinc-700' : ''}"
+										class="w-full text-left px-3 py-2.5 min-h-[44px] text-sm text-stone-700 dark:text-stone-200 hover:bg-stone-200 dark:hover:bg-stone-700 {i === addressActiveIndex ? 'bg-stone-200 dark:bg-stone-700' : ''}"
 										onclick={() => selectSuggestion(s)}
 									>
 										{s.display_name}
@@ -594,8 +594,8 @@
 					{/if}
 				</div>
 				{#if lat !== null && addressQuery && addressSuggestions.length === 0}
-					<p class="flex items-center gap-1.5 text-xs text-zinc-300">
-						<Icon name="map-pin" size={11} class="shrink-0 text-zinc-400" />
+					<p class="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-400">
+						<Icon name="map-pin" size={11} class="shrink-0 text-stone-500 dark:text-stone-400" />
 						{address}
 					</p>
 				{/if}
@@ -609,32 +609,32 @@
 				hidden={locationMode !== 'map'}
 				class="space-y-2"
 			>
-				<div bind:this={miniMapEl} class="w-full rounded-lg overflow-hidden" style="height: 260px;"></div>
+				<div bind:this={miniMapEl} class="w-full rounded-md overflow-hidden" style="height: 260px;"></div>
 				{#if lat !== null}
-					<p class="flex items-center gap-1.5 text-xs text-zinc-300">
-						<Icon name="map-pin" size={11} class="shrink-0 text-zinc-400" />
+					<p class="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-400">
+						<Icon name="map-pin" size={11} class="shrink-0 text-stone-500 dark:text-stone-400" />
 						{address ?? `${lat.toFixed(5)}, ${lng?.toFixed(5)}`} — drag the pin to adjust
 					</p>
 				{:else}
-					<p class="text-xs text-zinc-300">Tap the map to place a pin</p>
+					<p class="text-xs text-stone-600 dark:text-stone-400">Tap the map to place a pin</p>
 				{/if}
 			</div>
 		</div>
 
 		<!-- Severity -->
-		<fieldset class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<legend class="flex items-center gap-2 text-sm font-semibold text-zinc-300 mb-2">
-				<Icon name="alert-triangle" size={14} class="text-zinc-400" />
-				How severe is the damage? <span class="text-zinc-300 font-normal">(optional)</span>
+		<fieldset class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<legend class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-400 mb-2">
+				<Icon name="alert-triangle" size={14} class="text-stone-500 dark:text-stone-400" />
+				How severe is the damage? <span class="text-stone-600 dark:text-stone-400 font-normal">(optional)</span>
 			</legend>
-			<p class="text-xs text-zinc-300">This helps other residents understand urgency at a glance.</p>
+			<p class="text-xs text-stone-600 dark:text-stone-400">This helps other residents understand urgency at a glance.</p>
 			<div class="grid grid-cols-2 gap-2">
 				{#each SEVERITY_OPTIONS as opt (opt.value)}
 					<label
-						class="flex flex-col items-start gap-1.5 p-3 rounded-lg border text-left cursor-pointer transition-colors
+						class="flex flex-col items-start gap-1.5 p-3 rounded-md border text-left cursor-pointer transition-colors
 							{severity === opt.value
-								? 'border-sky-500 bg-sky-500/10'
-								: 'border-zinc-700 hover:border-zinc-500'}"
+								? 'border-amber-500 bg-amber-500/10'
+								: 'border-stone-300 dark:border-stone-600 hover:border-stone-400 dark:hover:border-stone-500'}"
 					>
 						<input
 							type="radio"
@@ -648,23 +648,23 @@
 						<div class="flex items-end gap-0.5 h-4" aria-hidden="true">
 							{#each [1, 2, 3, 4] as i (i)}
 								<div
-									class="w-1.5 rounded-t-sm transition-colors {i <= opt.level ? opt.barColor : 'bg-zinc-700'}"
+									class="w-1.5 rounded-t-sm transition-colors {i <= opt.level ? opt.barColor : 'bg-stone-300 dark:bg-stone-600'}"
 									style="height: {i * 25}%"
 								></div>
 							{/each}
 						</div>
-						<span class="text-sm font-semibold text-white leading-tight">{opt.label}</span>
-						<span class="text-xs text-zinc-300 leading-tight">{opt.sub}</span>
+						<span class="text-sm font-semibold text-stone-900 dark:text-white leading-tight">{opt.label}</span>
+						<span class="text-xs text-stone-600 dark:text-stone-400 leading-tight">{opt.sub}</span>
 					</label>
 				{/each}
 			</div>
 		</fieldset>
 
 		<!-- Photo (optional) -->
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
-			<label for="photo-input" class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="camera" size={14} class="text-sky-400" />
-				Photo <span class="text-zinc-300 font-normal">(optional)</span>
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
+			<label for="photo-input" class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-400">
+				<Icon name="camera" size={14} class="text-amber-500 dark:text-amber-400" />
+				Photo <span class="text-stone-600 dark:text-stone-400 font-normal">(optional)</span>
 			</label>
 
 			<input
@@ -677,12 +677,12 @@
 			/>
 			{#if photoPreview}
 				<div class="relative">
-					<img src={photoPreview} alt="Selected" class="w-full rounded-lg object-cover aspect-video" />
+					<img src={photoPreview} alt="Selected" class="w-full rounded-md object-cover aspect-video" />
 					<button
 						type="button"
 						onclick={clearPhoto}
 						aria-label="Remove photo"
-						class="absolute top-2 right-2 bg-zinc-900/80 hover:bg-zinc-900 rounded-full p-1.5 text-zinc-400 hover:text-white transition-colors"
+						class="absolute top-2 right-2 bg-stone-900/80 hover:bg-stone-900 rounded-full p-1.5 text-stone-400 hover:text-white transition-colors"
 					>
 						<Icon name="x" size={14} />
 					</button>
@@ -691,64 +691,64 @@
 				<button
 					type="button"
 					onclick={() => photoInput?.click()}
-					class="w-full py-3 rounded-lg border-2 border-dashed border-zinc-700 hover:border-sky-500 hover:bg-sky-500/5 text-zinc-400 hover:text-sky-400 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
+					class="w-full py-3 rounded-md border-2 border-dashed border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-500 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
 				>
 					<Icon name="camera" size={15} class="shrink-0" />
 					Add a photo
 				</button>
 			{/if}
 
-			<p class="text-xs text-zinc-300">Photos are reviewed before appearing publicly — usually within a few hours. Only take one if you're safely off the road.</p>
+			<p class="text-xs text-stone-600 dark:text-stone-400">Photos are reviewed before appearing publicly — usually within a few hours. Only take one if you're safely off the road.</p>
 		</div>
 
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3" role="status" aria-live="polite" aria-atomic="true">
-			<div class="flex items-center gap-2 text-sm font-semibold text-zinc-300">
-				<Icon name="check-circle" size={14} class={hasLocation ? 'text-green-400' : 'text-zinc-400'} />
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3" role="status" aria-live="polite" aria-atomic="true">
+			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-400">
+				<Icon name="check-circle" size={14} class={hasLocation ? 'text-green-400' : 'text-stone-500 dark:text-stone-400'} />
 				Ready to submit
 			</div>
 
 			{#if hasLocation}
 				<div class="space-y-2">
-					<div class="rounded-lg bg-zinc-800/80 p-3 space-y-1.5">
+					<div class="rounded-md bg-stone-100/80 dark:bg-stone-800/80 p-3 space-y-1.5">
 						<p class="flex items-center gap-1.5 text-xs font-semibold text-green-400">
 							<Icon name="map-pin" size={12} class="shrink-0" />
 							Location locked in
 						</p>
-						<p class="text-sm text-zinc-200 break-words overflow-wrap-anywhere">{locationSummary}</p>
+						<p class="text-sm text-stone-700 dark:text-stone-200 break-words overflow-wrap-anywhere">{locationSummary}</p>
 					</div>
 					<div class="grid gap-2 sm:grid-cols-2">
-						<div class="rounded-lg bg-zinc-800/60 p-3">
-							<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-300">Severity</p>
-							<p class="mt-1 text-sm text-zinc-300">{severity ?? 'Optional — not added yet'}</p>
+						<div class="rounded-md bg-stone-100/60 dark:bg-stone-800/60 p-3">
+							<p class="text-[11px] font-semibold text-stone-600 dark:text-stone-400">Severity</p>
+							<p class="mt-1 text-sm text-stone-600 dark:text-stone-400">{severity ?? 'Optional — not added yet'}</p>
 						</div>
-						<div class="rounded-lg bg-zinc-800/60 p-3">
-							<p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-300">Photo</p>
-							<p class="mt-1 text-sm text-zinc-300">{photoFile ? 'Attached and ready to upload' : 'Optional — not added yet'}</p>
+						<div class="rounded-md bg-stone-100/60 dark:bg-stone-800/60 p-3">
+							<p class="text-[11px] font-semibold text-stone-600 dark:text-stone-400">Photo</p>
+							<p class="mt-1 text-sm text-stone-600 dark:text-stone-400">{photoFile ? 'Attached and ready to upload' : 'Optional — not added yet'}</p>
 						</div>
 					</div>
 				</div>
-				<p class="text-xs text-zinc-300 leading-relaxed">
+				<p class="text-xs text-stone-600 dark:text-stone-400 leading-relaxed">
 					After you submit, a pothole page is created right away. It appears on the public map after
 					{confirmationThreshold} independent report{confirmationThreshold === 1 ? '' : 's'} from the same location.
 				</p>
 			{:else}
-				<p class="text-sm text-zinc-300">
+				<p class="text-sm text-stone-600 dark:text-stone-400">
 					Choose a location above to unlock the report button.
 				</p>
-				<p class="text-xs text-zinc-300">
+				<p class="text-xs text-stone-600 dark:text-stone-400">
 					Use GPS for the fastest report, or switch to address search or map pin if location access fails.
 				</p>
 			{/if}
 		</div>
 
-		<p class="text-xs text-zinc-300 text-center">
-			By submitting you consent to collection of your rounded GPS location (±11 m), a hashed IP address for deduplication, and any photos you attach (reviewed before publishing). No account required. <a href="/about#privacy" class="underline hover:text-white">Privacy policy →</a>
+		<p class="text-xs text-stone-600 dark:text-stone-400 text-center">
+			By submitting you consent to collection of your rounded GPS location (±11 m), a hashed IP address for deduplication, and any photos you attach (reviewed before publishing). No account required. <a href="/about#privacy" class="underline hover:text-stone-900 dark:hover:text-white">Privacy policy →</a>
 		</p>
 
 		<button
 			type="submit"
 			disabled={submitting || !hasLocation}
-			class="w-full py-4 font-bold text-lg rounded-xl transition-colors flex items-center justify-center gap-2 disabled:bg-zinc-800 disabled:text-zinc-500 disabled:cursor-not-allowed bg-sky-700 hover:bg-sky-600 text-white"
+			class="w-full py-4 font-bold text-lg rounded-md transition-colors flex items-center justify-center gap-2 disabled:bg-stone-200 dark:disabled:bg-stone-800 disabled:text-stone-400 dark:disabled:text-stone-500 disabled:cursor-not-allowed bg-amber-500 hover:bg-amber-600 text-white"
 		>
 			{#if submitting}
 				<Icon name="loader" size={16} class="animate-spin shrink-0" />
@@ -759,11 +759,11 @@
 			{/if}
 		</button>
 
-		<p class="text-xs text-zinc-300 text-center">
+		<p class="text-xs text-stone-600 dark:text-stone-400 text-center">
 			{confirmationThreshold} independent report{confirmationThreshold === 1 ? '' : 's'} from the same location are needed before a pothole appears on the public map.
 		</p>
-		<p class="text-xs text-zinc-300 text-center">
-			On a major road? It may be maintained by the Region of Waterloo, not the city. <a href="/about" class="underline hover:text-white">Learn more →</a>
+		<p class="text-xs text-stone-600 dark:text-stone-400 text-center">
+			On a major road? It may be maintained by the Region of Waterloo, not the city. <a href="/about" class="underline hover:text-stone-900 dark:hover:text-white">Learn more →</a>
 		</p>
 	</form>
 </div>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -491,9 +491,9 @@
 					disabled={gpsStatus === 'loading'}
 					class="w-full py-3 rounded-md border-2 border-dashed font-semibold text-sm transition-colors flex items-center justify-center gap-2
 						{gpsStatus === 'got'
-							? 'border-green-500 bg-green-500/10 text-green-400'
+							? 'border-green-500 bg-green-500/10 text-green-700 dark:text-green-400'
 							: gpsStatus === 'error'
-							? 'border-red-500 bg-red-500/10 text-red-400'
+							? 'border-red-500 bg-red-500/10 text-red-700 dark:text-red-400'
 							: 'border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-600 dark:text-stone-400 hover:text-amber-700 dark:hover:text-amber-400'}"
 				>
 					{#if gpsStatus === 'loading'}
@@ -512,7 +512,7 @@
 				</button>
 
 				{#if gpsStatus === 'error'}
-					<p class="text-xs text-red-400" role="alert">
+					<p class="text-xs text-red-700 dark:text-red-400" role="alert">
 						Could not get your location — signal may be weak. Try moving outside, or use address or map mode instead.
 					</p>
 					<p class="text-xs text-stone-600 dark:text-stone-400">
@@ -703,14 +703,14 @@
 
 		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3" role="status" aria-live="polite" aria-atomic="true">
 			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-400">
-				<Icon name="check-circle" size={14} class={hasLocation ? 'text-green-400' : 'text-stone-500 dark:text-stone-400'} />
+				<Icon name="check-circle" size={14} class={hasLocation ? 'text-green-700 dark:text-green-400' : 'text-stone-500 dark:text-stone-400'} />
 				Ready to submit
 			</div>
 
 			{#if hasLocation}
 				<div class="space-y-2">
 					<div class="rounded-md bg-stone-100/80 dark:bg-stone-800/80 p-3 space-y-1.5">
-						<p class="flex items-center gap-1.5 text-xs font-semibold text-green-400">
+						<p class="flex items-center gap-1.5 text-xs font-semibold text-green-700 dark:text-green-400">
 							<Icon name="map-pin" size={12} class="shrink-0" />
 							Location locked in
 						</p>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -470,7 +470,7 @@
 						class="flex-1 min-h-[44px] py-1.5 px-2 rounded-md text-xs font-semibold transition-colors
 							{locationMode === tab.mode
 								? 'bg-white dark:bg-stone-700 text-stone-900 dark:text-white shadow-sm'
-								: 'text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'}"
+								: 'text-stone-600 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'}"
 					>
 						{tab.label}
 					</button>
@@ -494,7 +494,7 @@
 							? 'border-green-500 bg-green-500/10 text-green-400'
 							: gpsStatus === 'error'
 							? 'border-red-500 bg-red-500/10 text-red-400'
-							: 'border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-500 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400'}"
+							: 'border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-600 dark:text-stone-400 hover:text-amber-700 dark:hover:text-amber-400'}"
 				>
 					{#if gpsStatus === 'loading'}
 						<Icon name="loader" size={15} class="animate-spin shrink-0" />
@@ -691,7 +691,7 @@
 				<button
 					type="button"
 					onclick={() => photoInput?.click()}
-					class="w-full py-3 rounded-md border-2 border-dashed border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-500 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
+					class="w-full py-3 rounded-md border-2 border-dashed border-stone-300 dark:border-stone-600 hover:border-amber-500 hover:bg-amber-500/5 text-stone-600 dark:text-stone-400 hover:text-amber-700 dark:hover:text-amber-400 font-semibold text-sm transition-colors flex items-center justify-center gap-2"
 				>
 					<Icon name="camera" size={15} class="shrink-0" />
 					Add a photo
@@ -748,7 +748,7 @@
 		<button
 			type="submit"
 			disabled={submitting || !hasLocation}
-			class="w-full py-4 font-bold text-lg rounded-md transition-colors flex items-center justify-center gap-2 disabled:bg-stone-200 dark:disabled:bg-stone-800 disabled:text-stone-400 dark:disabled:text-stone-500 disabled:cursor-not-allowed bg-amber-500 hover:bg-amber-600 text-white"
+			class="w-full py-4 font-bold text-lg rounded-md transition-colors flex items-center justify-center gap-2 disabled:bg-stone-200 dark:disabled:bg-stone-800 disabled:text-stone-400 dark:disabled:text-stone-500 disabled:cursor-not-allowed bg-amber-500 hover:bg-amber-600 text-stone-900"
 		>
 			{#if submitting}
 				<Icon name="loader" size={16} class="animate-spin shrink-0" />

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -498,7 +498,7 @@
 				<Icon name="flame" size={18} class="text-orange-400 shrink-0" />
 				Top streets
 			</h2>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md overflow-hidden">
 				<table class="w-full text-sm">
 					<thead>
 						<tr class="border-b border-stone-200 dark:border-stone-700">

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -224,15 +224,15 @@
 	<!-- Page header + time filter -->
 	<div class="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
 		<div>
-			<h1 class="page-title text-3xl sm:text-4xl text-white flex items-center gap-2.5">
-				<Icon name="bar-chart-2" size={26} class="text-sky-400 shrink-0" />
+			<h1 class="page-title text-3xl sm:text-4xl text-stone-900 dark:text-white flex items-center gap-2.5">
+				<Icon name="bar-chart-2" size={26} class="text-amber-500 shrink-0" />
 				By the numbers
 			</h1>
-			<p class="page-intro text-zinc-400 mt-1">Pothole accountability data for Waterloo Region.</p>
+			<p class="page-intro text-stone-500 dark:text-stone-400 mt-1">Pothole accountability data for Waterloo Region.</p>
 		</div>
 
 		<div
-			class="flex items-center gap-1 bg-zinc-900 border border-zinc-700 rounded-lg p-1"
+			class="flex items-center gap-1 bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-1"
 			role="group"
 			aria-label="Filter by time window"
 		>
@@ -240,10 +240,10 @@
 				<button
 					onclick={() => (windowDays = w.value)}
 					aria-pressed={windowDays === w.value}
-					class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-zinc-900
+					class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1 focus:ring-offset-white dark:focus:ring-offset-stone-900
 						{windowDays === w.value
-							? 'bg-sky-600 text-white'
-							: 'text-zinc-400 hover:text-white hover:bg-zinc-800'}"
+							? 'bg-amber-500 text-white'
+							: 'bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white'}"
 				>
 					{w.label}
 				</button>
@@ -255,29 +255,29 @@
 	<section aria-labelledby="summary-heading">
 		<h2 id="summary-heading" class="sr-only">Summary statistics</h2>
 		<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<p class="text-xs text-zinc-500 uppercase tracking-wide">Total reported</p>
-				<p class="text-3xl font-bold text-white" role="status" aria-live="polite">{totalConfirmed}</p>
-				<p class="text-xs text-zinc-500">confirmed potholes</p>
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-1">
+				<p class="text-xs text-stone-500 dark:text-stone-400 uppercase tracking-wide">Total reported</p>
+				<p class="text-3xl font-bold text-stone-900 dark:text-white" role="status" aria-live="polite">{totalConfirmed}</p>
+				<p class="text-xs text-stone-500 dark:text-stone-400">confirmed potholes</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<p class="text-xs text-zinc-500 uppercase tracking-wide">Currently open</p>
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-1">
+				<p class="text-xs text-stone-500 dark:text-stone-400 uppercase tracking-wide">Currently open</p>
 				<p class="text-3xl font-bold text-orange-400" role="status" aria-live="polite">{totalOpen}</p>
-				<p class="text-xs text-zinc-500">unfilled, on the map</p>
+				<p class="text-xs text-stone-500 dark:text-stone-400">unfilled, on the map</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<p class="text-xs text-zinc-500 uppercase tracking-wide">Fill rate</p>
-				<p class="text-3xl font-bold text-sky-400" role="status" aria-live="polite">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-1">
+				<p class="text-xs text-stone-500 dark:text-stone-400 uppercase tracking-wide">Fill rate</p>
+				<p class="text-3xl font-bold text-amber-500" role="status" aria-live="polite">
 					{fillRate === null ? '—' : `${fmt(fillRate, 0)}%`}
 				</p>
-				<p class="text-xs text-zinc-500">{totalFilled} of {totalConfirmed} filled</p>
+				<p class="text-xs text-stone-500 dark:text-stone-400">{totalFilled} of {totalConfirmed} filled</p>
 			</div>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-1">
-				<p class="text-xs text-zinc-500 uppercase tracking-wide">Avg days to fill</p>
-				<p class="text-3xl font-bold {avgDaysToFill === null ? 'text-zinc-500' : 'text-green-400'}" role="status" aria-live="polite">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-1">
+				<p class="text-xs text-stone-500 dark:text-stone-400 uppercase tracking-wide">Avg days to fill</p>
+				<p class="text-3xl font-bold {avgDaysToFill === null ? 'text-stone-500 dark:text-stone-400' : 'text-green-400'}" role="status" aria-live="polite">
 					{avgDaysToFill === null ? '—' : fmt(avgDaysToFill, 1)}
 				</p>
-				<p class="text-xs text-zinc-500">from report to fixed</p>
+				<p class="text-xs text-stone-500 dark:text-stone-400">from report to fixed</p>
 			</div>
 		</div>
 	</section>
@@ -285,11 +285,11 @@
 	<!-- ── Monthly trend chart ─────────────────────────────────────────────────── -->
 	<section aria-labelledby="trend-heading">
 		<div class="flex items-center justify-between mb-4 flex-wrap gap-3">
-			<h2 id="trend-heading" class="section-title text-lg text-white">
+			<h2 id="trend-heading" class="section-title text-lg text-stone-900 dark:text-white">
 				Monthly activity
-				<span class="text-zinc-500 font-normal text-sm">(last 18 months, full dataset)</span>
+				<span class="text-stone-500 dark:text-stone-400 font-normal text-sm">(last 18 months, full dataset)</span>
 			</h2>
-			<div class="flex items-center gap-4 text-xs text-zinc-500" aria-hidden="true">
+			<div class="flex items-center gap-4 text-xs text-stone-500 dark:text-stone-400" aria-hidden="true">
 				<span class="flex items-center gap-1.5">
 					<span class="w-3 h-3 rounded-sm bg-orange-500/70 inline-block"></span> Reported
 				</span>
@@ -299,7 +299,7 @@
 			</div>
 		</div>
 
-		<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-5">
 			<div
 				class="flex items-end gap-px h-28"
 				role="img"
@@ -327,7 +327,7 @@
 			{#each monthlyData as m, i (m.key)}
 					<div class="flex-1 text-center min-w-0 overflow-hidden">
 						{#if i % 3 === 0 || i === monthlyData.length - 1}
-							<span class="text-zinc-600 text-[10px]">{m.label}</span>
+							<span class="text-stone-400 dark:text-stone-600 text-[10px]">{m.label}</span>
 						{/if}
 					</div>
 				{/each}
@@ -359,27 +359,27 @@
 	<!-- ── City breakdown ─────────────────────────────────────────────────────── -->
 	{#if cityRows.length > 0}
 		<section aria-labelledby="city-heading">
-			<h2 id="city-heading" class="section-title text-lg text-white mb-4">By city</h2>
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+			<h2 id="city-heading" class="section-title text-lg text-stone-900 dark:text-white mb-4">By city</h2>
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md overflow-hidden overflow-x-auto">
 				<table class="w-full text-sm">
 					<thead>
-						<tr class="border-b border-zinc-800">
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">City</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Total</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Open</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Filled</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Fill rate</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium hidden sm:table-cell">Avg days</th>
+						<tr class="border-b border-stone-200 dark:border-stone-700">
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">City</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Total</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Open</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Filled</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Fill rate</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium hidden sm:table-cell">Avg days</th>
 						</tr>
 					</thead>
 					<tbody>
 					{#each cityRows as c (c.city)}
-							<tr class="border-b border-zinc-800/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
-								<td class="px-4 py-3 font-medium text-white">{c.city}</td>
-								<td class="px-4 py-3 text-right text-zinc-300">{c.total}</td>
-								<td class="px-4 py-3 text-right font-semibold {c.open > 0 ? 'text-orange-400' : 'text-zinc-500'}">{c.open}</td>
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
+								<td class="px-4 py-3 font-medium text-stone-900 dark:text-white">{c.city}</td>
+								<td class="px-4 py-3 text-right text-stone-600 dark:text-stone-300">{c.total}</td>
+								<td class="px-4 py-3 text-right font-semibold {c.open > 0 ? 'text-orange-400' : 'text-stone-500 dark:text-stone-400'}">{c.open}</td>
 								<td class="px-4 py-3 text-right text-green-400">{c.filled}</td>
-								<td class="px-4 py-3 text-right text-sky-400">{c.fillRate === null ? '—' : `${fmt(c.fillRate, 0)}%`}</td>
+								<td class="px-4 py-3 text-right text-amber-500">{c.fillRate === null ? '—' : `${fmt(c.fillRate, 0)}%`}</td>
 								<td class="px-4 py-3 text-right text-zinc-400 hidden sm:table-cell">{fmt(c.avgDays, 1)}</td>
 							</tr>
 						{/each}
@@ -392,47 +392,47 @@
 	<!-- ── Ward leaderboard ───────────────────────────────────────────────────── -->
 	<section aria-labelledby="ward-heading">
 		<div class="flex items-center justify-between mb-4 flex-wrap gap-2">
-			<h2 id="ward-heading" class="section-title text-lg text-white">By ward</h2>
+			<h2 id="ward-heading" class="section-title text-lg text-stone-900 dark:text-white">By ward</h2>
 		</div>
 
 		{#if wardLookupFailed}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm" role="status">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-6 text-center text-stone-500 dark:text-stone-400 text-sm" role="status">
 				Ward boundary data is temporarily unavailable. City-level totals above are unaffected.
 			</div>
 		{:else if wardRows.length === 0}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-zinc-500 text-sm">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-6 text-center text-stone-500 dark:text-stone-400 text-sm">
 				No ward data available for the selected window.
 			</div>
 		{:else}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md overflow-hidden overflow-x-auto">
 				<table class="w-full text-sm min-w-[600px]">
 					<thead>
-						<tr class="border-b border-zinc-800">
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">City</th>
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">Ward</th>
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium hidden md:table-cell">Councillor</th>
-							<th scope="col" class="text-right px-4 py-3">
+						<tr class="border-b border-stone-200 dark:border-stone-700">
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">City</th>
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Ward</th>
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium hidden md:table-cell">Councillor</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400">
 								<button
 									onclick={() => setSort('open')}
-									class="text-zinc-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
+									class="text-stone-600 dark:text-stone-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
 									aria-label="Sort by open holes{sortCol === 'open' ? `, currently ${sortAsc ? 'ascending' : 'descending'}` : ''}"
 								>
 									Open <span aria-hidden="true">{sortLabel('open')}</span>
 								</button>
 							</th>
-							<th scope="col" class="text-right px-4 py-3">
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400">
 								<button
 									onclick={() => setSort('fillRate')}
-									class="text-zinc-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
+									class="text-stone-600 dark:text-stone-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
 									aria-label="Sort by fill rate{sortCol === 'fillRate' ? `, currently ${sortAsc ? 'ascending' : 'descending'}` : ''}"
 								>
 									Fill rate <span aria-hidden="true">{sortLabel('fillRate')}</span>
 								</button>
 							</th>
-							<th scope="col" class="text-right px-4 py-3">
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400">
 								<button
 									onclick={() => setSort('avgDays')}
-									class="text-zinc-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
+									class="text-stone-600 dark:text-stone-400 font-medium hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
 									aria-label="Sort by average days to fill{sortCol === 'avgDays' ? `, currently ${sortAsc ? 'ascending' : 'descending'}` : ''}"
 								>
 									Avg days <span aria-hidden="true">{sortLabel('avgDays')}</span>
@@ -440,7 +440,7 @@
 							</th>
 							<th
 								scope="col"
-								class="text-right px-4 py-3 text-zinc-400 font-medium"
+								class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium"
 								title="Accountability grade: fill rate (70%) + speed (30%). Requires ≥5 potholes."
 							>
 								Grade
@@ -449,13 +449,13 @@
 					</thead>
 					<tbody>
 					{#each wardRows as row (row.key)}
-							{@const g = wardGrade(row.fillRate, row.avgDays, row.total)}
-							<tr class="border-b border-zinc-800/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
-								<td class="px-4 py-3 text-zinc-300 capitalize">
-									<a href="/stats/ward/{row.city}/{row.ward}" class="hover:text-sky-400 transition-colors">{row.city}</a>
+						{@const g = wardGrade(row.fillRate, row.avgDays, row.total)}
+						<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-stone-50 dark:hover:bg-stone-800/30 transition-colors">
+							<td class="px-4 py-3 text-stone-600 dark:text-stone-300 capitalize">
+									<a href="/stats/ward/{row.city}/{row.ward}" class="hover:text-amber-500 transition-colors">{row.city}</a>
 								</td>
 								<td class="px-4 py-3 text-zinc-300">
-									<a href="/stats/ward/{row.city}/{row.ward}" aria-label="{row.city} Ward {row.ward}" class="hover:text-sky-400 transition-colors">Ward {row.ward}</a>
+									<a href="/stats/ward/{row.city}/{row.ward}" aria-label="{row.city} Ward {row.ward}" class="hover:text-amber-500 transition-colors">Ward {row.ward}</a>
 								</td>
 								<td class="px-4 py-3 hidden md:table-cell">
 									{#if row.councillorUrl}
@@ -463,28 +463,28 @@
 											href={row.councillorUrl}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="text-sky-400 hover:text-sky-300 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
+											class="text-amber-500 hover:text-amber-600 dark:hover:text-amber-400 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
 										>
 											{row.councillorName}
 										</a>
 									{:else}
-										<span class="text-zinc-500">{row.councillorName}</span>
+										<span class="text-stone-500 dark:text-stone-400">{row.councillorName}</span>
 									{/if}
 								</td>
-								<td class="px-4 py-3 text-right font-semibold {row.open > 0 ? 'text-orange-400' : 'text-zinc-500'}">
+								<td class="px-4 py-3 text-right font-semibold {row.open > 0 ? 'text-orange-400' : 'text-stone-500 dark:text-stone-400'}">
 									{row.open}
 								</td>
 								<td class="px-4 py-3 text-right text-sky-400">
 									{row.total === 0 ? '—' : `${fmt(row.fillRate, 0)}%`}
 								</td>
-								<td class="px-4 py-3 text-right text-zinc-400">{fmt(row.avgDays, 1)}</td>
+								<td class="px-4 py-3 text-right text-stone-500 dark:text-stone-400">{fmt(row.avgDays, 1)}</td>
 								<td class="px-4 py-3 text-right font-bold tabular-nums {g.color}" title="Grade: {g.grade}">{g.grade}</td>
 							</tr>
 						{/each}
 					</tbody>
 				</table>
 			</div>
-			<p class="text-xs text-zinc-600 mt-2">
+			<p class="text-xs text-stone-500 dark:text-stone-600 mt-2">
 				Click column headers to sort. Potholes outside mapped ward boundaries may be excluded.
 				Grade = fill rate (70%) + response speed (30%); requires ≥5 potholes.
 			</p>
@@ -494,24 +494,24 @@
 	<!-- ── Street hotspots ───────────────────────────────────────────────────── -->
 	{#if streetHotspots.length > 0}
 		<section aria-labelledby="hotspots-heading">
-			<h2 id="hotspots-heading" class="flex items-center gap-2 text-lg font-semibold text-white mb-4">
+			<h2 id="hotspots-heading" class="flex items-center gap-2 text-lg font-semibold text-stone-900 dark:text-white mb-4">
 				<Icon name="flame" size={18} class="text-orange-400 shrink-0" />
 				Top streets
 			</h2>
 			<div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
 				<table class="w-full text-sm">
 					<thead>
-						<tr class="border-b border-zinc-800">
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">#</th>
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">Street</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Total</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Open</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Filled</th>
+						<tr class="border-b border-stone-200 dark:border-stone-700">
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">#</th>
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Street</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Total</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Open</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Filled</th>
 						</tr>
 					</thead>
 					<tbody>
 						{#each streetHotspots as row, i (row.street)}
-							<tr class="border-b border-zinc-800/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
 								<td class="px-4 py-3 text-zinc-600 tabular-nums">{i + 1}</td>
 								<td class="px-4 py-3 font-medium text-white">{row.street}</td>
 								<td class="px-4 py-3 text-right font-semibold tabular-nums text-zinc-300">{row.total}</td>
@@ -522,40 +522,40 @@
 					</tbody>
 				</table>
 			</div>
-			<p class="text-xs text-zinc-600 mt-2">Street names extracted from geocoded addresses. Obeys the active time filter.</p>
+			<p class="text-xs text-stone-500 dark:text-stone-600 mt-2">Street names extracted from geocoded addresses. Obeys the active time filter.</p>
 		</section>
 	{/if}
 
 	<!-- ── Worst offenders ────────────────────────────────────────────────────── -->
 	<section aria-labelledby="offenders-heading">
-		<h2 id="offenders-heading" class="section-title flex items-center gap-2 text-lg text-white mb-4">
+		<h2 id="offenders-heading" class="section-title flex items-center gap-2 text-lg text-stone-900 dark:text-white mb-4">
 			<Icon name="alert-triangle" size={18} class="text-red-400 shrink-0" />
 			Longest-open unfilled holes
 		</h2>
 
 		{#if offenders.length === 0}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center text-green-400 text-sm font-semibold flex items-center justify-center gap-2">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-6 text-center text-green-400 text-sm font-semibold flex items-center justify-center gap-2">
 				<Icon name="check-circle" size={16} class="shrink-0" />
 				No open potholes in this time window!
 			</div>
 		{:else}
-			<div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md overflow-hidden overflow-x-auto">
 				<table class="w-full text-sm min-w-[520px]">
 					<thead>
-						<tr class="border-b border-zinc-800">
-							<th scope="col" class="text-left px-4 py-3 text-zinc-400 font-medium">Location</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium hidden sm:table-cell">Reported</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Confirmations</th>
-							<th scope="col" class="text-right px-4 py-3 text-zinc-400 font-medium">Days open</th>
+						<tr class="border-b border-stone-200 dark:border-stone-700">
+							<th scope="col" class="text-left px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Location</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium hidden sm:table-cell">Reported</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Confirmations</th>
+							<th scope="col" class="text-right px-4 py-3 text-stone-600 dark:text-stone-400 font-medium">Days open</th>
 						</tr>
 					</thead>
 					<tbody>
 				{#each offenders as p (p.id)}
-							<tr class="border-b border-zinc-800/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
 								<td class="px-4 py-3">
 									<a
 										href="/hole/{p.id}"
-										class="text-sky-400 hover:text-sky-300 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
+										class="text-amber-500 hover:text-amber-600 dark:hover:text-amber-400 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
 									>
 										{p.address ?? `${p.lat.toFixed(4)}, ${p.lng.toFixed(4)}`}
 									</a>
@@ -563,12 +563,12 @@
 								<td class="px-4 py-3 text-right text-zinc-400 hidden sm:table-cell">
 									{format(new Date(p.created_at), 'MMM d, yyyy')}
 								</td>
-								<td class="px-4 py-3 text-right text-zinc-300 tabular-nums">
+								<td class="px-4 py-3 text-right text-stone-600 dark:text-stone-300 tabular-nums">
 									{p.confirmed_count ?? 1}
 								</td>
 								<td
 									class="px-4 py-3 text-right font-bold tabular-nums
-										{p.days > 90 ? 'text-red-400' : p.days > 30 ? 'text-orange-400' : 'text-zinc-300'}"
+										{p.days > 90 ? 'text-red-400' : p.days > 30 ? 'text-orange-400' : 'text-stone-600 dark:text-stone-300'}"
 									aria-label="{p.days} days open"
 								>
 									{p.days}
@@ -581,7 +581,7 @@
 		{/if}
 	</section>
 
-	<p class="text-center text-xs text-zinc-700 pb-4">
+	<p class="text-center text-xs text-stone-600 dark:text-stone-700 pb-4">
 		Data refreshes on each page load. Ward assignment computes client-side and may miss potholes near boundaries.
 	</p>
 </div>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -374,13 +374,13 @@
 					</thead>
 					<tbody>
 					{#each cityRows as c (c.city)}
-							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-stone-100 dark:hover:bg-stone-800/30 transition-colors">
 								<td class="px-4 py-3 font-medium text-stone-900 dark:text-white">{c.city}</td>
 								<td class="px-4 py-3 text-right text-stone-600 dark:text-stone-300">{c.total}</td>
 								<td class="px-4 py-3 text-right font-semibold {c.open > 0 ? 'text-orange-400' : 'text-stone-500 dark:text-stone-400'}">{c.open}</td>
 								<td class="px-4 py-3 text-right text-green-400">{c.filled}</td>
 								<td class="px-4 py-3 text-right text-amber-500">{c.fillRate === null ? '—' : `${fmt(c.fillRate, 0)}%`}</td>
-								<td class="px-4 py-3 text-right text-zinc-400 hidden sm:table-cell">{fmt(c.avgDays, 1)}</td>
+								<td class="px-4 py-3 text-right text-stone-500 dark:text-stone-400 hidden sm:table-cell">{fmt(c.avgDays, 1)}</td>
 							</tr>
 						{/each}
 					</tbody>
@@ -454,7 +454,7 @@
 							<td class="px-4 py-3 text-stone-600 dark:text-stone-300 capitalize">
 									<a href="/stats/ward/{row.city}/{row.ward}" class="hover:text-amber-500 transition-colors">{row.city}</a>
 								</td>
-								<td class="px-4 py-3 text-zinc-300">
+								<td class="px-4 py-3 text-stone-600 dark:text-stone-300">
 									<a href="/stats/ward/{row.city}/{row.ward}" aria-label="{row.city} Ward {row.ward}" class="hover:text-amber-500 transition-colors">Ward {row.ward}</a>
 								</td>
 								<td class="px-4 py-3 hidden md:table-cell">
@@ -511,11 +511,11 @@
 					</thead>
 					<tbody>
 						{#each streetHotspots as row, i (row.street)}
-							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
-								<td class="px-4 py-3 text-zinc-600 tabular-nums">{i + 1}</td>
-								<td class="px-4 py-3 font-medium text-white">{row.street}</td>
-								<td class="px-4 py-3 text-right font-semibold tabular-nums text-zinc-300">{row.total}</td>
-								<td class="px-4 py-3 text-right tabular-nums {row.open > 0 ? 'text-orange-400 font-semibold' : 'text-zinc-500'}">{row.open}</td>
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-stone-100 dark:hover:bg-stone-800/30 transition-colors">
+								<td class="px-4 py-3 text-stone-500 dark:text-stone-400 tabular-nums">{i + 1}</td>
+								<td class="px-4 py-3 font-medium text-stone-900 dark:text-white">{row.street}</td>
+								<td class="px-4 py-3 text-right font-semibold tabular-nums text-stone-700 dark:text-stone-300">{row.total}</td>
+								<td class="px-4 py-3 text-right tabular-nums {row.open > 0 ? 'text-orange-400 font-semibold' : 'text-stone-500 dark:text-stone-400'}">{row.open}</td>
 								<td class="px-4 py-3 text-right tabular-nums text-green-400">{row.filled}</td>
 							</tr>
 						{/each}
@@ -551,7 +551,7 @@
 					</thead>
 					<tbody>
 				{#each offenders as p (p.id)}
-							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-zinc-800/30 transition-colors">
+							<tr class="border-b border-stone-200 dark:border-stone-700/50 last:border-0 hover:bg-stone-100 dark:hover:bg-stone-800/30 transition-colors">
 								<td class="px-4 py-3">
 									<a
 										href="/hole/{p.id}"
@@ -560,7 +560,7 @@
 										{p.address ?? `${p.lat.toFixed(4)}, ${p.lng.toFixed(4)}`}
 									</a>
 								</td>
-								<td class="px-4 py-3 text-right text-zinc-400 hidden sm:table-cell">
+								<td class="px-4 py-3 text-right text-stone-500 dark:text-stone-400 hidden sm:table-cell">
 									{format(new Date(p.created_at), 'MMM d, yyyy')}
 								</td>
 								<td class="px-4 py-3 text-right text-stone-600 dark:text-stone-300 tabular-nums">

--- a/src/routes/stats/ward/[city]/[ward]/+page.svelte
+++ b/src/routes/stats/ward/[city]/[ward]/+page.svelte
@@ -102,7 +102,7 @@
         {councillor.name.charAt(0)}
       </div>
       <div class="flex-1 min-w-0">
-        <p class="text-xs text-stone-500 uppercase tracking-wide">{cityLabel} · Ward {ward}</p>
+        <p class="text-xs font-semibold text-stone-500">{cityLabel} · Ward {ward}</p>
         <h1 class="text-xl font-bold text-white mt-0.5">{councillor.name}</h1>
       </div>
       <div class="shrink-0">

--- a/src/routes/stats/ward/[city]/[ward]/+page.svelte
+++ b/src/routes/stats/ward/[city]/[ward]/+page.svelte
@@ -90,7 +90,7 @@
 <div class="max-w-2xl mx-auto px-4 py-8 space-y-6">
 
   <!-- Back link -->
-  <a href="/stats#ward-heading" class="inline-flex items-center gap-1.5 text-stone-500 hover:text-stone-300 text-sm transition-colors">
+  <a href="/stats#ward-heading" class="inline-flex items-center gap-1.5 text-stone-500 hover:text-stone-700 dark:hover:text-stone-300 text-sm transition-colors">
     <Icon name="arrow-left" size={14} />
     All wards
   </a>

--- a/src/routes/stats/ward/[city]/[ward]/+page.svelte
+++ b/src/routes/stats/ward/[city]/[ward]/+page.svelte
@@ -90,49 +90,49 @@
 <div class="max-w-2xl mx-auto px-4 py-8 space-y-6">
 
   <!-- Back link -->
-  <a href="/stats#ward-heading" class="inline-flex items-center gap-1.5 text-zinc-500 hover:text-zinc-300 text-sm transition-colors">
+  <a href="/stats#ward-heading" class="inline-flex items-center gap-1.5 text-stone-500 hover:text-stone-300 text-sm transition-colors">
     <Icon name="arrow-left" size={14} />
     All wards
   </a>
 
   <!-- Header: councillor + grade -->
-  <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+  <div class="bg-stone-900 border border-stone-800 rounded-md p-5">
     <div class="flex items-start gap-4">
-      <div class="shrink-0 w-12 h-12 rounded-full bg-sky-500 flex items-center justify-center text-white font-bold text-xl select-none">
+      <div class="shrink-0 w-12 h-12 rounded-full bg-amber-500 flex items-center justify-center text-white font-bold text-xl select-none">
         {councillor.name.charAt(0)}
       </div>
       <div class="flex-1 min-w-0">
-        <p class="text-xs text-zinc-500 uppercase tracking-wide">{cityLabel} · Ward {ward}</p>
+        <p class="text-xs text-stone-500 uppercase tracking-wide">{cityLabel} · Ward {ward}</p>
         <h1 class="text-xl font-bold text-white mt-0.5">{councillor.name}</h1>
       </div>
       <div class="shrink-0">
         <span class="text-3xl font-extrabold {grade.color}">{grade.grade}</span>
-        <p class="text-xs text-zinc-600 text-right mt-0.5">grade</p>
+        <p class="text-xs text-stone-600 text-right mt-0.5">grade</p>
       </div>
     </div>
   </div>
 
   <!-- Stat pills -->
   <div class="grid grid-cols-3 gap-3">
-    <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 text-center">
+    <div class="bg-stone-900 border border-stone-800 rounded-md p-4 text-center">
       <p class="text-2xl font-bold text-white">{total}</p>
-      <p class="text-xs text-zinc-500 mt-0.5">reported</p>
+      <p class="text-xs text-stone-500 mt-0.5">reported</p>
     </div>
-    <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 text-center">
+    <div class="bg-stone-900 border border-stone-800 rounded-md p-4 text-center">
       <p class="text-2xl font-bold text-green-400">{filled}</p>
-      <p class="text-xs text-zinc-500 mt-0.5">filled</p>
+      <p class="text-xs text-stone-500 mt-0.5">filled</p>
     </div>
-    <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-4 text-center">
-      <p class="text-2xl font-bold {open > 0 ? 'text-orange-400' : 'text-zinc-500'}">{open}</p>
-      <p class="text-xs text-zinc-500 mt-0.5">open</p>
+    <div class="bg-stone-900 border border-stone-800 rounded-md p-4 text-center">
+      <p class="text-2xl font-bold {open > 0 ? 'text-orange-400' : 'text-stone-500'}">{open}</p>
+      <p class="text-xs text-stone-500 mt-0.5">open</p>
     </div>
   </div>
 
   <!-- Mini bar chart -->
-  <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+  <div class="bg-stone-900 border border-stone-800 rounded-md p-5">
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-zinc-300">Monthly activity</h2>
-      <div class="flex items-center gap-3 text-xs text-zinc-500">
+      <h2 class="text-sm font-semibold text-stone-300">Monthly activity</h2>
+      <div class="flex items-center gap-3 text-xs text-stone-500">
         <span class="flex items-center gap-1"><span class="w-2.5 h-2.5 rounded-sm bg-orange-500/70 inline-block"></span>Reported</span>
         <span class="flex items-center gap-1"><span class="w-2.5 h-2.5 rounded-sm bg-green-500/70 inline-block"></span>Filled</span>
       </div>
@@ -151,7 +151,7 @@
       {#each monthlyData as m, i (m.key)}
         <div class="flex-1 text-center min-w-0 overflow-hidden">
           {#if i % 3 === 0 || i === monthlyData.length - 1}
-            <span class="text-zinc-600 text-[9px]">{m.label}</span>
+            <span class="text-stone-600 text-[9px]">{m.label}</span>
           {/if}
         </div>
       {/each}
@@ -159,10 +159,10 @@
   </div>
 
   <!-- Open potholes list -->
-  <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-3">
-    <h2 class="text-sm font-semibold text-zinc-300">Open potholes in this ward</h2>
+  <div class="bg-stone-900 border border-stone-800 rounded-md p-5 space-y-3">
+    <h2 class="text-sm font-semibold text-stone-300">Open potholes in this ward</h2>
     {#if openPotholes.length === 0}
-      <p class="text-zinc-500 text-sm">No open potholes in this ward right now.</p>
+      <p class="text-stone-500 text-sm">No open potholes in this ward right now.</p>
     {:else}
       <ul class="space-y-2">
         {#each openPotholes as p (p.id)}
@@ -171,10 +171,10 @@
               href="/hole/{p.id}"
               class="flex items-center justify-between gap-3 text-sm hover:text-white transition-colors group"
             >
-              <span class="text-zinc-300 group-hover:text-white truncate">
+              <span class="text-stone-300 group-hover:text-white truncate">
                 {p.address || `${p.lat.toFixed(4)}, ${p.lng.toFixed(4)}`}
               </span>
-              <span class="shrink-0 text-zinc-600 tabular-nums text-xs">{p.days}d</span>
+              <span class="shrink-0 text-stone-600 tabular-nums text-xs">{p.days}d</span>
             </a>
           </li>
         {/each}
@@ -183,12 +183,12 @@
   </div>
 
   <!-- Actions -->
-  <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-3">
-    <h2 class="text-sm font-semibold text-zinc-300">Take action</h2>
+  <div class="bg-stone-900 border border-stone-800 rounded-md p-5 space-y-3">
+    <h2 class="text-sm font-semibold text-stone-300">Take action</h2>
     <div class="flex flex-wrap gap-2">
       <a
         href={emailUrl}
-        class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+        class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-800 hover:bg-stone-700 text-stone-300 text-sm rounded-md transition-colors"
       >
         <Icon name="mail" size={13} class="shrink-0" />
         Email {councillor.name.split(' ')[0]}
@@ -197,7 +197,7 @@
         href={councillor.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+        class="flex-1 inline-flex items-center justify-center gap-1.5 py-2 px-3 bg-stone-800 hover:bg-stone-700 text-stone-300 text-sm rounded-md transition-colors"
       >
         <Icon name="external-link" size={13} class="shrink-0" />
         Councillor page


### PR DESCRIPTION
## Summary

- Replaces AI-SaaS visual pattern (zinc + sky-500 + rounded-2xl + uppercase tracking labels) with a Civic Data Portal aesthetic — distinctive, purposeful, connected to the subject matter
- Stone palette replaces zinc (warm concrete undertone vs synthetic cool grey)
- Amber-500 replaces sky-500 as primary accent (road marking semantic connection)
- System-adaptive dark mode via `prefers-color-scheme` — no JS toggle required, works out of the box
- Bordered card surfaces replace filled zinc backgrounds (document-like, not SaaS dashboard)
- `uppercase tracking-[0.18em]` label pattern removed everywhere; weight hierarchy used instead
- `rounded-xl`/`rounded-2xl` capped at `rounded-md` throughout
- `HomeIntroCard` step cards replaced with amber-bordered `<ol>` (no icon halos)
- Status badges switched to outlined pattern (`border border-current`)
- All pages updated: home, report, pothole detail, stats, about, how-to, error, ward pages, shared components, admin nav

## Test plan

- [ ] Light mode visual walkthrough: home (map + intro card), report form, pothole detail, stats, about, how-to
- [ ] Dark mode walkthrough (DevTools → Rendering → `prefers-color-scheme: dark`)
- [ ] Mobile viewport check (375px) — mobile tool tray, report form
- [ ] Intro card appears on first visit (clear localStorage or private window), dismisses correctly
- [ ] Report form submits successfully end-to-end
- [ ] Stats time filters (All time / 1y / 90d / 30d) work correctly
- [ ] `npm run build` passes (verified in CI)
- [ ] No white-on-white or black-on-black in light mode (WCAG AA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)