### PR TITLE
feat(a11y): add homepage list view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@ Documentation that's wrong is worse than no documentation. Update it in the same
 
 If a PR touches infrastructure, routes, or the DB schema without updating the relevant docs, treat it as incomplete.
 
+### Roadmap & Planning Docs
+- **`ROADMAP.md`** — canonical project roadmap. Check this first when asked what remains, what's planned, or whether a phase is complete.
+- **`docs/superpowers/specs/`** — feature/design specs. Some older specs may already be implemented; verify against the code before treating them as open work.
+- **`docs/superpowers/plans/`** — implementation plans/checklists. These can be stale after a PR lands; use them for context, not as the source of truth unless the current code and `ROADMAP.md` agree.
+- Current known remaining roadmap work is Phase 7 in `ROADMAP.md`: homepage map WCAG 2.1 AA keyboard audit and contrast/focus pass. The visible homepage Map/List toggle and keyboard-equivalent list actions have shipped.
+
 ## Repo Hygiene — Non-Negotiable
 
 The repo is public. Treat every commit as permanent.
@@ -76,11 +82,7 @@ npm run dev          # http://localhost:5173
 | `npm run build` | Production build |
 | `npm run check` | Type checking (svelte-check) |
 | `npm run lint` | ESLint (TS + Svelte files) |
-| `npm run format` | Prettier format all source files |
-| `npm run format:check` | Prettier check-only (no writes) |
 | `npm run test` | Playwright E2E tests |
-| `npm run test:unit` | Vitest unit tests |
-| `npm run test:all` | Vitest + Playwright |
 | `npm run test:a11y` | axe-core a11y tests (Playwright) |
 
 ### Pre-commit hooks (Husky + lint-staged)
@@ -96,11 +98,10 @@ npm run dev          # http://localhost:5173
 - `prettier-plugin-svelte` handles Svelte files
 - **eslint-config-prettier** disables ESLint rules that conflict with Prettier
 
-### Unit tests (Vitest)
-- Fast Node.js tests for pure functions (no DOM/SSR needed)
-- Config: `vitest.config.ts` — includes `$lib` alias
-- E2E tests remain in Playwright; unit tests should be Vitest for speed
-- Existing Playwright-based unit tests (`exif-strip`, `ssrf`) migrated to Vitest
+### Unit tests
+- Unit-style tests live under `tests/unit/` and currently run through Playwright (`npx playwright test tests/unit/`).
+- There is no Vitest configuration or `npm run test:unit` script in the current project.
+- E2E and API-level tests also use Playwright under `tests/e2e/`; axe checks use `npm run test:a11y`.
 
 ### EditorConfig
 - **`.editorconfig`** enforces consistent indentation across editors

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,7 @@ _Objective: Grow the community of reporters and make fixes more likely._
 _Objective: Make the data usable for everyone, regardless of ability or input device._
 
 - [ ] **Accessible non-map data view:** Maps are inherently hard for screen-reader and keyboard users, and the fix is a first-class *alternative* to the map — not a different map library. (A WebGL/canvas map such as MapLibre would render markers to an opaque `<canvas>`, making it *less* legible to assistive tech than Leaflet's DOM markers — so Leaflet stays.) Promote today's `sr-only` "Pothole list" into a real, visible, sortable/filterable list or table view that toggles with the map.
-  - Ensure every map-only action (share, "it's fixed", open details) has a keyboard-reachable equivalent in the list view.
-  - Keyboard-audit the map controls and popups; adopt a documented WCAG 2.1 AA conformance goal for the homepage.
+  - [x] Add a visible Map/List toggle and sortable/filterable list view on the homepage.
+  - [x] Ensure map-only actions (share, "it's fixed", open details, show on map) have keyboard-reachable equivalents in the list view.
+  - [ ] Keyboard-audit the map controls and popups; adopt a documented WCAG 2.1 AA conformance goal for the homepage.
 - [ ] **Contrast & focus pass:** Carry the redesign's light/dark theming through every surface (status colours, watchlist, stats) and guarantee a visible keyboard focus indicator on all custom controls. _(Started in the 2026-06 accessibility audit PR.)_

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -185,12 +185,34 @@
 			.slice(0, 4),
 	);
 
-	// Pre-sorted list for the sr-only aside — avoids inline sort on every render.
-	let reportedPotholesSorted = $derived(
-		potholes
-			.filter((p) => p.status === 'reported')
-			.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)),
+	type ViewMode = 'map' | 'list';
+	type ListStatusFilter = 'all' | 'reported' | 'filled' | 'expired';
+	type ListSort = 'newest' | 'oldest' | 'status';
+
+	let viewMode = $state<ViewMode>('map');
+	let listStatusFilter = $state<ListStatusFilter>('reported');
+	let listSort = $state<ListSort>('newest');
+
+	let visibleListPotholes = $derived(
+		[...potholes]
+			.filter((pothole) => listStatusFilter === 'all' || pothole.status === listStatusFilter)
+			.sort((left, right) => {
+				if (listSort === 'oldest') return Date.parse(left.created_at) - Date.parse(right.created_at);
+				if (listSort === 'status') {
+					const statusOrder = { reported: 0, expired: 1, filled: 2, pending: 3 };
+					return statusOrder[left.status] - statusOrder[right.status];
+				}
+				return Date.parse(right.created_at) - Date.parse(left.created_at);
+			}),
 	);
+
+	function potholeLabel(pothole: Pothole) {
+		return pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`;
+	}
+
+	function formattedDate(iso: string) {
+		return iso.slice(0, 10);
+	}
 
 	// Report-here pin-drop mode
 	let reportMode = $state(false);
@@ -291,26 +313,89 @@
 		const marker = markersById[id];
 		if (!map || !marker) return;
 
-		if (!layers.reported) {
-			layers.reported = true;
-			map.addLayer(clusterGroups.reported);
+		const status = potholes.find((pothole) => pothole.id === id)?.status;
+		const layerKey = status === 'filled' || status === 'expired' ? status : 'reported';
+
+		if (!layers[layerKey]) {
+			layers[layerKey] = true;
+			map.addLayer(clusterGroups[layerKey]);
 		}
 
 		mobileToolsOpen = false;
+		viewMode = 'map';
 		const latLng = marker.getLatLng();
 		const targetZoom = Math.max(map.getZoom(), 15);
 
 		// MarkerCluster requires zooming through the cluster before the popup can open.
-		if (!clusterGroups.reported?.zoomToShowLayer) {
+		if (!clusterGroups[layerKey]?.zoomToShowLayer) {
 			map.flyTo(latLng, targetZoom, { duration: 0.6 });
 			marker.openPopup();
 			return;
 		}
 
-		clusterGroups.reported.zoomToShowLayer(marker, () => {
+		clusterGroups[layerKey].zoomToShowLayer(marker, () => {
 			map.flyTo(latLng, targetZoom, { duration: 0.6 });
 			marker.openPopup();
 		});
+	}
+
+	async function showPotholeOnMap(id: string) {
+		viewMode = 'map';
+		await tick();
+		focusPothole(id);
+	}
+
+	async function sharePothole(pothole: Pothole) {
+		const url = `${window.location.origin}/hole/${pothole.id}`;
+		const text = `Pothole at ${potholeLabel(pothole)} in Waterloo Region`;
+
+		try {
+			if (navigator.share) {
+				await navigator.share({ title: 'FillTheHole.ca pothole report', text, url });
+			} else {
+				await navigator.clipboard.writeText(url);
+				toast.success('Link copied.');
+			}
+		} catch (err) {
+			if (err instanceof Error && err.name === 'AbortError') return;
+			try {
+				await navigator.clipboard.writeText(url);
+				toast.success('Link copied.');
+			} catch {
+				toastError('Could not share this link.');
+			}
+		}
+	}
+
+	async function markPotholeFilled(id: string) {
+		try {
+			const res = await fetch('/api/filled', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id }),
+			});
+			const result = await res.json();
+			if (!res.ok && res.status !== 409) throw new Error(result.message || 'Failed');
+
+			toast.success(result.ok ? 'Marked as fixed!' : result.message);
+			if (!result.ok) return;
+
+			if (!clientPotholes) clientPotholes = [...(potholes as Pothole[])];
+			clientPotholes = clientPotholes.map((pothole) =>
+				pothole.id === id
+					? { ...pothole, status: 'filled', filled_at: new Date().toISOString() }
+					: pothole,
+			);
+
+			const marker = markersById[id];
+			if (marker) {
+				clusterGroups.reported?.removeLayer(marker);
+				clusterGroups.filled?.addLayer(marker);
+			}
+			liveAnnouncement = 'Pothole marked fixed and moved to the filled list.';
+		} catch (err: unknown) {
+			toastError(err instanceof Error ? err.message : 'Something went wrong');
+		}
 	}
 
 	function locateMe() {
@@ -706,37 +791,156 @@
 	<meta property="og:type" content="website" />
 </svelte:head>
 
-<h1 class="sr-only">Waterloo Region Pothole Map</h1>
-
-<aside class="sr-only" aria-label="Pothole list">
-	<h2 aria-live="polite" aria-atomic="true">Active potholes ({liveReportedCount})</h2>
-	{#if liveReportedCount === 0}
-		<p>No active potholes reported.</p>
-	{:else}
-		<ul>
-			{#each reportedPotholesSorted as pothole (pothole.id)}
-				<li>
-					<!-- Skip-link pattern: the link becomes a fixed overlay on keyboard focus
-					     so sighted keyboard users see where focus is. -->
-					<a
-						href="/hole/{pothole.id}"
-						class="focus:fixed focus:top-4 focus:left-4 focus:z-[2000] focus:bg-stone-900 dark:focus:bg-white focus:text-white dark:focus:text-stone-900 focus:px-4 focus:py-2 focus:rounded-md focus:border focus:border-stone-700 dark:focus:border-stone-200 focus:shadow-xl focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500"
-					>
-						{pothole.address || `${pothole.lat.toFixed(4)}, ${pothole.lng.toFixed(4)}`}
-						— confirmed by {pothole.confirmed_count} report{pothole.confirmed_count ===
-						1
-							? ''
-							: 's'}
-					</a>
-				</li>
-			{/each}
-		</ul>
-	{/if}
-</aside>
+<h1 class="sr-only">Waterloo Region Pothole Map and List</h1>
 
 <div class="relative w-full isolate" style="height: calc(100dvh - 57px - env(safe-area-inset-top))">
-	<div bind:this={mapEl} class="w-full h-full bg-white dark:bg-stone-900"></div>
-	<HomeIntroCard />
+	<div
+		bind:this={mapEl}
+		aria-hidden={viewMode === 'list'}
+		inert={viewMode === 'list'}
+		class="w-full h-full bg-white dark:bg-stone-900 {viewMode === 'list' ? 'pointer-events-none' : ''}"
+	></div>
+
+	<div class="absolute top-4 right-4 z-[1002] rounded-md border border-stone-200 dark:border-stone-700 bg-white/95 dark:bg-stone-900/95 p-1 shadow-lg">
+		<div class="flex" role="group" aria-label="Choose map or list view">
+			{#each [['map', 'Map'], ['list', 'List']] as const as [mode, label] (mode)}
+				<button
+					type="button"
+					aria-pressed={viewMode === mode}
+					onclick={() => (viewMode = mode)}
+					class="rounded px-3 py-2 text-sm font-semibold transition-colors {viewMode === mode
+						? 'bg-stone-900 text-white dark:bg-white dark:text-stone-900'
+						: 'text-stone-600 hover:text-stone-900 dark:text-stone-300 dark:hover:text-white'}"
+				>
+					{label}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	{#if viewMode === 'list'}
+		<section
+			id="pothole-list-view"
+			class="absolute inset-0 z-[1000] overflow-y-auto bg-stone-50 dark:bg-asphalt px-4 pb-8 pt-20 sm:px-6 lg:px-8"
+			aria-labelledby="pothole-list-heading"
+		>
+			<div class="mx-auto max-w-5xl space-y-4">
+				<div class="rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-4 shadow-sm">
+					<div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+						<div>
+							<p class="text-xs font-semibold uppercase tracking-wide text-amber-500">Accessible list view</p>
+							<h2 id="pothole-list-heading" class="mt-1 font-brand text-3xl font-bold leading-none text-stone-900 dark:text-white">
+								Potholes without the map
+							</h2>
+							<p class="mt-2 max-w-2xl text-sm leading-relaxed text-stone-600 dark:text-stone-300">
+								Use filters and keyboard-reachable actions to open details, share a report,
+								or mark a live pothole fixed without interacting with map markers.
+							</p>
+						</div>
+
+						<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 md:min-w-[320px]">
+							<label class="text-xs font-semibold text-stone-600 dark:text-stone-300">
+								Status
+								<select
+									bind:value={listStatusFilter}
+									class="mt-1 w-full rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-950 px-3 py-2 text-sm text-stone-900 dark:text-white"
+								>
+									<option value="reported">Reported</option>
+									<option value="filled">Filled</option>
+									<option value="expired">Expired</option>
+									<option value="all">All statuses</option>
+								</select>
+							</label>
+
+							<label class="text-xs font-semibold text-stone-600 dark:text-stone-300">
+								Sort
+								<select
+									bind:value={listSort}
+									class="mt-1 w-full rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-950 px-3 py-2 text-sm text-stone-900 dark:text-white"
+								>
+									<option value="newest">Newest first</option>
+									<option value="oldest">Oldest first</option>
+									<option value="status">Status</option>
+								</select>
+							</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="text-sm text-stone-600 dark:text-stone-300" role="status" aria-live="polite">
+					Showing {visibleListPotholes.length} pothole{visibleListPotholes.length === 1 ? '' : 's'}.
+				</div>
+
+				{#if visibleListPotholes.length === 0}
+					<div class="rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-6 text-center text-sm text-stone-600 dark:text-stone-300">
+						No potholes match this filter.
+					</div>
+				{:else}
+					<ul class="space-y-3" aria-label="Pothole reports">
+						{#each visibleListPotholes as pothole (pothole.id)}
+							{@const info = STATUS_CONFIG[pothole.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.reported}
+							<li class="rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-4 shadow-sm">
+								<div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+									<div class="min-w-0 space-y-2">
+										<div class="flex flex-wrap items-center gap-2">
+											<span class="inline-flex items-center gap-1.5 rounded border border-stone-200 dark:border-stone-700 px-2 py-1 text-xs font-semibold text-stone-600 dark:text-stone-300">
+												<Icon name={info.icon} size={12} class={info.colorClass} />
+												{info.label}
+											</span>
+											<span class="text-xs text-stone-500 dark:text-stone-400">Reported {formattedDate(pothole.created_at)}</span>
+											{#if pothole.photos_published}
+												<span class="inline-flex items-center gap-1 text-xs text-stone-500 dark:text-stone-400">
+													<Icon name="camera" size={12} />
+													Photo
+												</span>
+											{/if}
+										</div>
+
+										<h3 class="text-lg font-semibold text-stone-900 dark:text-white">
+											<a href="/hole/{pothole.id}" class="underline-offset-4 hover:underline">
+												{potholeLabel(pothole)}
+											</a>
+										</h3>
+
+										<p class="text-sm leading-relaxed text-stone-600 dark:text-stone-300">
+											{pothole.description || 'No description provided.'}
+										</p>
+
+										<p class="text-xs text-stone-500 dark:text-stone-400">
+											Confirmed by {pothole.confirmed_count} report{pothole.confirmed_count === 1 ? '' : 's'} · {pothole.lat.toFixed(4)}, {pothole.lng.toFixed(4)}
+										</p>
+									</div>
+
+									<div class="flex shrink-0 flex-wrap gap-2 md:max-w-[280px] md:justify-end">
+										<a href="/hole/{pothole.id}" class="inline-flex items-center justify-center gap-1.5 rounded-md bg-stone-900 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-stone-700 dark:bg-white dark:text-stone-900 dark:hover:bg-stone-200">
+											Open details
+										</a>
+										<button type="button" onclick={() => sharePothole(pothole)} class="inline-flex items-center justify-center gap-1.5 rounded-md border border-stone-200 dark:border-stone-700 px-3 py-2 text-sm font-semibold text-stone-600 transition-colors hover:border-stone-400 hover:text-stone-900 dark:text-stone-300 dark:hover:border-stone-500 dark:hover:text-white">
+											<Icon name="share-2" size={14} />
+											Share
+										</button>
+										{#if pothole.status === 'reported'}
+											<button type="button" onclick={() => markPotholeFilled(pothole.id)} class="inline-flex items-center justify-center gap-1.5 rounded-md border border-green-300 bg-green-50 px-3 py-2 text-sm font-semibold text-green-800 transition-colors hover:bg-green-100 dark:border-green-800 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-900">
+												<Icon name="check-circle" size={14} />
+												It's fixed
+											</button>
+										{/if}
+										<button type="button" onclick={() => showPotholeOnMap(pothole.id)} class="inline-flex items-center justify-center gap-1.5 rounded-md border border-stone-200 dark:border-stone-700 px-3 py-2 text-sm font-semibold text-stone-600 transition-colors hover:border-stone-400 hover:text-stone-900 dark:text-stone-300 dark:hover:border-stone-500 dark:hover:text-white">
+											<Icon name="map" size={14} />
+											Show on map
+										</button>
+									</div>
+								</div>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		</section>
+	{/if}
+	{#if viewMode === 'map'}
+		<HomeIntroCard />
+	{/if}
 
 	{#if !mapReady}
 		<div class="absolute inset-0 flex items-center justify-center bg-white dark:bg-stone-900">

--- a/tests/e2e/map-page.spec.ts
+++ b/tests/e2e/map-page.spec.ts
@@ -305,6 +305,40 @@ test.describe("Map page smoke test", () => {
     ).toBeVisible();
   });
 
+  test("list view exposes keyboard-equivalent pothole actions", async ({
+    page,
+  }) => {
+    await seedPopupFixture(page, [
+      seededReportedPothole,
+      seededSecondReportedPothole,
+    ]);
+    await page.route("**/api/filled", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, message: "Marked as fixed!" }),
+      });
+    });
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "List" }).click();
+    await expect(
+      page.getByRole("heading", { name: /Potholes without the map/i }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: /123 Test Street/i }),
+    ).toHaveAttribute("href", `/hole/${seededReportedPothole.id}`);
+    await expect(page.getByRole("button", { name: "Share" }).first()).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /It's fixed/i }).first(),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /It's fixed/i }).first().click();
+    await expect(page.getByText("Marked as fixed!")).toBeVisible();
+    await expect(page.getByText("Showing 1 pothole.")).toBeVisible();
+  });
+
   test("reopening a popup does not duplicate the share handler", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- Adds a visible Map/List switcher on the homepage.
- Replaces the screen-reader-only pothole list with a first-class sortable/filterable list view.
- Adds keyboard-reachable equivalents for map-only actions: open details, share, mark fixed, and show on map.
- Updates ROADMAP.md and CLAUDE.md so the remaining Phase 7 work is clear.
- Corrects stale CLAUDE.md tooling docs for the current Playwright-only test setup.

## Verification

- npm run check
- npm run lint
- npm run build
- npx playwright test tests/e2e/map-page.spec.ts
- npm run test:a11y

## Notes

A full local npm run test was also attempted. It reached 205 passed / 9 skipped, but admin MFA/photo moderation specs failed in this local environment because admin session/trusted-device fixture cookies were not created with the local Supabase fixture path. The focused homepage/list tests and axe suite pass cleanly.