### PR TITLE
perf: CDN caching (s-maxage) for stats/feeds + drop Pro-only photo transform (#206)

### DIFF
--- a/src/routes/api/export.csv/+server.ts
+++ b/src/routes/api/export.csv/+server.ts
@@ -97,7 +97,7 @@ export const GET: RequestHandler = async ({ request }) => {
 		return new Response(null, {
 			status: 304,
 			headers: {
-				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+				'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600',
 				'Last-Modified': lastModified,
 				'Access-Control-Allow-Origin': '*',
 				'Cross-Origin-Resource-Policy': 'cross-origin'
@@ -112,7 +112,7 @@ export const GET: RequestHandler = async ({ request }) => {
 		headers: {
 			'Content-Type': 'text/csv; charset=utf-8',
 			'Content-Disposition': 'attachment; filename="fillthehole-potholes.csv"',
-			'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+			'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600',
 			'Last-Modified': lastModified,
 			'Access-Control-Allow-Origin': '*',
 			'Cross-Origin-Resource-Policy': 'cross-origin',

--- a/src/routes/api/feed.json/+server.ts
+++ b/src/routes/api/feed.json/+server.ts
@@ -51,7 +51,7 @@ export const GET: RequestHandler = async ({ request }) => {
 		return new Response(null, {
 			status: 304,
 			headers: {
-				'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
+				'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=600',
 				'Last-Modified': lastModified,
 				'Access-Control-Allow-Origin': '*',
 				'Cross-Origin-Resource-Policy': 'cross-origin'
@@ -67,7 +67,7 @@ export const GET: RequestHandler = async ({ request }) => {
 		},
 		{
 			headers: {
-				'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
+				'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=600',
 				'Last-Modified': lastModified,
 				'Access-Control-Allow-Origin': '*',
 				// L8: This feed is intentionally public/cross-origin (CORS * above).

--- a/src/routes/api/feed.xml/+server.ts
+++ b/src/routes/api/feed.xml/+server.ts
@@ -137,7 +137,7 @@ ${items}
 		return new Response(null, {
 			status: 304,
 			headers: {
-				'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+				'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600',
 				'Last-Modified': lastBuild,
 				'Access-Control-Allow-Origin': '*',
 				'Cross-Origin-Resource-Policy': 'cross-origin'
@@ -148,7 +148,7 @@ ${items}
 	return new Response(xml, {
 		headers: {
 			'Content-Type': 'application/rss+xml; charset=utf-8',
-			'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+			'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600',
 			'Last-Modified': lastBuild,
 			'Access-Control-Allow-Origin': '*',
 			'Cross-Origin-Resource-Policy': 'cross-origin'

--- a/src/routes/hole/[id]/+page.server.ts
+++ b/src/routes/hole/[id]/+page.server.ts
@@ -227,12 +227,11 @@ export const load: PageServerLoad = async ({ params, url, setHeaders }) => {
           moderation_status: "approved" as const,
           moderation_score: null,
           url: storage.getPublicUrl(p.storage_path).data.publicUrl,
-          // Supabase Image Transformation (Pro feature): serve an 800px-wide
-          // resized image for the thumbnail strip. The img onerror handler falls
-          // back to url if transformation is unavailable.
-          thumbnailUrl: storage.getPublicUrl(p.storage_path, {
-            transform: { width: 800, quality: 80, resize: 'contain' }
-          }).data.publicUrl,
+          // Uploads are client-side resized to <=800px (see $lib/image), so the
+          // stored original is already thumbnail-sized. Serve it directly rather
+          // than via Supabase Image Transformation (a paid-plan feature that,
+          // when unavailable, cost a failed request + onerror fallback per thumb).
+          thumbnailUrl: storage.getPublicUrl(p.storage_path).data.publicUrl,
         };
       })
     : [];

--- a/src/routes/stats/+page.server.ts
+++ b/src/routes/stats/+page.server.ts
@@ -42,7 +42,7 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		return { potholes: fixture, wards: ALL_WARDS, freezeThawByMonth: {} as Record<string, number> };
 	}
 
-	setHeaders({ 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' });
+	setHeaders({ 'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=300' });
 
 	// Fetch potholes and pre-warm the ward boundary cache in parallel.
 	// fetchWards() now never rejects (errors are caught and cached as []) so


### PR DESCRIPTION
Closes #206.

Netlify's CDN shares cached responses based on `s-maxage`; plain `max-age` mostly yields per-browser caching only. Several endpoints set `max-age`/`stale-while-revalidate` but omit `s-maxage`, so each unique visitor re-executes expensive work.

- **Stats page** (`stats/+page.server.ts`): add `s-maxage=60`. The expensive per-request point-in-polygon `lookupWard()` over every pothole now runs once per cache window instead of per visitor. **Deliberately did not add a row cap** — this is an accountability page; truncating rows would produce wrong fill-rates/ward-grades. Caching is the right fix.
- **Open-data endpoints**: add `s-maxage` (matching each existing `max-age`) to `feed.json` (60), `feed.xml` (300), `export.csv` (300). `export.csv` pulls up to 10k rows per miss, so shared caching matters most there.
- **Photo thumbnails** (`hole/[id]/+page.server.ts`): drop the Supabase Image Transformation call (a paid-plan feature that, when unavailable, cost a failed request + `onerror` fallback per thumbnail). Uploads are already client-resized to ≤800px, so the stored original is served directly.

## Verification
svelte-check 0 errors, eslint clean, 14 passing (open-data + pothole-detail; 7 Supabase-dependent skipped).

## Note
Pure header/URL changes — no schema, env, or logic changes. Independent of #203 (error logging) and #205 (polling perf), though it touches `feed.xml`/`export.csv` which #203 also edits — expect a small merge reconcile there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird