### PR TITLE
feat(legal): dedicated privacy policy + terms pages; drop corny about line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,8 @@ src/
     +layout.server.ts         # Server layout loader
     +page.server.ts           # Loads potholes for map
     about/+page.svelte        # About page
+    privacy/+page.svelte      # Privacy policy (PIPEDA-grade; retention, third parties, rights)
+    terms/+page.svelte        # Terms of use (acceptable use, UGC licence, no-warranty, Ontario law)
     how-to/+page.svelte       # User-facing how-to / help guide
     stats/
       +page.server.ts         # SSR load — potholes for metrics

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -118,9 +118,9 @@
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
 			<a href="/updates" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">What's new</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
-			<a href="/about#privacy" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Privacy</a>
+			<a href="/privacy" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Privacy</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
-			<a href="/about#disclaimer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Disclaimer</a>
+			<a href="/terms" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">Terms</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
 			<a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="underline hover:text-stone-900 dark:hover:text-white transition-colors">GitHub</a>
 			<span class="mx-1 text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -27,9 +27,6 @@
 			fillthehole.ca makes the problem visible. Every reported pothole goes on a public map.
 			Every day it stays unfilled is tracked. Your councillor's contact is one tap away.
 		</p>
-		<p class="text-amber-700 dark:text-amber-400 font-medium">
-			Sunlight is the best disinfectant. A public map is hard to ignore.
-		</p>
 	</section>
 
 	<section class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-6 space-y-4">
@@ -139,7 +136,9 @@
 	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed" id="privacy">
 		<h2 class="section-title text-xl text-stone-900 dark:text-white">Privacy</h2>
 		<p>
-			No accounts. No names. No tracking. Here's exactly what this site does and doesn't do with your data.
+			No accounts. No names. No tracking. Here's the short version — the
+			<a href="/privacy" class="text-amber-700 dark:text-amber-400 underline hover:text-amber-600 dark:hover:text-amber-300 transition-colors">full privacy policy</a>
+			covers retention, your rights, and every third-party service in detail.
 		</p>
 
 		<div class="space-y-3">
@@ -221,6 +220,10 @@
 			</p>
 			<p>
 				For official road hazard reporting, use the city links above. To report an urgent road hazard, contact your municipality directly using the links above.
+			</p>
+			<p>
+				See the full <a href="/terms" class="text-amber-700 dark:text-amber-400 underline hover:text-amber-600 dark:hover:text-amber-300 transition-colors">Terms of use</a>
+				and <a href="/privacy" class="text-amber-700 dark:text-amber-400 underline hover:text-amber-600 dark:hover:text-amber-300 transition-colors">Privacy policy</a>.
 			</p>
 		</div>
 	</section>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+</script>
+
+<svelte:head>
+	<title>Privacy Policy — FillTheHole.ca</title>
+	<meta
+		name="description"
+		content="What FillTheHole.ca collects, why, how long it's kept, and which services are involved — in plain language."
+	/>
+</svelte:head>
+
+<div class="max-w-2xl mx-auto px-4 py-12 space-y-10">
+	<div>
+		<h1 class="page-title text-4xl sm:text-5xl text-stone-900 dark:text-white mb-2">Privacy policy</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-lg">
+			No accounts. No names. No ad tracking. Here's everything this site does with data, in plain
+			language.
+		</p>
+		<p class="text-xs text-stone-500 dark:text-stone-500 mt-2">Last updated: July 7, 2026</p>
+	</div>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">The short version</h2>
+		<ul class="list-disc pl-5 space-y-2 text-sm">
+			<li>Reporting a pothole stores its location, an approximate street address, your description, and a timestamp — nothing about you.</li>
+			<li>Your IP address is one-way hashed the moment a request arrives and is used only to stop duplicates and abuse. The raw IP is never stored or logged by this app.</li>
+			<li>Photos have all hidden metadata (EXIF, GPS tags) stripped on the server before anything else happens to them.</li>
+			<li>Everything expires: most operational records are automatically purged within 90 days.</li>
+			<li>The pothole record itself — location, status, how long it took to fill — is a permanent public dataset. That's the point of the site.</li>
+		</ul>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">What we collect, and why</h2>
+
+		<div class="space-y-3">
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="crosshair" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
+					Report details
+				</div>
+				<p class="text-sm">
+					When you report a pothole we store its GPS coordinates (rounded to roughly 11&nbsp;m
+					before storage), a street address looked up from those coordinates, the severity and
+					description you provide, and timestamps. This is what appears on the public map. None of
+					it is tied to an identity.
+				</p>
+			</div>
+
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="info" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
+					IP addresses — hashed, never stored raw
+				</div>
+				<p class="text-sm">
+					To stop one person from confirming their own report over and over, or flooding the
+					site, we need to tell devices apart. Your IP address is immediately converted to an
+					HMAC-SHA-256 hash using a server-side secret; only the hash is stored, and only for
+					duplicate-prevention and rate-limiting. The raw IP is never written to disk or logged by
+					this application, and the hash can't be reversed without the secret.
+				</p>
+			</div>
+
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="camera" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
+					Photos
+				</div>
+				<p class="text-sm">
+					Uploaded photos are processed server-side before storage: all embedded metadata (EXIF,
+					GPS tags, comments) is stripped, then the image is screened by an automated moderation
+					service and held for review. Photos are never shown publicly until a site administrator
+					explicitly publishes them.
+				</p>
+			</div>
+
+			<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4 space-y-1">
+				<div class="flex items-center gap-2 text-sm font-semibold text-stone-900 dark:text-white">
+					<Icon name="bell" size={14} class="text-stone-400 dark:text-stone-500 shrink-0" />
+					Notifications (optional)
+				</div>
+				<p class="text-sm">
+					If you turn on push notifications, we store the anonymous delivery endpoint your browser
+					generates — no email, no phone number. Per-pothole "notify me when filled"
+					subscriptions are deleted as soon as the notification is sent.
+				</p>
+			</div>
+		</div>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">What stays on your device</h2>
+		<p class="text-sm">
+			The site sets no cookies for visitors. (Site administrators receive session cookies after
+			logging in.) A few entries live in your browser's local storage and are never used to track
+			you:
+		</p>
+		<ul class="list-disc pl-5 space-y-1.5 text-sm">
+			<li><code class="text-stone-900 dark:text-stone-300 bg-stone-200 dark:bg-stone-800 px-1 rounded text-xs">fth-home-intro-dismissed</code> — remembers you've closed the homepage intro.</li>
+			<li><code class="text-stone-900 dark:text-stone-300 bg-stone-200 dark:bg-stone-800 px-1 rounded text-xs">fillthehole_watchlist</code> — the list of reports you've submitted, so the site can show you their status. Stored only in your browser; the IDs are sent to the server only to look up current statuses and are not stored there.</li>
+			<li><code class="text-stone-900 dark:text-stone-300 bg-stone-200 dark:bg-stone-800 px-1 rounded text-xs">hit:&lt;id&gt;</code> and <code class="text-stone-900 dark:text-stone-300 bg-stone-200 dark:bg-stone-800 px-1 rounded text-xs">fill-notify:&lt;id&gt;</code> — remember which potholes you've flagged or subscribed to, so buttons show the right state.</li>
+		</ul>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">How long we keep things</h2>
+		<p class="text-sm">
+			Retention isn't a promise in a document — it's enforced by automated nightly purge jobs in
+			the database:
+		</p>
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4">
+			<ul class="space-y-1.5 text-sm">
+				<li><strong class="text-stone-900 dark:text-stone-300">Pothole records</strong> (location, address, description, status, dates) — kept indefinitely as the public accountability record.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">Published photos</strong> — kept with their pothole record; administrators can remove them.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">Confirmation records</strong> (hashed IP) — purged 90 days after a pothole is filled or expires.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">"I hit this" signals, action logs, rate-limit records</strong> — purged after 90 days.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">Push subscriptions</strong> — purged after 180 days without use; fill-notification subscriptions are deleted when the notification is sent.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">Administrator sign-in attempts</strong> — purged after 90 days; the admin audit log is kept 24 months to support breach investigation.</li>
+			</ul>
+		</div>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Services we rely on</h2>
+		<p class="text-sm">
+			The site runs on a small set of infrastructure and data services. Here's each one and exactly
+			what it receives:
+		</p>
+		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-md p-4">
+			<ul class="space-y-1.5 text-sm">
+				<li><a href="https://supabase.com/privacy" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Supabase</a> — hosts the database and photo storage described above.</li>
+				<li><a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Netlify</a> — serves the website. As the hosting provider it processes network traffic (including IP addresses) to deliver pages, under its own policy.</li>
+				<li><a href="https://www.openstreetmap.org" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">OpenStreetMap</a> — your browser loads map tiles directly from OSM's servers, which see your IP and the map areas you view.</li>
+				<li><a href="https://nominatim.org" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Nominatim</a> — street-address lookups. Requests go through our server, so Nominatim receives coordinates and search text but never your IP.</li>
+				<li><a href="https://www.esri.com/en-us/privacy/main" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Esri ArcGIS</a> — on pothole pages we check Kitchener's 311 system for a matching repair request. Our server sends only the pothole's rounded coordinates.</li>
+				<li><a href="https://sightengine.com/policies/privacy" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">SightEngine</a> — uploaded photos (already metadata-stripped) are screened for inappropriate content before an administrator reviews them.</li>
+				<li><a href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Sentry</a> — if something breaks, a technical error report (page, browser type, stack trace) is sent so bugs get fixed. We don't attach names or identifiers.</li>
+				<li><strong class="text-stone-900 dark:text-stone-300">Browser push services</strong> — if you enable notifications, delivery goes through your browser vendor's push service (Apple, Google, or Mozilla) using the anonymous endpoint your browser created.</li>
+				<li><a href="https://open-meteo.com" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Open-Meteo</a> — regional weather history for the stats page's freeze–thaw chart. Requests use a fixed region-wide coordinate; no user data is involved.</li>
+				<li><a href="https://bsky.app" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">Bluesky</a> — confirmed potholes and fills may be auto-posted to a public feed. Only already-public map data is posted.</li>
+			</ul>
+		</div>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Your rights</h2>
+		<p class="text-sm">
+			Under Canada's federal privacy law (PIPEDA) you can ask what information an organization
+			holds about you, ask for corrections, and challenge how it's handled. Honest caveat: because
+			this site stores no identities and IP hashes are one-way, we usually
+			<em>cannot</em> link any report to a person — which protects you, but also means we can't
+			prove who submitted what. We'll still act on any reasonable request to correct or remove a
+			report or photo. Open an issue on
+			<a href="https://github.com/BreakableHoodie/filltheholedotca/issues" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">GitHub</a>
+			or use the contact options there.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Security &amp; breaches</h2>
+		<p class="text-sm">
+			Traffic is encrypted in transit (HTTPS). The database enforces row-level security, admin
+			accounts require multi-factor authentication, and administrative actions are audit-logged. If
+			a breach ever creates a real risk of significant harm, we follow a documented incident-response
+			process, including notifying the Office of the Privacy Commissioner of Canada and affected
+			people as PIPEDA requires.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Changes</h2>
+		<p class="text-sm">
+			This policy is version-controlled with the site's
+			<a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">open-source code</a>
+			— every change to it is public, diff-able, and dated. Significant changes will be announced on
+			the <a href="/updates" class="text-amber-700 dark:text-amber-400 underline">What's new</a> page.
+		</p>
+	</section>
+
+	<div class="text-center pt-4 space-x-4">
+		<a href="/terms" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors underline">
+			Terms of use
+		</a>
+		<a href="/" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors">
+			<Icon name="arrow-left" size={14} />
+			Back to the map
+		</a>
+	</div>
+</div>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -12,7 +12,9 @@ const STATIC_PAGES = [
 	{ path: '/stats', changefreq: 'daily', priority: '0.8' },
 	{ path: '/how-to', changefreq: 'monthly', priority: '0.6' },
 	{ path: '/about', changefreq: 'monthly', priority: '0.5' },
-	{ path: '/updates', changefreq: 'monthly', priority: '0.4' }
+	{ path: '/updates', changefreq: 'monthly', priority: '0.4' },
+	{ path: '/privacy', changefreq: 'yearly', priority: '0.3' },
+	{ path: '/terms', changefreq: 'yearly', priority: '0.3' }
 ];
 
 const PRIORITY: Record<string, string> = {

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+</script>
+
+<svelte:head>
+	<title>Terms of Use — FillTheHole.ca</title>
+	<meta
+		name="description"
+		content="The terms for using FillTheHole.ca — a free, community-run, open-source pothole tracker for Waterloo Region."
+	/>
+</svelte:head>
+
+<div class="max-w-2xl mx-auto px-4 py-12 space-y-10">
+	<div>
+		<h1 class="page-title text-4xl sm:text-5xl text-stone-900 dark:text-white mb-2">Terms of use</h1>
+		<p class="page-intro text-stone-600 dark:text-stone-400 text-lg">
+			Plain terms for a free, open-source civic tool. No fine print traps.
+		</p>
+		<p class="text-xs text-stone-500 dark:text-stone-500 mt-2">Last updated: July 7, 2026</p>
+	</div>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">What this is</h2>
+		<p class="text-sm">
+			FillTheHole.ca is a free, independent, community-run tool for reporting and tracking potholes
+			in Waterloo Region, Ontario. It is
+			<strong class="text-stone-900 dark:text-stone-300">not affiliated with, endorsed by, or operated by</strong>
+			the City of Kitchener, City of Waterloo, City of Cambridge, the Region of Waterloo, the
+			Province of Ontario, or any other government body. By using the site you agree to these terms.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Acceptable use</h2>
+		<p class="text-sm">Use the site in good faith. Specifically, don't:</p>
+		<ul class="list-disc pl-5 space-y-1.5 text-sm">
+			<li>Submit false, fake, or deliberately mislocated reports.</li>
+			<li>Upload photos you don't have the right to share, or that contain people's faces, licence plates, or other identifying details you'd need consent for.</li>
+			<li>Upload content that is illegal, hateful, harassing, sexual, or otherwise inappropriate. Photos are automatically screened and human-reviewed; violations are removed.</li>
+			<li>Attempt to bypass the geofence, rate limits, or duplicate-prevention, or automate submissions.</li>
+			<li>Scrape, overload, or attack the service. (The open data below means you don't need to scrape — just use the feeds.)</li>
+		</ul>
+		<p class="text-sm">
+			We may remove any report or photo, and block abusive traffic, at our discretion.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Your reports and photos</h2>
+		<p class="text-sm">
+			You keep ownership of anything you submit. By submitting a report or photo, you grant this
+			project a non-exclusive, royalty-free licence to display, store, and distribute it as part of
+			the public pothole record and the open datasets below. Because the map is a public
+			accountability tool and the data is released openly, treat every submission as public and
+			permanent — don't include anything private. Photos are held for moderation and are only
+			published after an administrator reviews them.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Safety</h2>
+		<div class="flex gap-3 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-700/40 rounded-md p-4 text-sm text-amber-900 dark:text-amber-200/90">
+			<Icon name="alert-triangle" size={18} class="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+			<p>
+				<strong class="text-amber-800 dark:text-amber-300">Never put yourself in danger to report a pothole.</strong>
+				Don't stop in traffic or step onto a road. Report from a sidewalk, a parking lot, or after
+				you've safely parked. No pothole is worth an injury. For an urgent road hazard, contact your
+				municipality directly.
+			</p>
+		</div>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">No warranty, no liability</h2>
+		<p class="text-sm">
+			All pothole data is
+			<strong class="text-stone-900 dark:text-stone-300">community-sourced and unverified</strong>.
+			Reports may be inaccurate, outdated, or mislocated; a pothole marked "filled" may have been
+			re-reported in error. Do not rely on this map as a definitive record of road conditions.
+		</p>
+		<p class="text-sm">
+			The site is provided
+			<strong class="text-stone-900 dark:text-stone-300">"as is," without warranty of any kind</strong>,
+			express or implied. To the fullest extent permitted by law, the operator is not liable for any
+			damage to vehicles, injuries, or losses arising from use of, or reliance on, anything displayed
+			here. For official road-hazard reporting, use the city and provincial links on the
+			<a href="/about" class="text-amber-700 dark:text-amber-400 underline">About</a> page.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Open data &amp; open source</h2>
+		<p class="text-sm">
+			The pothole dataset is published openly (<a href="/api/export.csv" class="text-amber-700 dark:text-amber-400 underline">CSV</a>
+			and <a href="/api/feed.xml" class="text-amber-700 dark:text-amber-400 underline">RSS</a>) for research,
+			journalism, and civic use — no API key required. The site's source code is released under the
+			<a href="https://github.com/BreakableHoodie/filltheholedotca/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">GNU AGPL-3.0 licence</a>;
+			you're free to read, modify, and self-host it under those terms.
+		</p>
+	</section>
+
+	<section class="space-y-4 text-stone-600 dark:text-stone-400 leading-relaxed">
+		<h2 class="section-title text-xl text-stone-900 dark:text-white">Privacy, changes &amp; governing law</h2>
+		<p class="text-sm">
+			Your privacy is covered by our <a href="/privacy" class="text-amber-700 dark:text-amber-400 underline">Privacy Policy</a>.
+			These terms may change; because they're version-controlled with the
+			<a href="https://github.com/BreakableHoodie/filltheholedotca" target="_blank" rel="noopener noreferrer" class="text-amber-700 dark:text-amber-400 underline">open-source code</a>,
+			every revision is public and dated. Continued use after a change means you accept it. These
+			terms are governed by the laws of the Province of Ontario and the federal laws of Canada that
+			apply there.
+		</p>
+	</section>
+
+	<div class="text-center pt-4 space-x-4">
+		<a href="/privacy" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors underline">
+			Privacy policy
+		</a>
+		<a href="/" class="inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-white text-sm transition-colors">
+			<Icon name="arrow-left" size={14} />
+			Back to the map
+		</a>
+	</div>
+</div>

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -73,10 +73,16 @@ test.describe("Navigation — core routes load", () => {
     await expect(page).toHaveURL("/");
   });
 
-  test("footer privacy link navigates to about#privacy", async ({ page }) => {
+  test("footer privacy link navigates to the privacy policy", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("link", { name: "Privacy" }).click();
-    await expect(page).toHaveURL("/about#privacy");
+    await expect(page).toHaveURL("/privacy");
+  });
+
+  test("footer terms link navigates to the terms page", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "Terms" }).click();
+    await expect(page).toHaveURL("/terms");
   });
 
   test("skip link is the first focusable element and points to #maincontent", async ({


### PR DESCRIPTION
## What

Adds two dedicated legal pages and removes a tired aphorism from the About page.

- **`/privacy`** — a PIPEDA-grade privacy policy written from the code's *actual* behaviour, not boilerplate: immediate HMAC-SHA-256 IP hashing (no raw IP stored/logged), the real nightly `pg_cron` retention schedule (90-day operational data, 180-day push subscriptions, 24-month audit log), server-side EXIF stripping, and an exhaustive third-party disclosure (Supabase, Netlify, OpenStreetMap, Nominatim, Esri ArcGIS, SightEngine, Sentry, browser push, Open-Meteo, Bluesky) with exactly what each receives. Includes a plain-language data-subject-rights section with the honest caveat that one-way IP hashing means we usually *can't* tie a report to a person.
- **`/terms`** — acceptable use, UGC licence + moderation policy, the safety warning, no-warranty/liability, open-data + AGPL, and Ontario governing law.
- Footer links updated (`Privacy` → `/privacy`, new `Terms` → `/terms`; were `/about#privacy` and `/about#disclaimer`).
- `/about` privacy + disclaimer sections now summarise and link out to the full pages.
- Both routes added to `sitemap.xml`; `CLAUDE.md` project structure updated.
- Removed the **"Sunlight is the best disinfectant. A public map is hard to ignore."** pull-line — the preceding paragraph already states the point plainly.

## Notably

The privacy page deliberately does **not** list "votes" as a collected data category. While drafting, the parallel code-quality review caught that `CLAUDE.md` documents a whole voting feature (`pothole_votes`, `/api/vote`, `schema_votes*.sql`) that **does not exist in the codebase** — so a boilerplate policy trusting the docs would have shipped a false privacy claim. Tracked separately in the assessment (#195).

## Verification

- `svelte-check`: 0 errors, 0 warnings (1598 files)
- `npm run build`: exit 0; both routes compile
- Drove the built app under `preview`: `/privacy` and `/terms` both HTTP 200 with correct titles; cross-links and footer links resolve; confirmed no "votes" text in `/privacy` and no "Sunlight" in `/about`

Refs #196, #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird