### PR TITLE
fix(a11y/ux): WCAG contrast, keyboard focus, resilient share, corrected how-to copy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,3 +65,12 @@ _Objective: Grow the community of reporters and make fixes more likely._
 - [x] **Repeat Pothole Detection:** Detail page warns when a nearby pothole was previously filled — flags recurring road issues for escalation.
 - [x] **Embed Widget:** `/api/embed/[id]` returns a self-contained embeddable card (iframe-friendly) showing pothole status and a CTA link back to the site.
 - [x] **PWA + Push Notifications:** Web App Manifest, service worker, and browser push notification infrastructure. Users can subscribe to fill alerts; requires `VAPID_PUBLIC_KEY` + `PUBLIC_VAPID_PUBLIC_KEY` env vars.
+
+## Phase 7: Accessibility & Inclusion (Planned)
+
+_Objective: Make the data usable for everyone, regardless of ability or input device._
+
+- [ ] **More accessible map experience:** Leaflet has known limitations for keyboard and screen-reader users — pan/zoom and spatial markers aren't meaningfully exposed to assistive technology. Evaluate migrating the map to **MapLibre GL JS** (vector tiles, modern styling, actively maintained) as the leading candidate.
+  - Trade-off to design around: WebGL/canvas maps are opaque to screen readers, so a library swap alone does **not** deliver accessibility. Pair any migration with a first-class non-map view — a sortable, filterable list/table of potholes as a true peer to the map, promoting today's `sr-only` "Pothole list" fallback into a real, styled interface.
+  - Target full keyboard operability for pan/zoom and marker focus, and adopt a documented WCAG 2.1 AA conformance goal for the map surface.
+- [ ] **Contrast & focus pass:** Carry the redesign's light/dark theming through every surface (status colours, watchlist, stats) and guarantee a visible keyboard focus indicator on all custom controls. _(Started in the 2026-06 accessibility audit PR.)_

--- a/src/lib/components/WatchlistPanel.svelte
+++ b/src/lib/components/WatchlistPanel.svelte
@@ -78,32 +78,32 @@
 </script>
 
 {#if ids.length > 0}
-	<section aria-labelledby="watchlist-heading" class="bg-stone-950 border-t border-stone-800">
+	<section aria-labelledby="watchlist-heading" class="bg-stone-100 dark:bg-stone-950 border-t border-stone-200 dark:border-stone-800">
 		<div class="max-w-6xl mx-auto px-4 py-8">
 			<div class="flex items-center gap-2 mb-5">
-				<Icon name="bookmark-filled" size={15} class="text-amber-400 shrink-0" />
-				<h2 id="watchlist-heading" class="text-sm font-semibold text-stone-300">
+				<Icon name="bookmark-filled" size={15} class="text-amber-600 dark:text-amber-400 shrink-0" />
+				<h2 id="watchlist-heading" class="text-sm font-semibold text-stone-700 dark:text-stone-300">
 					My Watchlist
 				</h2>
-				<span class="text-stone-600 text-xs tabular-nums ml-1">({ids.length})</span>
+				<span class="text-stone-500 dark:text-stone-400 text-xs tabular-nums ml-1">({ids.length})</span>
 			</div>
 
 			{#if loading}
 				<!-- Skeleton cards — match expected layout to prevent CLS -->
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each [...Array(Math.min(ids.length, PAGE_SIZE)).keys()] as i (i)}
-						<div class="relative bg-stone-900 rounded-md overflow-hidden border border-stone-800 h-[100px] animate-pulse">
-							<div class="absolute inset-y-0 left-0 w-[3px] bg-stone-700"></div>
+						<div class="relative bg-white dark:bg-stone-900 rounded-md overflow-hidden border border-stone-200 dark:border-stone-800 h-[100px] animate-pulse">
+							<div class="absolute inset-y-0 left-0 w-[3px] bg-stone-300 dark:bg-stone-700"></div>
 							<div class="pl-5 pr-3 pt-3.5 pb-3.5 flex flex-col gap-2.5">
-								<div class="h-4 bg-stone-700 rounded w-3/4"></div>
-								<div class="h-3 bg-stone-800 rounded w-1/2"></div>
-								<div class="h-3 bg-stone-800 rounded w-1/3"></div>
+								<div class="h-4 bg-stone-200 dark:bg-stone-700 rounded w-3/4"></div>
+								<div class="h-3 bg-stone-200 dark:bg-stone-800 rounded w-1/2"></div>
+								<div class="h-3 bg-stone-200 dark:bg-stone-800 rounded w-1/3"></div>
 							</div>
 						</div>
 					{/each}
 				</div>
 			{:else if fetchError}
-				<p class="text-stone-400 text-sm">Couldn't load watchlist status. Try refreshing.</p>
+				<p class="text-stone-600 dark:text-stone-400 text-sm">Couldn't load watchlist status. Try refreshing.</p>
 			{:else if potholes.length > 0}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each visiblePotholes as pothole (pothole.id)}
@@ -115,10 +115,10 @@
 							pothole.status === 'filled'   ? 'bg-green-500' :
 							pothole.status === 'expired'  ? 'bg-stone-600' : 'bg-stone-700'}
 						{@const pillColor =
-							pothole.status === 'reported' ? 'bg-orange-500/10 text-orange-400' :
-							pothole.status === 'filled'   ? 'bg-green-500/10 text-green-400' :
-							'bg-stone-700/60 text-stone-400'}
-						<div class="relative bg-stone-900 rounded-md overflow-hidden border border-stone-800 hover:border-stone-700 transition-colors">
+							pothole.status === 'reported' ? 'bg-orange-500/10 text-orange-700 dark:text-orange-400' :
+							pothole.status === 'filled'   ? 'bg-green-500/10 text-green-700 dark:text-green-400' :
+							'bg-stone-200 dark:bg-stone-700/60 text-stone-600 dark:text-stone-400'}
+						<div class="relative bg-white dark:bg-stone-900 rounded-md overflow-hidden border border-stone-200 dark:border-stone-800 hover:border-stone-300 dark:hover:border-stone-700 transition-colors">
 							<!-- Status accent strip -->
 							<div class="absolute inset-y-0 left-0 w-[3px] {accentColor}"></div>
 
@@ -127,13 +127,13 @@
 								<div class="flex items-start justify-between gap-2">
 									<a
 										href="/hole/{pothole.id}"
-										class="flex-1 text-sm font-semibold text-white hover:text-amber-400 transition-colors leading-snug line-clamp-2"
+										class="flex-1 text-sm font-semibold text-stone-900 dark:text-white hover:text-amber-600 dark:hover:text-amber-400 transition-colors leading-snug line-clamp-2"
 									>
 										{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
 									</a>
 									<button
 										onclick={() => unwatch(pothole.id)}
-										class="shrink-0 text-stone-600 hover:text-stone-300 transition-colors p-1 -mr-1 rounded-md hover:bg-stone-800"
+										class="shrink-0 text-stone-400 dark:text-stone-600 hover:text-stone-700 dark:hover:text-stone-300 transition-colors p-1 -mr-1 rounded-md hover:bg-stone-100 dark:hover:bg-stone-800"
 										aria-label="Remove {pothole.address || 'this pothole'} from watchlist"
 										title="Remove from watchlist"
 									>
@@ -147,20 +147,20 @@
 										<Icon name={info.icon} size={11} />
 										{info.label}
 									</span>
-									<span class="text-xs text-stone-600 tabular-nums shrink-0">{daysLabel(pothole)}</span>
+									<span class="text-xs text-stone-500 dark:text-stone-400 tabular-nums shrink-0">{daysLabel(pothole)}</span>
 								</div>
 
 								<!-- Footer: view link + photo badge -->
 								<div class="flex items-center justify-between gap-2 pt-0.5">
 									<a
 										href="/hole/{pothole.id}"
-										class="text-xs font-medium text-stone-400 hover:text-amber-400 transition-colors"
+										class="text-xs font-medium text-stone-600 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
 										aria-label="View details for {pothole.address || 'this pothole'}"
 									>
 										View details →
 									</a>
 									{#if pothole.photos_published}
-										<span class="inline-flex items-center gap-1 text-[11px] text-stone-600">
+										<span class="inline-flex items-center gap-1 text-[11px] text-stone-500 dark:text-stone-400">
 											<Icon name="camera" size={11} />
 											Photo
 										</span>
@@ -175,7 +175,7 @@
 						<button
 							type="button"
 							onclick={() => (showAll = !showAll)}
-							class="text-xs font-medium text-stone-400 hover:text-amber-400 transition-colors"
+							class="text-xs font-medium text-stone-600 dark:text-stone-400 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
 						>
 							{showAll ? 'Show fewer' : `Show ${potholes.length - PAGE_SIZE} more`}
 						</button>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,8 +15,12 @@ export const STATUS_CONFIG: Record<
 	string,
 	{ icon: IconName; label: string; colorClass: string; hex: string }
 > = {
-	pending:  { icon: 'clock',        label: 'Pending confirmation', colorClass: 'text-zinc-400',  hex: '#a1a1aa' },
-	reported: { icon: 'map-pin',      label: 'Reported',             colorClass: 'text-orange-400', hex: '#f97316' },
-	expired:  { icon: 'clock',        label: 'Expired',              colorClass: 'text-zinc-500',   hex: '#71717a' },
-	filled:   { icon: 'check-circle', label: 'Filled',               colorClass: 'text-green-400',  hex: '#22c55e' },
+	// colorClass carries light + dark variants: the single zinc/400-level values
+	// failed WCAG AA (4.5:1) on the light stone surfaces introduced in the redesign
+	// (e.g. text-orange-400 ≈ 2:1, text-green-400 ≈ 1.6:1 on white). hex is unchanged
+	// — it drives map markers, not body text.
+	pending:  { icon: 'clock',        label: 'Pending confirmation', colorClass: 'text-stone-500 dark:text-stone-400',  hex: '#a1a1aa' },
+	reported: { icon: 'map-pin',      label: 'Reported',             colorClass: 'text-orange-700 dark:text-orange-400', hex: '#f97316' },
+	expired:  { icon: 'clock',        label: 'Expired',              colorClass: 'text-stone-500 dark:text-stone-400',   hex: '#71717a' },
+	filled:   { icon: 'check-circle', label: 'Filled',               colorClass: 'text-green-700 dark:text-green-400',  hex: '#22c55e' },
 } as const;

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -373,14 +373,26 @@
 		return `https://www.google.com/maps?q=&layer=c&cbll=${lat},${lng}`;
 	}
 
-	function share(address: string | null, lat: number, lng: number) {
+	async function share(address: string | null, lat: number, lng: number) {
 		const loc = address || `${lat.toFixed(4)}, ${lng.toFixed(4)}`;
 		const text = `There's an unfilled pothole at ${loc} in the Waterloo Region — help get it on the map!`;
-		if (navigator.share) {
-			navigator.share({ title: 'fillthehole.ca', text, url: window.location.href });
-		} else {
-			navigator.clipboard.writeText(window.location.href);
-			toast.success('Link copied!');
+		const url = window.location.href;
+		try {
+			if (navigator.share) {
+				await navigator.share({ title: 'fillthehole.ca', text, url });
+			} else {
+				await navigator.clipboard.writeText(url);
+				toast.success('Link copied!');
+			}
+		} catch (err) {
+			// Dismissing the native share sheet rejects with AbortError — not a failure.
+			if (err instanceof Error && err.name === 'AbortError') return;
+			try {
+				await navigator.clipboard.writeText(url);
+				toast.success('Link copied!');
+			} catch {
+				toastError('Could not share this link.');
+			}
 		}
 	}
 

--- a/src/routes/how-to/+page.svelte
+++ b/src/routes/how-to/+page.svelte
@@ -51,14 +51,14 @@
 	<!-- Reporting -->
 	<section class="space-y-4">
 		<h2 class="section-title text-xl text-stone-900 dark:text-white flex items-center gap-2">
-			<Icon name="map-pin" size={18} class="text-orange-400 shrink-0" />
+			<Icon name="map-pin" size={18} class="text-orange-600 dark:text-orange-400 shrink-0" />
 			Reporting a pothole
 		</h2>
 
-		<div class="flex gap-3 bg-amber-950/40 border border-amber-700/40 rounded-md p-4 text-sm text-amber-200/90">
-			<Icon name="alert-triangle" size={18} class="text-amber-400 shrink-0 mt-0.5" />
+		<div class="flex gap-3 bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700/40 rounded-md p-4 text-sm text-amber-900 dark:text-amber-200/90">
+			<Icon name="alert-triangle" size={18} class="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
 			<p>
-				<strong class="text-amber-300">Stay safe.</strong>
+				<strong class="text-amber-900 dark:text-amber-300">Stay safe.</strong>
 				Never stop in traffic or step onto a road to report. Report from the sidewalk or parking lot,
 				or let a passenger report while you drive. No pothole is worth an injury.
 			</p>
@@ -69,7 +69,7 @@
 			<ol class="space-y-3 list-none">
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
-					<span><strong class="text-stone-700 dark:text-stone-200">Lock your location.</strong> Tap the crosshair icon to use your device's GPS, or search by address and drop a pin manually.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Set the location.</strong> Use GPS for the fastest report, or switch to the address or map tab to search or drop a pin.</span>
 				</li>
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
@@ -81,7 +81,7 @@
 				</li>
 				<li class="flex gap-3">
 					<span class="shrink-0 w-6 h-6 rounded-full bg-amber-500 text-stone-900 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
-					<span><strong class="text-stone-700 dark:text-stone-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation from a different location before it shows up on the public map.</span>
+					<span><strong class="text-stone-700 dark:text-stone-200">Submit.</strong> Your report is logged immediately. It needs one more independent confirmation — a second person reporting the same spot from their own device — before it shows up on the public map.</span>
 				</li>
 			</ol>
 		</div>
@@ -112,7 +112,7 @@
 			Watchlist
 		</h2>
 		<p class="text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
-			On any pothole detail page, tap <strong class="text-stone-700 dark:text-stone-200">Watch this hole</strong> to save
+			On any pothole detail page, tap <strong class="text-stone-700 dark:text-stone-200">Watch</strong> to save
 			it to your watchlist. Watched holes appear in a section on the homepage so you can quickly
 			see whether they've been filled.
 		</p>

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -632,6 +632,7 @@
 				{#each SEVERITY_OPTIONS as opt (opt.value)}
 					<label
 						class="flex flex-col items-start gap-1.5 p-3 rounded-md border text-left cursor-pointer transition-colors
+							has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-amber-500 has-[:focus-visible]:ring-offset-2 has-[:focus-visible]:ring-offset-white dark:has-[:focus-visible]:ring-offset-stone-900
 							{severity === opt.value
 								? 'border-amber-500 bg-amber-500/10'
 								: 'border-stone-300 dark:border-stone-600 hover:border-stone-400 dark:hover:border-stone-500'}"


### PR DESCRIPTION
Implements the **Accessibility / UX** slice of the [2026-06-11 full-site audit](../blob/fix/a11y-ux-audit/docs/code-review/2026-06-11-full-site-audit.md).

## Contrast (WCAG 2.1 AA, 4.5:1)

- **`STATUS_CONFIG`** status colours were single zinc/400-level tokens that fail on the redesign's light stone surfaces — `text-orange-400` ≈ 2:1, `text-green-400` ≈ 1.6:1 on white. Now light/dark pairs (`text-orange-700 dark:text-orange-400`, etc.). `hex` is untouched (it drives map markers, not text). Fixes the map legend, in-app status guide, hole detail, and watchlist.
- **`WatchlistPanel`** was fixed-dark throughout. On the light homepage that was both a jarring dark band *and* a real contrast failure (`text-stone-600` on `bg-stone-950` ≈ 2.5:1). Converted the whole component to mode-adaptive theming and lifted the dim secondary text to readable levels in both modes.

## Keyboard & interaction

- **Severity radios** (report form) are `sr-only` with the `<label>` carrying the visual state, but keyboard focus was invisible. Added a `has-[:focus-visible]` ring on the label — keyboard-only (the input is a child, not a sibling, so `peer-*` doesn't apply; `has-*` does).
- **`share()` on hole detail** was a floating promise: `navigator.share()` rejects with `AbortError` when the user dismisses the sheet (unhandled rejection), and `navigator.clipboard.writeText()` wasn't awaited so "Link copied!" fired even on failure. Rewrote it to mirror the homepage popup pattern — swallow `AbortError`, fall back to clipboard, surface a real error toast if that fails too.

## Content / copy (how-to)

- **Corrected a factual error**: the steps said a report "needs one more independent confirmation *from a different location*" — the opposite of the rule. A confirmation is a second person reporting the **same** spot (25m merge radius, distinct IPs), as the Confirming section already states.
- "Tap the crosshair icon" predated the GPS/Address/Map tab picker → updated.
- Watchlist button is labelled **"Watch"**, not "Watch this hole" → fixed (Label-in-Name).
- Safety callout used dark-only amber tokens that broke in light mode → made adaptive.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → success

## Deferred (noted in the audit doc)

`div`→`h2` card-title semantics on hole detail, stats-page contrast sweep, and the remaining component-level contrast items — lower-severity, batched for a follow-up to keep this PR reviewable.

## Notes

One of four audit PRs. No file overlap with the security (#170) or SEO (#171) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)