### PR TITLE
perf(psi): reduced-precision ward geometry, lighter map payload + bootstrap

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -20,7 +20,10 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
 	try {
 		const { data, error } = await supabase
 			.from('potholes')
-			.select('id, created_at, lat, lng, address, description, status, confirmed_count, filled_at, expired_at, photos_published')
+			// filled_at/expired_at are intentionally omitted — the map never reads
+			// them (the "mark filled" flow sets filled_at on its own optimistic copy),
+			// so they're dead weight across up to MAX_POTHOLES_ON_HOME_PAGE rows.
+			.select('id, created_at, lat, lng, address, description, status, confirmed_count, photos_published')
 			.neq('status', 'pending')
 			.order('created_at', { ascending: false })
 			.limit(MAX_POTHOLES_ON_HOME_PAGE);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -297,13 +297,21 @@
 	}
 
 	onMount(async () => {
-		await import('leaflet/dist/leaflet.css');
+		// The three stylesheets have no load-order constraint, so fetch them in
+		// parallel rather than in series. Only the JS is ordered: markercluster
+		// augments the global `L`, so leaflet must register window.L before it
+		// imports. This turns a 6-request waterfall into CSS-in-parallel alongside
+		// leaflet -> markercluster.
+		const cssLoaded = Promise.all([
+			import('leaflet/dist/leaflet.css'),
+			import('leaflet.markercluster/dist/MarkerCluster.css'),
+			import('leaflet.markercluster/dist/MarkerCluster.Default.css')
+		]);
 		const leafletModule = await import('leaflet');
 		const L = leafletModule.default ?? leafletModule;
 		(window as unknown as Record<string, unknown>).L = L;
 		await import('leaflet.markercluster');
-		await import('leaflet.markercluster/dist/MarkerCluster.css');
-		await import('leaflet.markercluster/dist/MarkerCluster.Default.css');
+		await cssLoaded;
 
 		LRef = L;
 
@@ -355,6 +363,15 @@
 		clientPotholes = seededPotholes?.length ? seededPotholes : null;
 		markersById = {};
 
+		// Collect markers per layer, then bulk-insert with addLayers() after the
+		// loop. markercluster reclusters on every addLayer(); one addLayers() per
+		// group clusters once instead of once per marker — a real win at scale.
+		const pendingByLayer: Record<string, import('leaflet').Marker[]> = {
+			reported: [],
+			expired: [],
+			filled: []
+		};
+
 		for (const pothole of potholesToRender) {
 			// Any unknown legacy status falls back to the reported layer.
 			const layerKey = pothole.status in clusterGroups ? pothole.status : 'reported';
@@ -397,7 +414,12 @@
 				{ maxWidth: 240 }
 			);
 
-			clusterGroups[layerKey].addLayer(marker);
+			pendingByLayer[layerKey].push(marker);
+		}
+
+		// One bulk insert per cluster group instead of one recluster per marker.
+		for (const [key, group] of Object.entries(clusterGroups)) {
+			if (pendingByLayer[key].length) group.addLayers(pendingByLayer[key]);
 		}
 
 		// Delegated listener for popup Fixed button

--- a/src/routes/api/wards.geojson/+server.ts
+++ b/src/routes/api/wards.geojson/+server.ts
@@ -23,17 +23,19 @@ type NormalizedFeature = {
 const SOURCES = [
 	{
 		city: 'kitchener',
-		url: 'https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Wards/FeatureServer/0/query?where=1%3D1&outFields=WARDID&outSR=4326&f=geojson',
+		// geometryPrecision=5 (~1m) roughly halves the boundary payload with no
+		// visible difference at map zoom levels (verified: 153 kB -> 87 kB).
+		url: 'https://services1.arcgis.com/qAo1OsXi67t7XgmS/arcgis/rest/services/Wards/FeatureServer/0/query?where=1%3D1&outFields=WARDID&outSR=4326&geometryPrecision=5&f=geojson',
 		wardField: 'WARDID'
 	},
 	{
 		city: 'waterloo',
-		url: 'https://services.arcgis.com/ZpeBVw5o1kjit7LT/arcgis/rest/services/Wards2022/FeatureServer/0/query?where=1%3D1&outFields=WARD_NO&outSR=4326&f=geojson',
+		url: 'https://services.arcgis.com/ZpeBVw5o1kjit7LT/arcgis/rest/services/Wards2022/FeatureServer/0/query?where=1%3D1&outFields=WARD_NO&outSR=4326&geometryPrecision=5&f=geojson',
 		wardField: 'WARD_NO'
 	},
 	{
 		city: 'cambridge',
-		url: 'https://maps.cambridge.ca/arcgispub03/rest/services/Voting/FeatureServer/2/query?where=1%3D1&outFields=WARD_ID&outSR=4326&f=geojson',
+		url: 'https://maps.cambridge.ca/arcgispub03/rest/services/Voting/FeatureServer/2/query?where=1%3D1&outFields=WARD_ID&outSR=4326&geometryPrecision=5&f=geojson',
 		wardField: 'WARD_ID'
 	}
 ] satisfies SourceConfig[];


### PR DESCRIPTION
Implements the **Performance / PSI** slice of the [2026-06-11 full-site audit](../blob/perf/psi-critical-path/docs/code-review/2026-06-11-full-site-audit.md). Focused on the map critical path — the heaviest part of the homepage.

## Changes

**Ward boundary payload (biggest win)**
The three ArcGIS sources returned full ~15-decimal coordinates. Adding `geometryPrecision=5` (~1m, imperceptible at map zoom) roughly halves each. Measured against the live endpoints:

| Source | Before | After |
|--------|--------|-------|
| Kitchener | 153 kB | 87 kB |
| Cambridge | — | 67 kB |
| Combined (`/api/wards.geojson`) | ~374 kB | ~216 kB |

All three endpoints (including the older `maps.cambridge.ca` server) honour the param and return valid features.

**SSR payload**
Dropped `filled_at`/`expired_at` from the homepage map query — the page never reads them (the "mark filled" flow sets `filled_at` on its own optimistic copy), so they were dead weight across up to 2000 rows.

**Leaflet bootstrap waterfall**
The three stylesheets have no load-order constraint but were `await`ed in series behind the JS. Now they load in parallel alongside the ordered `leaflet → markercluster` JS (markercluster augments `window.L`, so that pair stays sequential). Six sequential requests become two short chains.

**Marker insertion**
Collect markers per cluster group and insert with one `addLayers()` per group instead of `addLayer()` per marker. markercluster reclusters on every add, so this clusters once per group rather than once per marker — a real win as the dataset grows.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → success
- Preview: homepage 200; `/api/wards.geojson` returns 25 features with 5-decimal coordinates

## Deferred (with rationale, in the audit doc)

- **Defer Sentry init off the critical path** — the clean version needs early-error buffering so nothing is dropped before idle; doing it carelessly trades a perf win for lost error visibility. Wants measurement + a buffering shim, not a drive-by change.
- **Font preload retune** — overlaps the SEO PR's `+layout.svelte` head edits and risks FOUT without LCP measurement.

## Notes

One of four audit PRs. No file overlap with security (#170) or a11y (#172); the SEO PR (#171) also touches `+layout.svelte` head but on different lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)