### PR TITLE
feat(seo): meta hygiene, social cards, sitemap + robots — and fix broken OG images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ src/
       export.csv/+server.ts   # GET — CSV export of all reported/filled potholes (open data)
       feed.xml/+server.ts     # GET — RSS 2.0 feed of recent confirmations/fills (open data)
       ccc/[id]/+server.ts           # GET — ArcGIS CCC repair data proxy (off SSR path)
+      og/default/+server.ts         # GET — satori-rendered default OG/Twitter card (homepage + pages without a per-record image)
       notify/[id]/+server.ts        # POST/DELETE — per-pothole fill notification subscription
       geocode/search/+server.ts     # GET — Nominatim search proxy (sets User-Agent server-side)
       geocode/reverse/+server.ts    # GET — Nominatim reverse geocode proxy

--- a/src/app.css
+++ b/src/app.css
@@ -29,6 +29,11 @@
 
 body {
   font-family: var(--font-sans);
+  /* Opt into system dark mode so native controls, scrollbars, and the
+     pre-hydration canvas (visible in mobile overscroll/address-bar gaps)
+     follow the user's preference. Mirrors the layout's bg-stone-50/asphalt. */
+  color-scheme: light dark;
+  background-color: light-dark(#fafaf9, #191714);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app.html
+++ b/src/app.html
@@ -1,15 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-CA">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-		<meta name="description" content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, flag, and hold the city accountable." />
+		<!-- No global meta description: each route supplies its own via <svelte:head>.
+		     A site-wide tag here renders before %sveltekit.head% and would override the
+		     per-page descriptions search engines should actually use. -->
 		<meta property="og:site_name" content="FillTheHole.ca" />
 		<meta property="og:locale" content="en_CA" />
 		<link rel="icon" href="/favicon.png" type="image/png" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/manifest.webmanifest" />
-		<meta name="theme-color" content="#09090b" />
+		<meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#191714" media="(prefers-color-scheme: dark)" />
 		<script type="application/ld+json">
 		{
 			"@context": "https://schema.org",
@@ -46,7 +49,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="bg-zinc-950 text-zinc-100 min-h-screen">
+	<body data-sveltekit-preload-data="hover" class="min-h-screen">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/server/og-helpers.ts
+++ b/src/lib/server/og-helpers.ts
@@ -1,7 +1,14 @@
 // Lightweight satori element helper — avoids React dependency.
 // props intentionally typed as any: satori's CSS style values are mixed types
 // and the return must satisfy satori's internal ReactNode-compatible signature.
+//
+// Childless elements (shape-only boxes like status dots) MUST yield
+// `children: undefined`, not `[]` — satori reads an empty array as a multi-child
+// node and throws "Expected <div> to have explicit display: flex ... if it has
+// more than one child node", 500-ing the whole OG render.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function el(type: string, props: Record<string, any>, ...children: any[]): any {
-	return { type, props: { ...props, children: children.length === 1 ? children[0] : children } };
+	const child =
+		children.length === 0 ? undefined : children.length === 1 ? children[0] : children;
+	return { type, props: { ...props, children: child } };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,15 @@
 <svelte:head>
 	<title>Waterloo Region Pothole Tracker — FillTheHole.ca</title>
 	<link rel="canonical" href="https://fillthehole.ca{page.url.pathname}" />
+	<!-- Render og:image as a large card on Twitter/X; per-page og:image still applies -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<!-- RSS autodiscovery for the open-data activity feed -->
+	<link
+		rel="alternate"
+		type="application/rss+xml"
+		title="FillTheHole.ca — recent pothole activity"
+		href="https://fillthehole.ca/api/feed.xml"
+	/>
 	<!-- Preload critical fonts — eliminates the CSS @import waterfall for first paint -->
 	<link rel="preload" href={barlowBold} as="font" type="font/woff2" crossorigin="anonymous" />
 	<link rel="preload" href={publicSans400} as="font" type="font/woff2" crossorigin="anonymous" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -523,6 +523,10 @@
 	<meta property="og:description" content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, confirm, and hold the city accountable." />
 	<meta property="og:url" content="https://fillthehole.ca/" />
 	<meta property="og:type" content="website" />
+	<meta property="og:image" content="https://fillthehole.ca/api/og/default" />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="630" />
+	<meta name="twitter:image" content="https://fillthehole.ca/api/og/default" />
 </svelte:head>
 
 <h1 class="sr-only">Waterloo Region Pothole Map</h1>

--- a/src/routes/api/og/default/+server.ts
+++ b/src/routes/api/og/default/+server.ts
@@ -1,0 +1,131 @@
+import type { RequestHandler } from './$types';
+import { error } from '@sveltejs/kit';
+import satori from 'satori';
+import { Resvg } from '@resvg/resvg-js';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { logError } from '$lib/server/observability';
+import { el } from '$lib/server/og-helpers';
+
+// Static, content-free branded card used as the default Open Graph / Twitter
+// image for pages without a per-record image (homepage, about, how-to, etc.).
+// CLAUDE.md forbids committing binary assets, so this is generated at request
+// time and cached hard rather than shipped as a PNG in the repo. Visual family
+// is kept in sync with /api/og/[id] so all share cards look alike.
+const require = createRequire(import.meta.url);
+const OG_FONT_PATH = require.resolve(
+	'@fontsource/barlow-condensed/files/barlow-condensed-latin-700-normal.woff'
+);
+
+let fontCache: ArrayBuffer | null = null;
+
+async function loadFont(): Promise<ArrayBuffer> {
+	if (fontCache) return fontCache;
+	try {
+		const fontFile = await readFile(OG_FONT_PATH);
+		fontCache = fontFile.buffer.slice(fontFile.byteOffset, fontFile.byteOffset + fontFile.byteLength);
+		return fontCache;
+	} catch (e) {
+		// Do not cache failures — next request should retry loading from disk.
+		logError('og/default', 'Font load failed', e);
+		throw error(500, 'OG image generation unavailable');
+	}
+}
+
+export const GET: RequestHandler = async () => {
+	const font = await loadFont();
+
+	const svg = await satori(
+		el(
+			'div',
+			{
+				style: {
+					width: '100%',
+					height: '100%',
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'space-between',
+					background: '#09090b',
+					padding: '56px 64px',
+					fontFamily: 'Barlow Condensed',
+					borderLeft: '6px solid #f97316',
+				},
+			},
+			// Header: logo mark + wordmark
+			el(
+				'div',
+				{ style: { display: 'flex', alignItems: 'center', gap: '14px' } },
+				el(
+					'div',
+					{
+						style: {
+							width: 44,
+							height: 44,
+							borderRadius: 22,
+							background: '#f97316',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+						},
+					},
+					el('div', { style: { width: 27, height: 27, borderRadius: 14, background: '#09090b' } })
+				),
+				el(
+					'div',
+					{ style: { display: 'flex', alignItems: 'baseline' } },
+					el(
+						'span',
+						{ style: { fontSize: 26, fontWeight: 700, color: '#fff', letterSpacing: '0.02em' } },
+						'FillTheHole'
+					),
+					el('span', { style: { fontSize: 26, fontWeight: 700, color: '#38bdf8' } }, '.ca')
+				)
+			),
+			// Body: headline + tagline
+			el(
+				'div',
+				{ style: { display: 'flex', flexDirection: 'column', gap: '14px' } },
+				el(
+					'div',
+					{ style: { fontSize: 74, fontWeight: 700, color: '#fff', lineHeight: 1.05, letterSpacing: '-0.01em' } },
+					'Waterloo Region Pothole Tracker'
+				),
+				el(
+					'div',
+					{ style: { fontSize: 30, color: '#a1a1aa', letterSpacing: '0.01em' } },
+					'Report it. Confirm it. Hold the city accountable.'
+				)
+			),
+			// Footer: region label
+			el(
+				'div',
+				{ style: { display: 'flex', alignItems: 'center', gap: '12px' } },
+				el('div', { style: { width: 10, height: 10, borderRadius: 5, background: '#f97316' } }),
+				el(
+					'div',
+					{ style: { fontSize: 24, color: '#71717a', fontWeight: 700, letterSpacing: '0.04em' } },
+					'KITCHENER · WATERLOO · CAMBRIDGE'
+				)
+			)
+		),
+		{
+			width: 1200,
+			height: 630,
+			fonts: [{ name: 'Barlow Condensed', data: font, weight: 700, style: 'normal' }],
+		}
+	);
+
+	const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } });
+	const png = new Uint8Array(resvg.render().asPng());
+
+	return new Response(png, {
+		headers: {
+			'Content-Type': 'image/png',
+			// Static content — cache aggressively at the edge.
+			'Cache-Control': 'public, max-age=86400, s-maxage=604800, immutable',
+			// OG images are embedded by external social crawlers — opt out of the
+			// same-site default set in hooks.server.ts.
+			'Cross-Origin-Resource-Policy': 'cross-origin',
+		},
+	});
+};

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -395,6 +395,7 @@
 	<meta property="og:image" content="{origin}/api/og/{pothole.id}" />
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="630" />
+	<meta name="twitter:image" content="{origin}/api/og/{pothole.id}" />
 	<meta property="og:url" content="{origin}/hole/{pothole.id}" />
 	<meta property="og:type" content="website" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,11 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { supabase } from '$lib/supabase';
+import { COUNCILLORS } from '$lib/wards';
+import { logError } from '$lib/server/observability';
 import type { RequestHandler } from './$types';
 
 const ORIGIN = 'https://fillthehole.ca';
 
 const STATIC_PAGES = [
 	{ path: '/', changefreq: 'daily', priority: '1.0' },
+	{ path: '/report', changefreq: 'monthly', priority: '0.9' },
 	{ path: '/stats', changefreq: 'daily', priority: '0.8' },
 	{ path: '/how-to', changefreq: 'monthly', priority: '0.6' },
 	{ path: '/about', changefreq: 'monthly', priority: '0.5' }
@@ -25,7 +28,7 @@ export const GET: RequestHandler = async () => {
 		.order('created_at', { ascending: false });
 
 	if (dbError) {
-		console.error('sitemap: supabase error', dbError.message);
+		logError('sitemap', 'supabase error building sitemap', dbError);
 		error(503, 'Sitemap temporarily unavailable');
 	}
 
@@ -35,6 +38,16 @@ export const GET: RequestHandler = async () => {
     <loc>${ORIGIN}${path}</loc>
     <changefreq>${changefreq}</changefreq>
     <priority>${priority}</priority>
+  </url>`
+	).join('');
+
+	// One accountability page per councillor ward (/stats/ward/<city>/<ward>).
+	const wardEntries = COUNCILLORS.map(
+		({ city, ward }) => `
+  <url>
+    <loc>${ORIGIN}/stats/ward/${city}/${ward}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>`
 	).join('');
 
@@ -54,7 +67,7 @@ export const GET: RequestHandler = async () => {
 		.join('');
 
 	const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${staticEntries}${potholeEntries}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${staticEntries}${wardEntries}${potholeEntries}
 </urlset>`;
 
 	return new Response(xml, {

--- a/src/routes/stats/ward/[city]/[ward]/+page.svelte
+++ b/src/routes/stats/ward/[city]/[ward]/+page.svelte
@@ -78,11 +78,13 @@
 
 <svelte:head>
   <title>{councillor.name} · Ward {ward} — FillTheHole.ca</title>
+  <meta name="description" content="Ward {ward} {cityLabel} pothole accountability: grade {grade.grade}, {fillRate !== null ? fillRate.toFixed(0) + '% fill rate' : 'no data yet'}. {open} open potholes." />
   <meta property="og:title" content="{councillor.name} · Ward {ward} Accountability — FillTheHole.ca" />
   <meta property="og:description" content="Ward {ward} {cityLabel} pothole accountability: grade {grade.grade}, {fillRate !== null ? fillRate.toFixed(0) + '% fill rate' : 'no data yet'}. {open} open potholes." />
   <meta property="og:image" content="{origin}/api/og/ward/{city}/{ward}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
+  <meta name="twitter:image" content="{origin}/api/og/ward/{city}/{ward}" />
   <meta property="og:url" content="{origin}/stats/ward/{city}/{ward}" />
   <meta property="og:type" content="website" />
 </svelte:head>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,13 @@
-# allow crawling everything by default
+# Crawl public pages freely. The blanket /api/ block used to hide the
+# Open Graph images and open-data endpoints from crawlers and social
+# unfurlers — allow those explicitly, keep the rest of /api/ and all of
+# /admin/ out of the index.
 User-agent: *
+Allow: /api/og/
+Allow: /api/export.csv
+Allow: /api/feed.xml
+Allow: /api/feed.json
 Disallow: /api/
+Disallow: /admin/
 
 Sitemap: https://fillthehole.ca/sitemap.xml


### PR DESCRIPTION
Implements the **SEO** slice of the [2026-06-11 full-site audit](../blob/feat/seo-audit-fixes/docs/code-review/2026-06-11-full-site-audit.md). While verifying the new OG route, this also uncovered and fixes a **live production bug**: every Open Graph image is currently returning HTTP 500.

## 🐞 Production bugfix — OG images are 500ing right now

The shared `el()` helper in `og-helpers.ts` set `children: []` for shape-only boxes (status dots, the logo mark). satori 0.26 reads an empty array as a multi-child node and throws *"Expected `<div>` to have explicit display: flex … if it has more than one child node"*, 500-ing the whole render. **Verified against the live site** — `https://fillthehole.ca/api/og/<id>` returns `{"message":"Internal Error"}`.

```
- children: children.length === 1 ? children[0] : children
+ children: children.length === 0 ? undefined
+         : children.length === 1 ? children[0] : children
```

This restores `/api/og/[id]` and `/api/og/ward/...`. Verified locally: both now return `200 image/png` 1200×630 (were 500). Isolated in its own commit (`92d943a`) so it can be cherry-picked as a hotfix ahead of the rest.

## SEO improvements

**Meta hygiene**
- Removed the site-wide `<meta name="description">` from `app.html`. It rendered *before* `%sveltekit.head%`, so search engines saw it first and ignored each route's own (more specific) description. Every public route already sets its own.
- `lang="en"` → `lang="en-CA"`.
- Theme-color is now a light/dark media pair (`#fafaf9` / `#191714`) matching the stone/asphalt redesign; `app.css` adds `color-scheme: light dark` + a `light-dark()` body background so native controls and the mobile overscroll canvas stop flashing zinc.

**Social cards** (none of the non-detail pages had an `og:image` or any `twitter:*`)
- New `/api/og/default` — a generated satori card (no committed PNG, per repo policy), wired as the homepage `og:image`.
- `twitter:card=summary_large_image` + RSS autodiscovery in the layout.
- `twitter:image` added to homepage, hole detail, and ward pages.

**Discoverability**
- Sitemap: added `/report` and one entry per councillor ward (`/stats/ward/<city>/<ward>`); replaced the bare `console.error` with `logError`.
- Ward page now emits a real `<meta name="description">` (previously only `og:description`).
- `robots.txt`: the blanket `Disallow: /api/` was hiding OG images and the open-data feeds from crawlers/unfurlers. Now allows `/api/og/`, `export.csv`, `feed.xml`, `feed.json`; disallows `/admin/`.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → success
- Preview server: `/api/og/default` and `/api/og/[id]` both render valid 1200×630 PNGs (screenshot of the default card below)

![default OG card](https://github.com/BreakableHoodie/filltheholedotca/assets/placeholder) <!-- the rendered card: dark zinc, orange ring mark, "Waterloo Region Pothole Tracker", "Report it. Confirm it. Hold the city accountable.", KITCHENER · WATERLOO · CAMBRIDGE -->

## Notes / merge order

- Touches `app.html` and `+layout.svelte` head (lines distinct from the perf PR's font-preload edits) — expect a clean auto-merge.
- One of four audit PRs. Recommend merging after #170 (security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)