### PR TITLE
fix(polling): surface pending→reported transitions via reported_at (#198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ src/
       +page.svelte            # Pothole detail (status, councillor contact, share, before/after photo galleries)
       +page.server.ts         # Loads single pothole + councillor
     api/
-      potholes/recent/+server.ts  # GET — polling endpoint: non-pending potholes created/filled/expired after ?since=
+      potholes/recent/+server.ts  # GET — polling endpoint: non-pending potholes created/reported/filled/expired after ?since=
       report/+server.ts       # POST — submit report (geofence, IP dedup, 2-confirm merge)
       filled/+server.ts       # POST — mark filled (reported → filled)
       photos/+server.ts       # POST — upload photo (magic-byte validation, moderation, rate limit)
@@ -203,6 +203,7 @@ potholes (
   id uuid PK, created_at, lat float8, lng float8,
   address text, description text,
   status text,          -- 'pending' | 'reported' | 'expired' | 'filled'
+  reported_at timestamptz,  -- stamped by increment_confirmation on pending -> reported
   filled_at timestamptz, expired_at timestamptz,
   confirmed_count int,  -- starts at 1, promoted to 'reported' at 2
   photos_published bool  -- admin toggle; published pothole ≠ published photos
@@ -261,6 +262,7 @@ Run migrations in this order:
 25. `schema_vote_ratelimit.sql` — extends `api_rate_limit_events_scope_check` to include `vote_submit`
 26. `schema_votes_ttl.sql` — pg_cron purge job for `pothole_votes` older than 90 days (PIPEDA data minimization)
 27. `schema_ward_subscriptions.sql` — adds `ward_subscriptions` table (ward-level push alert subscriptions) and extends `api_rate_limit_events_scope_check` to include `ward_notify_subscribe`
+28. `schema_pothole_reported_at.sql` — adds `reported_at` timestamptz column (backfilled for existing non-pending rows) and redefines `increment_confirmation` to stamp it on the `pending → reported` flip, so the polling endpoint can detect that transition
 
 Eleven `pg_cron` jobs run nightly:
 
@@ -295,7 +297,7 @@ pending → reported → filled
 - **Coord privacy**: reporter lat/lng is rounded to 4 decimal places (≈11m at Waterloo latitude) at write-time via `roundPublicCoord()` in `$lib/geo` — the precision is a hard-coded constant, not an env var. Geofence + merge-radius logic runs on the raw input so decisions aren't shifted by rounding. Serialization paths (feed.json, feed.xml, export.csv, embed, OG) re-apply `roundPublicCoord` as defense-in-depth for any historical rows stored at full precision.
 - **Photo EXIF**: server-side strip in `$lib/server/exif-strip` runs before SightEngine moderation and storage upload. `stripJpegMetadata` drops APP1–APP15 and COM segments from JPEGs. `stripPngMetadata` drops the `eXIf` chunk from PNGs. `stripWebpMetadata` drops EXIF/XMP chunks from VP8X-extended WebPs (simple VP8/VP8L files carry no metadata by spec). All three return the input unchanged on malformed input.
 - **Auto-expiry**: `reported` potholes expire after 90 days; `pending` potholes expire after 14 days (both via pg_cron)
-- **Real-time polling**: homepage polls `/api/potholes/recent?since=` every 60s for new/changed potholes without requiring page reload. Polling starts after map loads, pauses on disconnect.
+- **Real-time polling**: homepage polls `/api/potholes/recent?since=` every 60s for new/changed potholes without requiring page reload. The query filters on `created_at`, `reported_at`, `filled_at`, or `expired_at` being after `since`, so a `pending → reported` transition (which stamps `reported_at` via `increment_confirmation`) is surfaced even though it doesn't touch `created_at`. Polling starts after map loads, pauses on disconnect.
 - **Ward alerts**: residents can subscribe (browser push, no account) to a council ward on `/stats/ward/[city]/[ward]` via `/api/notify/ward`; subscriptions live in `ward_subscriptions` (service-role only, keyed `${city}-${ward}`, no user location stored). When a pothole flips `pending → reported`, `api/report` resolves its ward and fans out via `notifyWardSubscribers` (`$lib/server/webpush`) — best-effort, awaited, prunes only 410/404 endpoints (persistent, unlike one-shot fill subs).
 - **Admin map**: Leaflet + markercluster at `/admin/map` with status-filtered layers and click-to-manage popups. Loads all 5000 potholes. Admin-auth required.
 - **Before/after photos**: when pothole status is `filled`, the detail page splits published photos into before/after galleries via `splitByFill()` in `$lib/photo-split` — a read-time classification (`created_at < filled_at` = before, `>= filled_at` = after); a photo taken exactly at `filled_at` counts as "after". The split renders only when both eras have a photo, else the flat gallery shows. Marking a pothole filled prompts (optionally) for an "after" photo.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Run the migration files against your Supabase project in order:
 13. `schema_push.sql` — web push subscription storage
 14. `schema_push_unsubscribe_ratelimit.sql` — push unsubscribe rate limit scope
 15. `schema_review_fixes.sql` — RLS hardening; drops public read on `pothole_confirmations`
+16. `schema_pothole_reported_at.sql` — adds `reported_at` column + redefines `increment_confirmation` to stamp it, so polling can detect `pending → reported` transitions
 
 ### Run
 

--- a/schema.sql
+++ b/schema.sql
@@ -8,6 +8,7 @@ create table if not exists potholes (
   address          text,
   description      text,
   status           text default 'reported',  -- 'pending' | 'reported' | 'filled' | 'expired'
+  reported_at      timestamptz,
   filled_at        timestamptz,
   expired_at       timestamptz,
   confirmed_count  int default 1,

--- a/schema_pothole_reported_at.sql
+++ b/schema_pothole_reported_at.sql
@@ -1,0 +1,53 @@
+-- schema_pothole_reported_at.sql
+-- Fix #198: the polling endpoint (/api/potholes/recent) could not surface a
+-- pending -> reported transition because that flip updated no timestamp column.
+-- Add reported_at, set it when increment_confirmation promotes a pothole, and
+-- backfill existing non-pending rows so they aren't treated as "just reported".
+alter table potholes add column if not exists reported_at timestamptz;
+
+update potholes set reported_at = created_at
+where reported_at is null and status <> 'pending';
+
+create index if not exists potholes_reported_at_idx
+  on potholes (reported_at) where reported_at is not null;
+
+-- Redefine increment_confirmation (3-param signature) to stamp reported_at on the
+-- pending -> reported flip. Body is identical to schema_site_settings.sql EXCEPT
+-- the flip UPDATE also sets reported_at = now().
+CREATE OR REPLACE FUNCTION increment_confirmation(
+	p_pothole_id  uuid,
+	p_ip_hash     text,
+	p_threshold   int DEFAULT 2
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	v_count  int;
+	v_status text;
+BEGIN
+	INSERT INTO pothole_confirmations (pothole_id, ip_hash)
+	VALUES (p_pothole_id, p_ip_hash)
+	ON CONFLICT (pothole_id, ip_hash) DO NOTHING;
+
+	IF NOT FOUND THEN
+		RETURN jsonb_build_object('duplicate', true);
+	END IF;
+
+	UPDATE potholes
+	SET confirmed_count = confirmed_count + 1
+	WHERE id = p_pothole_id
+	RETURNING confirmed_count, status INTO v_count, v_status;
+
+	IF v_count >= p_threshold AND v_status = 'pending' THEN
+		UPDATE potholes SET status = 'reported', reported_at = now() WHERE id = p_pothole_id;
+		v_status := 'reported';
+	END IF;
+
+	RETURN jsonb_build_object(
+		'duplicate',       false,
+		'confirmed_count', v_count,
+		'status',          v_status
+	);
+END;
+$$;

--- a/src/routes/api/potholes/recent/+server.ts
+++ b/src/routes/api/potholes/recent/+server.ts
@@ -16,7 +16,9 @@ export const GET: RequestHandler = async ({ url }) => {
 			'id, created_at, lat, lng, address, description, status, confirmed_count, filled_at, expired_at, photos_published',
 		)
 		.neq('status', 'pending')
-		.or(`created_at.gt.${since},filled_at.gt.${since},expired_at.gt.${since}`)
+		.or(
+			`created_at.gt.${since},reported_at.gt.${since},filled_at.gt.${since},expired_at.gt.${since}`,
+		)
 		.order('created_at', { ascending: false })
 		.limit(100);
 

--- a/tests/unit/potholes-recent-query.spec.ts
+++ b/tests/unit/potholes-recent-query.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Regression guard for #198: the polling endpoint's `.or(...)` filter must include
+// `reported_at.gt.<since>` so a pending -> reported transition (which stamps
+// `reported_at` but not `created_at`) is surfaced by /api/potholes/recent polling.
+// This is a source-level assertion, not a live-DB behavioural test — the RPC flip
+// and the query itself require a real Supabase instance to exercise end-to-end
+// (see manual verification steps in the PR description).
+test('recent potholes endpoint filters on reported_at alongside created_at/filled_at/expired_at', () => {
+	const source = readFileSync(
+		fileURLToPath(
+			new URL('../../src/routes/api/potholes/recent/+server.ts', import.meta.url),
+		),
+		'utf-8',
+	);
+
+	const orCallMatch = source.match(/\.or\(\s*`([^`]+)`/);
+	expect(orCallMatch, 'expected a `.or(`...`)` filter call in the recent potholes endpoint').not.toBeNull();
+
+	const filter = orCallMatch![1];
+	expect(filter).toContain('created_at.gt.');
+	expect(filter).toContain('reported_at.gt.');
+	expect(filter).toContain('filled_at.gt.');
+	expect(filter).toContain('expired_at.gt.');
+});


### PR DESCRIPTION
Closes #198.

## The bug
The homepage's 60s polling endpoint (`/api/potholes/recent`) filtered `.or(created_at.gt, filled_at.gt, expired_at.gt)`, but the `increment_confirmation` RPC that flips a pothole `pending → reported` set **no** timestamp — and `potholes` had no `reported_at`/`updated_at` column. So a pothole going live only matched the filter if both confirmations landed within ~60s; normally they arrive hours/days apart, so **open tabs never saw it appear** without a reload. The flagship real-time feature missed its most important event.

## The fix
- **`schema_pothole_reported_at.sql`** (new migration): adds `reported_at timestamptz`, backfills existing non-pending rows (`reported_at = created_at`), adds a partial index, and `CREATE OR REPLACE`s `increment_confirmation` to stamp `reported_at = now()` on the flip. The RPC body is a byte-exact copy of the current definition except that one line; `CREATE OR REPLACE` preserves the existing `REVOKE EXECUTE FROM PUBLIC` grant (no security regression).
- **`schema.sql`**: adds `reported_at` to the canonical `potholes` table.
- **Endpoint**: `.or(...)` now includes `reported_at.gt.${since}` (4-term).
- **Docs**: CLAUDE.md (schema block, migration list step 28, real-time-polling rule) and README migration list updated.
- **Test**: source-level regression guard asserting the filter includes `reported_at.gt.` (live behavior needs a real DB, documented as such).

## Manual step before deploy
Apply `schema_pothole_reported_at.sql` to Supabase. Then verify: create a pending pothole, note `T0`, drive it to the confirmation threshold, and `GET /api/potholes/recent?since=T0` — it should now appear even though `created_at` predates `T0`.

## Note
README's migration list was already stale (stopped at #15, ~12 entries behind CLAUDE.md's) before this PR; the new entry was appended in README's own numbering. A separate README-migration-list backfill is worth doing (relates to the docs-hygiene pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird