### PR TITLE
docs(roadmap): reframe Phase 7 — keep Leaflet, build an accessible list view

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ _Objective: Grow the community of reporters and make fixes more likely._
 
 _Objective: Make the data usable for everyone, regardless of ability or input device._
 
-- [ ] **More accessible map experience:** Leaflet has known limitations for keyboard and screen-reader users — pan/zoom and spatial markers aren't meaningfully exposed to assistive technology. Evaluate migrating the map to **MapLibre GL JS** (vector tiles, modern styling, actively maintained) as the leading candidate.
-  - Trade-off to design around: WebGL/canvas maps are opaque to screen readers, so a library swap alone does **not** deliver accessibility. Pair any migration with a first-class non-map view — a sortable, filterable list/table of potholes as a true peer to the map, promoting today's `sr-only` "Pothole list" fallback into a real, styled interface.
-  - Target full keyboard operability for pan/zoom and marker focus, and adopt a documented WCAG 2.1 AA conformance goal for the map surface.
+- [ ] **Accessible non-map data view:** Maps are inherently hard for screen-reader and keyboard users, and the fix is a first-class *alternative* to the map — not a different map library. (A WebGL/canvas map such as MapLibre would render markers to an opaque `<canvas>`, making it *less* legible to assistive tech than Leaflet's DOM markers — so Leaflet stays.) Promote today's `sr-only` "Pothole list" into a real, visible, sortable/filterable list or table view that toggles with the map.
+  - Ensure every map-only action (share, "it's fixed", open details) has a keyboard-reachable equivalent in the list view.
+  - Keyboard-audit the map controls and popups; adopt a documented WCAG 2.1 AA conformance goal for the homepage.
 - [ ] **Contrast & focus pass:** Carry the redesign's light/dark theming through every surface (status colours, watchlist, stats) and guarantee a visible keyboard focus indicator on all custom controls. _(Started in the 2026-06 accessibility audit PR.)_


### PR DESCRIPTION
Follow-up to #172. The Phase 7 map item landed in main (via #172's squash) with the original framing — "evaluate migrating to MapLibre." A closer look at the integration surface changed the recommendation, and #172 merged before the corrected wording could be folded in. This PR carries just that wording fix.

## Why keep Leaflet

- **MapLibre would regress the goal.** GL/canvas markers render to an opaque `<canvas>` — *less* legible to assistive tech than Leaflet's DOM markers. The accessibility win is a non-map data view, which is library-agnostic.
- **~4× bundle.** `maplibre-gl` (~200 kB gz) vs Leaflet + markercluster (~50 kB gz) — undoes the PSI/critical-path work in #173.
- **Added dependency.** Vector tiles need a style + tile provider (cost/ops) vs the free OSM raster tiles used today.
- **Hard-to-port pattern.** The app relies on clustering *plus* interactive HTML popups/markers — Leaflet + markercluster's sweet spot; GL clustering can't carry interactive DOM.

So Phase 7's map item now targets promoting the existing `sr-only` "Pothole list" into a real, toggleable, sortable/filterable list/table view, plus a keyboard/ARIA pass — Leaflet stays.

Docs-only, one file, three lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)