### PR TITLE
feat: public "What's new" changelog page (/updates)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ src/
     +page.server.ts           # Loads potholes for map
     about/+page.svelte        # About page
     how-to/+page.svelte       # User-facing how-to / help guide
+    updates/+page.svelte      # "What's new" public changelog (data in $lib/updates.ts)
     stats/
       +page.server.ts         # SSR load — potholes for metrics
       +page.svelte            # Metrics dashboard (resolution time, ward leaderboards, trends, fill rate)

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -1,0 +1,37 @@
+// Public changelog shown on /updates. Keep entries resident-facing — describe
+// the user-visible improvement, not the implementation. Newest first.
+
+export interface UpdateEntry {
+	/** ISO date (YYYY-MM-DD) — used for the <time> element and ordering. */
+	date: string;
+	title: string;
+	items: string[];
+}
+
+export const UPDATES: UpdateEntry[] = [
+	{
+		date: '2026-06-11',
+		title: 'Pothole season, visualized',
+		items: [
+			'The stats page now overlays freeze–thaw cycles — the winter weather pattern that actually creates potholes — so you can see reports rise and fall with the thaw.'
+		]
+	},
+	{
+		date: '2026-06-11',
+		title: 'Faster, more private, more accessible',
+		items: [
+			'The map loads faster, with lighter ward boundaries and a quicker startup.',
+			'Stronger privacy: reports that have not yet been confirmed by a second person are no longer publicly listable.',
+			'Accessibility pass — better colour contrast, visible keyboard focus, and improved screen-reader support across the site.',
+			'Link previews (the cards shown when you share a pothole on social media) work again, and sharing is more reliable.',
+			'Clearer instructions on the how-to page, and better search-engine and feed discoverability.'
+		]
+	},
+	{
+		date: '2026-06-09',
+		title: 'A fresh look',
+		items: [
+			'A new civic-data-portal design in warm stone and amber, with automatic dark mode that follows your device.'
+		]
+	}
+];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -116,6 +116,8 @@
 			Community-sourced data — not official. Use at your own risk.
 			<a href="/how-to" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">How to use</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+			<a href="/updates" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">What's new</a>
+			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
 			<a href="/about#privacy" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Privacy</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
 			<a href="/about#disclaimer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Disclaimer</a>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -11,7 +11,8 @@ const STATIC_PAGES = [
 	{ path: '/report', changefreq: 'monthly', priority: '0.9' },
 	{ path: '/stats', changefreq: 'daily', priority: '0.8' },
 	{ path: '/how-to', changefreq: 'monthly', priority: '0.6' },
-	{ path: '/about', changefreq: 'monthly', priority: '0.5' }
+	{ path: '/about', changefreq: 'monthly', priority: '0.5' },
+	{ path: '/updates', changefreq: 'monthly', priority: '0.4' }
 ];
 
 const PRIORITY: Record<string, string> = {

--- a/src/routes/updates/+page.svelte
+++ b/src/routes/updates/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { format } from 'date-fns';
+	import { UPDATES } from '$lib/updates';
+</script>
+
+<svelte:head>
+	<title>What's new — FillTheHole.ca</title>
+	<meta
+		name="description"
+		content="Recent updates and improvements to FillTheHole.ca, the community pothole tracker for Waterloo Region."
+	/>
+</svelte:head>
+
+<div class="max-w-2xl mx-auto px-4 py-12 space-y-10">
+	<div>
+		<h1 class="page-title text-4xl sm:text-5xl text-stone-900 dark:text-white mb-2">What's new</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-lg">
+			Improvements we've shipped to the tracker. This is a community project, built in the open.
+		</p>
+	</div>
+
+	<div class="space-y-8">
+		{#each UPDATES as entry (entry.date + entry.title)}
+			<section class="space-y-3">
+				<div class="flex items-baseline justify-between gap-3 flex-wrap">
+					<h2 class="section-title text-xl text-stone-900 dark:text-white">{entry.title}</h2>
+					<time
+						datetime={entry.date}
+						class="text-xs font-medium text-stone-500 dark:text-stone-400 tabular-nums shrink-0"
+					>
+						{format(new Date(entry.date + 'T00:00:00'), 'MMM d, yyyy')}
+					</time>
+				</div>
+				<ul class="space-y-2">
+					{#each entry.items as item (item)}
+						<li class="flex gap-2.5 text-stone-600 dark:text-stone-400 leading-relaxed">
+							<span class="mt-2 w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" aria-hidden="true"></span>
+							<span>{item}</span>
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/each}
+	</div>
+
+	<p class="text-sm text-stone-500 dark:text-stone-400">
+		Want the exact details? Everything is public on
+		<a
+			href="https://github.com/BreakableHoodie/filltheholedotca"
+			target="_blank"
+			rel="noopener noreferrer"
+			class="underline hover:text-stone-700 dark:hover:text-stone-200 transition-colors">GitHub</a
+		>.
+	</p>
+</div>


### PR DESCRIPTION
Adds **`/updates`** — a resident-facing, dated list of shipped improvements, linked as **"What's new"** in the footer.

Per our discussion: this is the *transparency* version of a changelog rather than a Slack-style header popover. A quiet public page signals an actively-maintained civic project (the antidote to the civic-app-graveyard perception) without cluttering the header or adding per-user dismiss state for an audience that visits occasionally. It also gives the Bluesky bot something to announce and adds an SEO surface.

## What's here

- **`$lib/updates.ts`** — a typed `UpdateEntry[]` with user-facing copy (newest first). Editing the changelog is a one-array change; nothing else to touch.
- **`/updates/+page.svelte`** — reuses the about/how-to layout (stone/amber, dark-mode-ready), dated entries with `<time>`, plain SSR (no extra load).
- **Footer** — a site-wide "What's new" link.
- **Sitemap** — `/updates` added at priority 0.4.

Seeded with this stretch of work, framed for residents (e.g. "Stronger privacy: unconfirmed reports are no longer publicly listable" rather than "RLS policy hardening").

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → success
- Preview: `/updates` → 200, all entries render; "What's new" link present in the footer site-wide

## Merge note

References the freeze–thaw feature (#175) as shipped, so merge this **after** #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)