### PR TITLE
fix(seo): stop %sveltekit.head% leaking as visible text (re-land stranded fix)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,9 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-		<!-- No global meta description: each route supplies its own via <svelte:head>.
-		     A site-wide tag here renders before %sveltekit.head% and would override the
-		     per-page descriptions search engines should actually use. -->
+		<!-- No global meta description here on purpose: every route sets its own in
+		     its page head. A site-wide tag in this file would render first and take
+		     precedence over the per-page descriptions search engines should use. -->
 		<meta property="og:site_name" content="FillTheHole.ca" />
 		<meta property="og:locale" content="en_CA" />
 		<link rel="icon" href="/favicon.png" type="image/png" />


### PR DESCRIPTION
## The bug (live in production)

The `app.html` head comment literally contains `%sveltekit.head%`:

```html
<!-- … renders before %sveltekit.head% and would override the
     per-page descriptions search engines should actually use. -->
```

SvelteKit does a naive `String.replace('%sveltekit.head%', head)` on `app.html` (**first match only**), so it injects the rendered head **inside the comment** — breaking it — and leaves the *real* placeholder lower in the file rendering as literal text. The result is the visible string at the top of every page:

> and would override the per-page descriptions search engines should actually use. --> %sveltekit.head%

## Why it wasn't already fixed

The corrected wording was written during the SEO work but **pushed to that branch after its PR had already squash-merged**, so it never reached `main` (same merge-order stranding that hit the Phase 7 roadmap edit). `main` has been serving the broken comment since. This re-lands the fix from a fresh branch off current `main`.

## The fix

Reword the comment with no `%…%` placeholder and no angle-bracket tag.

## Verification (production build)

- literal `%sveltekit.head%` in rendered homepage: **0**
- leaked comment text: **0**
- `<title>` renders; exactly **1** `name="description"` meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)