### PR TITLE
docs: add CI, CodeQL, and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Live at **[fillthehole.ca](https://fillthehole.ca)**
 
+[![CI](https://github.com/BreakableHoodie/filltheholedotca/actions/workflows/ci.yml/badge.svg)](https://github.com/BreakableHoodie/filltheholedotca/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/BreakableHoodie/filltheholedotca/actions/workflows/codeql.yml/badge.svg)](https://github.com/BreakableHoodie/filltheholedotca/actions/workflows/codeql.yml)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
+
 ---
 
 ## What it does


### PR DESCRIPTION
## Summary

- Adds CI workflow status badge (build health at a glance for contributors)
- Adds CodeQL security analysis badge (signals the project takes security seriously)
- Adds AGPL-3.0 license badge (surfaces license implications upfront for anyone evaluating a fork or hosted deployment)

## Test plan

- [ ] Verify badges render correctly on the GitHub repo page
- [ ] Confirm CI and CodeQL badge links resolve to the correct workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)