### PR TITLE
fix(observability): log swallowed DB errors before error()/fail() (#203)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,3 +321,4 @@ $effect(() => { ... })             // NOT: $: { ... } for side effects
 - No auth system — all actions are public with IP-based deduplication
 - Leaflet imports must be inside `onMount` (SSR will break otherwise)
 - Server-side error logging: use `logError(area, message, err, context?)` from `$lib/server/observability` instead of bare `console.error`. It writes to the console AND forwards to Sentry with an `area` tag so issues surface in production. Bare `console.error` on a server route is a silent failure — nobody sees it.
+- Any `error(500)`/`fail(500)` (or `502`/`503`) that swallows a captured Supabase/DB/RPC/fetch error must be preceded by a `logError` call passing that error. SvelteKit treats errors thrown via `error()`/`fail()` as *expected* HttpErrors, so they never reach Sentry on their own — without the `logError` the underlying failure is invisible to the operator.

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/private';
+import { logError } from '$lib/server/observability';
 
 /**
  * Hash a client IP address with HMAC-SHA-256 using a server-side secret.
@@ -43,7 +44,7 @@ export async function hashClientAddressForLog(
 	try {
 		return await hashIp(getClientAddress());
 	} catch (e) {
-		console.error('[%s] Failed to hash client IP for logging:', scope, e);
+		logError('hash', 'Failed to hash client IP for logging', e);
 		return 'unavailable';
 	}
 }

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -44,7 +44,7 @@ export async function hashClientAddressForLog(
 	try {
 		return await hashIp(getClientAddress());
 	} catch (e) {
-		logError('hash', 'Failed to hash client IP for logging', e);
+		logError('hash', 'Failed to hash client IP for logging', e, { scope });
 		return 'unavailable';
 	}
 }

--- a/src/routes/admin/audit/+page.server.ts
+++ b/src/routes/admin/audit/+page.server.ts
@@ -3,6 +3,7 @@ import type { PageServerLoad } from './$types';
 import { z } from 'zod';
 import { requireRole } from '$lib/server/admin-auth';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const PAGE_SIZE = 50;
 
 export type AuditEntry = {
@@ -54,7 +55,10 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 		getAdminClient().from('admin_users').select('id, email, first_name, last_name').order('email')
 	]);
 
-	if (dbErr) throw error(500, 'Failed to load audit log');
+	if (dbErr) {
+		logError('admin/audit', 'Failed to load audit log', dbErr);
+		throw error(500, 'Failed to load audit log');
+	}
 
 	const totalPages = Math.ceil((count ?? 0) / PAGE_SIZE);
 

--- a/src/routes/admin/login/mfa/+page.server.ts
+++ b/src/routes/admin/login/mfa/+page.server.ts
@@ -13,6 +13,7 @@ import {
 import { generateCsrfToken, CSRF_COOKIE } from '$lib/server/admin-csrf';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 export const load: PageServerLoad = async ({ cookies, url }) => {
 	const sessionId = cookies.get(SESSION_COOKIE);
 	if (sessionId) {
@@ -156,7 +157,7 @@ export const actions: Actions = {
 					verified = true;
 				}
 			} catch (e) {
-				console.error('[mfa] TOTP decrypt/verify failed:', e);
+				logError('admin/mfa', 'TOTP decrypt/verify failed', e);
 			}
 		}
 
@@ -170,7 +171,7 @@ export const actions: Actions = {
 					remainingBackupCodes = result.remaining;
 				}
 			} catch (e) {
-				console.error('[mfa] Backup code check failed:', e);
+				logError('admin/mfa', 'Backup code check failed', e);
 			}
 		}
 
@@ -273,7 +274,7 @@ export const actions: Actions = {
 					maxAge: 30 * 24 * 60 * 60
 				});
 			} catch (e) {
-				console.error('[mfa] Failed to create trusted device:', e);
+				logError('admin/mfa', 'Failed to create trusted device', e);
 			}
 		}
 

--- a/src/routes/admin/map/+page.server.ts
+++ b/src/routes/admin/map/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getAdminClient } from '$lib/server/supabase';
 import { decodeHtmlEntities } from '$lib/escape';
+import { logError } from '$lib/server/observability';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.adminUser) throw error(401, 'Unauthorized');
@@ -14,7 +15,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 		.order('created_at', { ascending: false })
 		.limit(5000);
 
-	if (dbError) throw error(500, 'Failed to load potholes');
+	if (dbError) {
+		logError('admin/map', 'Failed to load potholes for admin map', dbError);
+		throw error(500, 'Failed to load potholes');
+	}
 
 	const potholes = (data ?? []).map((p) => ({
 		...p,

--- a/src/routes/admin/photos/+page.server.ts
+++ b/src/routes/admin/photos/+page.server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireRole, writeAuditLog } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 type PhotoRow = {
 	id: string;
 	storage_path: string;
@@ -77,7 +78,10 @@ export const actions: Actions = {
 			.from('pothole_photos')
 			.update({ moderation_status: 'approved' })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to approve photo' });
+		if (dbErr) {
+			logError('admin/photos', 'Failed to approve photo', dbErr, { photoId: id });
+			return fail(500, { error: 'Failed to approve photo' });
+		}
 
 		await writeAuditLog(locals.adminUser.id, 'photo.approve', 'photo', id, null, await hashIp(getClientAddress()));
 		return { success: true };
@@ -94,7 +98,10 @@ export const actions: Actions = {
 			.from('pothole_photos')
 			.update({ moderation_status: 'rejected' })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to reject photo' });
+		if (dbErr) {
+			logError('admin/photos', 'Failed to reject photo', dbErr, { photoId: id });
+			return fail(500, { error: 'Failed to reject photo' });
+		}
 
 		await writeAuditLog(locals.adminUser.id, 'photo.reject', 'photo', id, null, await hashIp(getClientAddress()));
 		return { success: true };
@@ -115,7 +122,10 @@ export const actions: Actions = {
 			.from('pothole_photos')
 			.update({ moderation_status: 'approved' })
 			.in('id', ids);
-		if (dbErr) return fail(500, { error: 'Failed to approve photos' });
+		if (dbErr) {
+			logError('admin/photos', 'Failed to bulk approve photos', dbErr, { count: ids.length });
+			return fail(500, { error: 'Failed to approve photos' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -143,7 +153,10 @@ export const actions: Actions = {
 			.from('pothole_photos')
 			.update({ moderation_status: 'rejected' })
 			.in('id', ids);
-		if (dbErr) return fail(500, { error: 'Failed to reject photos' });
+		if (dbErr) {
+			logError('admin/photos', 'Failed to bulk reject photos', dbErr, { count: ids.length });
+			return fail(500, { error: 'Failed to reject photos' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/admin/potholes/+page.server.ts
+++ b/src/routes/admin/potholes/+page.server.ts
@@ -5,6 +5,7 @@ import type { PotholeStatus } from '$lib/types';
 import { requireRole, writeAuditLog } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const VALID_STATUSES: PotholeStatus[] = ['pending', 'reported', 'filled', 'expired'];
 const VALID_SORT_COLS = ['created_at', 'address', 'status', 'confirmed_count'] as const;
 const VALID_PAGE_SIZES = [25, 50, 100] as const;
@@ -72,7 +73,10 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 	}
 
 	const { data, count, error: dbErr } = await query;
-	if (dbErr) throw error(500, 'Failed to load potholes');
+	if (dbErr) {
+		logError('admin/potholes', 'Failed to load potholes list', dbErr);
+		throw error(500, 'Failed to load potholes');
+	}
 
 	return {
 		potholes: data ?? [],
@@ -109,7 +113,10 @@ export const actions: Actions = {
 
 		await getAdminClient().from('pothole_confirmations').delete().in('pothole_id', ids);
 		const { error: dbErr } = await getAdminClient().from('potholes').delete().in('id', ids);
-		if (dbErr) return fail(500, { error: 'Failed to delete potholes' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to bulk delete potholes', dbErr, { count: ids.length });
+			return fail(500, { error: 'Failed to delete potholes' });
+		}
 
 		const ipHash = await hashIp(getClientAddress());
 		for (const id of ids) {
@@ -141,7 +148,10 @@ export const actions: Actions = {
 		};
 
 		const { error: dbErr } = await getAdminClient().from('potholes').update(updates).in('id', ids);
-		if (dbErr) return fail(500, { error: 'Failed to update status' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to bulk update pothole status', dbErr, { count: ids.length, status: s });
+			return fail(500, { error: 'Failed to update status' });
+		}
 
 		const ipHash = await hashIp(getClientAddress());
 		for (const id of ids) {
@@ -174,7 +184,10 @@ export const actions: Actions = {
 			.from('potholes')
 			.update({ photos_published: value })
 			.in('id', ids);
-		if (dbErr) return fail(500, { error: 'Failed to update photo visibility' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to bulk toggle photo visibility', dbErr, { count: ids.length });
+			return fail(500, { error: 'Failed to update photo visibility' });
+		}
 
 		const ipHash = await hashIp(getClientAddress());
 		for (const id of ids) {

--- a/src/routes/admin/potholes/[id]/+page.server.ts
+++ b/src/routes/admin/potholes/[id]/+page.server.ts
@@ -83,7 +83,10 @@ export const actions: Actions = {
 			.from('potholes')
 			.update(updates)
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to update status' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to update pothole status', dbErr, { potholeId: id });
+			return fail(500, { error: 'Failed to update status' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -114,7 +117,10 @@ export const actions: Actions = {
 			.from('potholes')
 			.update({ description: descParsed.data || null })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to update description' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to update pothole description', dbErr, { potholeId: id });
+			return fail(500, { error: 'Failed to update description' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -144,7 +150,10 @@ export const actions: Actions = {
 			.from('potholes')
 			.update({ address: addressParsed.data })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to update address' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to update pothole address', dbErr, { potholeId: id });
+			return fail(500, { error: 'Failed to update address' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -172,7 +181,10 @@ export const actions: Actions = {
 			.from('potholes')
 			.update({ photos_published: value })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to update photo visibility' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to toggle photo visibility', dbErr, { potholeId: id });
+			return fail(500, { error: 'Failed to update photo visibility' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -207,7 +219,10 @@ export const actions: Actions = {
 			);
 
 		const { error: dbErr } = await getAdminClient().from('potholes').delete().eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to delete pothole' });
+		if (dbErr) {
+			logError('admin/potholes', 'Failed to delete pothole', dbErr, { potholeId: id });
+			return fail(500, { error: 'Failed to delete pothole' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/admin/settings/mfa/+page.server.ts
+++ b/src/routes/admin/settings/mfa/+page.server.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/server/admin-crypto';
 import { generateTotpSecret, verifyTotpCode, generateTotpUri } from '$lib/server/admin-totp';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.adminUser) throw error(401, 'Unauthorized');
 	// Re-fetch totp_enabled fresh so UI reflects DB state, not session cache
@@ -84,7 +85,10 @@ export const actions: Actions = {
 			})
 			.eq('id', locals.adminUser.id);
 
-		if (dbErr) return fail(500, { error: 'Failed to enable MFA. Please try again.' });
+		if (dbErr) {
+			logError('admin/settings/mfa', 'Failed to enable MFA', dbErr, { userId: locals.adminUser.id });
+			return fail(500, { error: 'Failed to enable MFA. Please try again.' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -130,7 +134,10 @@ export const actions: Actions = {
 			.update({ totp_enabled: false, totp_secret: null, backup_codes: null })
 			.eq('id', locals.adminUser.id);
 
-		if (dbErr) return fail(500, { error: 'Failed to disable MFA' });
+		if (dbErr) {
+			logError('admin/settings/mfa', 'Failed to disable MFA', dbErr, { userId: locals.adminUser.id });
+			return fail(500, { error: 'Failed to disable MFA' });
+		}
 
 		// Invalidate all other sessions so a stolen session token cannot continue
 		// to bypass the MFA requirement that was just removed.
@@ -176,7 +183,10 @@ export const actions: Actions = {
 			.update({ backup_codes: JSON.stringify(hashedCodes) })
 			.eq('id', locals.adminUser.id);
 
-		if (dbErr) return fail(500, { error: 'Failed to regenerate backup codes' });
+		if (dbErr) {
+			logError('admin/settings/mfa', 'Failed to regenerate backup codes', dbErr, { userId: locals.adminUser.id });
+			return fail(500, { error: 'Failed to regenerate backup codes' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/admin/settings/password/+page.server.ts
+++ b/src/routes/admin/settings/password/+page.server.ts
@@ -5,6 +5,7 @@ import { writeAuditLog } from '$lib/server/admin-auth';
 import { hashPassword, verifyPassword } from '$lib/server/admin-crypto';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.adminUser) throw error(401, 'Unauthorized');
 	return {};
@@ -52,7 +53,10 @@ export const actions: Actions = {
 			.update({ password_hash: newHash })
 			.eq('id', locals.adminUser.id);
 
-		if (dbErr) return fail(500, { error: 'Failed to update password' });
+		if (dbErr) {
+			logError('admin/settings/password', 'Failed to update password', dbErr, { userId: locals.adminUser.id });
+			return fail(500, { error: 'Failed to update password' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/admin/settings/site/+page.server.ts
+++ b/src/routes/admin/settings/site/+page.server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireRole, writeAuditLog } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const BOOLEAN_SETTING = z.enum(['true', 'false']);
 
 const SETTING_SCHEMAS: Record<string, z.ZodTypeAny> = {
@@ -23,7 +24,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 		.select('key, value, updated_at')
 		.order('key');
 
-	if (dbErr) throw error(500, 'Failed to load settings');
+	if (dbErr) {
+		logError('admin/settings/site', 'Failed to load site settings', dbErr);
+		throw error(500, 'Failed to load settings');
+	}
 
 	return {
 		settings: Object.fromEntries((data ?? []).map((s) => [s.key, s]))
@@ -49,7 +53,10 @@ export const actions: Actions = {
 			.from('site_settings')
 			.upsert({ key, value: String(parsed.data), updated_at: new Date().toISOString() });
 
-		if (dbErr) return fail(500, { error: 'Failed to save setting' });
+		if (dbErr) {
+			logError('admin/settings/site', 'Failed to save site setting', dbErr, { settingKey: key });
+			return fail(500, { error: 'Failed to save setting' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/admin/signup/+page.server.ts
+++ b/src/routes/admin/signup/+page.server.ts
@@ -7,6 +7,7 @@ import { checkAuthRateLimit, recordAuthAttempt } from '$lib/server/admin-auth';
 import { hashPassword } from '$lib/server/admin-crypto';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 
 const MIN_BOOTSTRAP_SECRET_LENGTH = 32;
 
@@ -199,6 +200,7 @@ export const actions: Actions = {
 				.single();
 
 			if (insertError || !newUser) {
+				logError('admin/signup', 'Failed to insert bootstrap admin account', insertError ?? new Error('no user returned'));
 				return fail(500, { error: 'Failed to create bootstrap account. Please try again.', ...echo });
 			}
 
@@ -287,8 +289,10 @@ export const actions: Actions = {
 			.select('id')
 			.single();
 
-		if (insertError || !newUser)
+		if (insertError || !newUser) {
+			logError('admin/signup', 'Failed to insert invited admin account', insertError ?? new Error('no user returned'));
 			return fail(500, { error: 'Failed to create account. Please try again.', ...echo });
+		}
 
 		// Atomically mark invite as used — the .is('used_at', null) guard ensures only one
 		// concurrent signup wins even if two requests arrive with the same valid code.

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireRole, writeAuditLog, invalidateAllSessionsForUser } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const uuidSchema = z.string().uuid();
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -61,7 +62,10 @@ export const actions: Actions = {
 			.from('admin_users')
 			.update({ role: roleParsed.data })
 			.eq('id', userId);
-		if (dbErr) return fail(500, { error: 'Failed to update role' });
+		if (dbErr) {
+			logError('admin/users', 'Failed to update user role', dbErr, { targetUserId: userId });
+			return fail(500, { error: 'Failed to update role' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -86,7 +90,10 @@ export const actions: Actions = {
 			.from('admin_users')
 			.update({ is_active: true, activated_at: new Date().toISOString() })
 			.eq('id', userId);
-		if (dbErr) return fail(500, { error: 'Failed to activate user' });
+		if (dbErr) {
+			logError('admin/users', 'Failed to activate user', dbErr, { targetUserId: userId });
+			return fail(500, { error: 'Failed to activate user' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -113,7 +120,10 @@ export const actions: Actions = {
 			.from('admin_users')
 			.update({ is_active: false })
 			.eq('id', userId);
-		if (dbErr) return fail(500, { error: 'Failed to deactivate user' });
+		if (dbErr) {
+			logError('admin/users', 'Failed to deactivate user', dbErr, { targetUserId: userId });
+			return fail(500, { error: 'Failed to deactivate user' });
+		}
 
 		// Immediately revoke all their sessions
 		await invalidateAllSessionsForUser(userId);

--- a/src/routes/admin/users/invites/+page.server.ts
+++ b/src/routes/admin/users/invites/+page.server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireRole, writeAuditLog } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 type InviteRow = {
 	id: string;
 	code: string;
@@ -70,7 +71,10 @@ export const actions: Actions = {
 			is_active: true
 		});
 
-		if (dbErr) return fail(500, { error: 'Failed to create invite' });
+		if (dbErr) {
+			logError('admin/users/invites', 'Failed to create invite', dbErr);
+			return fail(500, { error: 'Failed to create invite' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,
@@ -94,7 +98,10 @@ export const actions: Actions = {
 			.from('admin_invite_codes')
 			.update({ is_active: false })
 			.eq('id', id);
-		if (dbErr) return fail(500, { error: 'Failed to deactivate invite' });
+		if (dbErr) {
+			logError('admin/users/invites', 'Failed to deactivate invite', dbErr, { inviteId: id });
+			return fail(500, { error: 'Failed to deactivate invite' });
+		}
 
 		await writeAuditLog(
 			locals.adminUser.id,

--- a/src/routes/api/admin/photo/[id]/+server.ts
+++ b/src/routes/api/admin/photo/[id]/+server.ts
@@ -29,7 +29,10 @@ export const PATCH: RequestHandler = async ({ request, params, locals, getClient
 		.update({ moderation_status })
 		.eq('id', id);
 
-	if (updateError) throw error(500, 'Failed to update photo status');
+	if (updateError) {
+		logError('admin/photo', 'Failed to update photo status', updateError, { photoId: id });
+		throw error(500, 'Failed to update photo status');
+	}
 
 	await writeAuditLog(
 		locals.adminUser.id,
@@ -64,7 +67,10 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 		.single();
 
 	const { error: deleteError } = await getAdminClient().from('pothole_photos').delete().eq('id', id);
-	if (deleteError) throw error(500, 'Failed to delete photo record');
+	if (deleteError) {
+		logError('admin/photo', 'Failed to delete photo record', deleteError, { photoId: id });
+		throw error(500, 'Failed to delete photo record');
+	}
 
 	// Best-effort storage cleanup
 	if (photo?.storage_path) {

--- a/src/routes/api/admin/photos/bulk/+server.ts
+++ b/src/routes/api/admin/photos/bulk/+server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireRole, writeAuditLog } from '$lib/server/admin-auth';
 import { hashIp } from '$lib/hash';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const bulkSchema = z.object({
 	action: z.enum(['approve', 'reject']),
 	ids: z.array(z.string().uuid()).min(1).max(50)
@@ -25,7 +26,10 @@ export const POST: RequestHandler = async ({ request, locals, getClientAddress }
 		.update({ moderation_status })
 		.in('id', ids);
 
-	if (updateError) throw error(500, 'Failed to bulk update photos');
+	if (updateError) {
+		logError('admin/photos-bulk', 'Failed to bulk update photos', updateError, { action, count: ids.length });
+		throw error(500, 'Failed to bulk update photos');
+	}
 
 	await writeAuditLog(
 		locals.adminUser.id,

--- a/src/routes/api/admin/pothole/[id]/+server.ts
+++ b/src/routes/api/admin/pothole/[id]/+server.ts
@@ -47,7 +47,10 @@ export const PATCH: RequestHandler = async ({ params, request, locals, getClient
 			.select('status')
 			.eq('id', id)
 			.maybeSingle();
-		if (fetchErr) throw error(500, 'Failed to fetch pothole');
+		if (fetchErr) {
+			logError('admin/pothole', 'Failed to fetch pothole', fetchErr, { potholeId: id });
+			throw error(500, 'Failed to fetch pothole');
+		}
 		if (!current) throw error(404, 'Pothole not found');
 
 		const allowed = ALLOWED_TRANSITIONS[current.status] ?? [];
@@ -62,7 +65,10 @@ export const PATCH: RequestHandler = async ({ params, request, locals, getClient
 	}
 
 	const { error: dbErr } = await getAdminClient().from('potholes').update(updates).eq('id', id);
-	if (dbErr) throw error(500, 'Failed to update');
+	if (dbErr) {
+		logError('admin/pothole', 'Failed to update pothole', dbErr, { potholeId: id });
+		throw error(500, 'Failed to update');
+	}
 
 	await writeAuditLog(
 		locals.adminUser.id,
@@ -97,7 +103,10 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 	}
 
 	const { error: deleteError } = await getAdminClient().from('potholes').delete().eq('id', id);
-	if (deleteError) throw error(500, 'Failed to delete');
+	if (deleteError) {
+		logError('admin/pothole-delete', 'Failed to delete pothole', deleteError, { potholeId: id });
+		throw error(500, 'Failed to delete');
+	}
 
 	await writeAuditLog(locals.adminUser.id, 'pothole.delete', 'pothole', id, null, await hashIp(getClientAddress()));
 

--- a/src/routes/api/admin/potholes/export/+server.ts
+++ b/src/routes/api/admin/potholes/export/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { requireRole } from '$lib/server/admin-auth';
 import type { PotholeStatus } from '$lib/types';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 const VALID_STATUSES: PotholeStatus[] = ['pending', 'reported', 'filled', 'expired'];
 
 function escapeCSV(val: unknown): string {
@@ -74,7 +75,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	}
 
 	const { data, error: dbErr } = await query;
-	if (dbErr) throw error(500, 'Failed to load potholes');
+	if (dbErr) {
+		logError('admin/potholes-export', 'Failed to load potholes for export', dbErr);
+		throw error(500, 'Failed to load potholes');
+	}
 
 	const rows = data ?? [];
 	const filename = `potholes-${new Date().toISOString().slice(0, 10)}`;

--- a/src/routes/api/export.csv/+server.ts
+++ b/src/routes/api/export.csv/+server.ts
@@ -4,6 +4,7 @@ import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/publi
 import { createClient } from '@supabase/supabase-js';
 import { decodeHtmlEntities } from '$lib/escape';
 import { roundPublicCoord } from '$lib/geo';
+import { logError } from '$lib/server/observability';
 
 const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);
 
@@ -75,7 +76,10 @@ export const GET: RequestHandler = async ({ request }) => {
 		.order('created_at', { ascending: false })
 		.limit(ROW_LIMIT);
 
-	if (dbError) throw error(500, 'Failed to load data');
+	if (dbError) {
+		logError('api/export.csv', 'Failed to load potholes for export', dbError);
+		throw error(500, 'Failed to load data');
+	}
 
 	const rows = data ?? [];
 

--- a/src/routes/api/feed.xml/+server.ts
+++ b/src/routes/api/feed.xml/+server.ts
@@ -4,6 +4,7 @@ import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/publi
 import { createClient } from '@supabase/supabase-js';
 import { decodeHtmlEntities } from '$lib/escape';
 import { PUBLIC_COORD_DECIMALS, roundPublicCoord } from '$lib/geo';
+import { logError } from '$lib/server/observability';
 
 const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);
 
@@ -79,7 +80,10 @@ export const GET: RequestHandler = async ({ request }) => {
 			.limit(50)
 	]);
 
-	if (reportedResult.error || filledResult.error) throw error(500, 'Failed to load data');
+	if (reportedResult.error || filledResult.error) {
+		logError('api/feed.xml', 'Failed to load potholes for feed', reportedResult.error ?? filledResult.error);
+		throw error(500, 'Failed to load data');
+	}
 
 	// Merge and deduplicate (a pothole could theoretically appear in both if status
 	// changed between the two queries — extremely unlikely but safe to guard).

--- a/src/routes/api/filled/+server.ts
+++ b/src/routes/api/filled/+server.ts
@@ -6,6 +6,7 @@ import { notify } from '$lib/server/pushover';
 import { broadcastPush, notifyFillSubscribers } from '$lib/server/webpush';
 import { postFilled } from '$lib/server/bluesky';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 
 // L6: All pothole_actions queries use the service-role client — the public SELECT
 // policy on pothole_actions was a data-leak vector (ip_hash correlation). After
@@ -35,7 +36,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('action', 'filled')
 		.gte('created_at', windowStart);
 
-	if (countError) throw error(500, 'Rate limit check failed');
+	if (countError) {
+		logError('api/filled', 'Failed to check fill rate limit', countError);
+		throw error(500, 'Rate limit check failed');
+	}
 	if ((recentFills ?? 0) >= FILL_RATE_LIMIT) {
 		throw error(429, 'Too many fill reports. Please slow down.');
 	}
@@ -50,6 +54,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		if (actionError.code === '23505') {
 			return json({ ok: false, message: "You've already marked this one as filled." });
 		}
+		logError('api/filled', 'Failed to record fill action', actionError, { potholeId: parsed.data.id });
 		throw error(500, 'Failed to record action');
 	}
 
@@ -63,7 +68,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.neq('status', 'expired')
 		.select('id, address');
 
-	if (updateError) throw error(500, 'Failed to update status');
+	if (updateError) {
+		logError('api/filled', 'Failed to update pothole status to filled', updateError, { potholeId: parsed.data.id });
+		throw error(500, 'Failed to update status');
+	}
 	if (!updated || updated.length === 0) throw error(409, 'Pothole is not in a fillable state');
 
 	const filledPothole = updated[0];

--- a/src/routes/api/geocode/reverse/+server.ts
+++ b/src/routes/api/geocode/reverse/+server.ts
@@ -1,6 +1,7 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
+import { logError } from '$lib/server/observability';
 
 const coordSchema = z.object({
 	lat: z.coerce.number().min(43.32).max(43.53),
@@ -29,7 +30,10 @@ export const GET: RequestHandler = async ({ url }) => {
 		}
 	});
 
-	if (!res.ok) throw error(502, 'Reverse geocode failed');
+	if (!res.ok) {
+		logError('api/geocode/reverse', 'Nominatim reverse geocode returned non-OK response', new Error(`Nominatim upstream ${res.status}`), { status: res.status });
+		throw error(502, 'Reverse geocode failed');
+	}
 
 	const data = await res.json();
 	return json(data);

--- a/src/routes/api/geocode/search/+server.ts
+++ b/src/routes/api/geocode/search/+server.ts
@@ -1,6 +1,7 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { z } from 'zod';
+import { logError } from '$lib/server/observability';
 
 const WR_VIEWBOX = '-80.59,43.32,-80.22,43.53';
 
@@ -33,7 +34,10 @@ export const GET: RequestHandler = async ({ url }) => {
 		}
 	});
 
-	if (!res.ok) throw error(502, 'Geocode search failed');
+	if (!res.ok) {
+		logError('api/geocode/search', 'Nominatim search returned non-OK response', new Error(`Nominatim upstream ${res.status}`), { status: res.status });
+		throw error(502, 'Geocode search failed');
+	}
 
 	const data = await res.json();
 	return json(data);

--- a/src/routes/api/hit/+server.ts
+++ b/src/routes/api/hit/+server.ts
@@ -27,7 +27,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('scope', 'hit_submit')
 		.gte('created_at', windowStart);
 
-	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if (rateLimitError) {
+		logError('api/hit', 'Failed to check per-IP rate limit', rateLimitError);
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((recentHits ?? 0) >= HIT_RATE_LIMIT) {
 		throw error(429, 'Too many requests. Please wait before trying again.');
 	}
@@ -39,7 +42,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.select('*', { count: 'exact', head: true })
 		.eq('pothole_id', parsed.data.id)
 		.gte('created_at', windowStart);
-	if (potholeRateLimitError) throw error(500, 'Failed to check rate limit');
+	if (potholeRateLimitError) {
+		logError('api/hit', 'Failed to check per-pothole rate limit', potholeRateLimitError, { potholeId: parsed.data.id });
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((potholeHits ?? 0) >= HIT_PER_POTHOLE_LIMIT) {
 		throw error(429, 'Too many requests. Please wait before trying again.');
 	}
@@ -55,9 +61,13 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 				.from('pothole_hits')
 				.select('*', { count: 'exact', head: true })
 				.eq('pothole_id', parsed.data.id);
-			if (countErr) throw error(500, 'Failed to fetch hit count');
+			if (countErr) {
+				logError('api/hit', 'Failed to fetch hit count', countErr, { potholeId: parsed.data.id });
+				throw error(500, 'Failed to fetch hit count');
+			}
 			return json({ ok: false, message: 'Already recorded.', count: count ?? 0 });
 		}
+		logError('api/hit', 'Failed to record hit', insertError, { potholeId: parsed.data.id });
 		throw error(500, 'Failed to record hit');
 	}
 

--- a/src/routes/api/notify/[id]/+server.ts
+++ b/src/routes/api/notify/[id]/+server.ts
@@ -39,7 +39,10 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 		.eq('scope', 'fill_notify_subscribe')
 		.gte('created_at', windowStart);
 
-	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if (rateLimitError) {
+		logError('api/notify', 'Failed to check rate limit', rateLimitError, { potholeId: id });
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((recent ?? 0) >= RATE_LIMIT) throw error(429, 'Too many requests. Please wait before trying again.');
 
 	// Confirm the pothole exists and is in a state where a fill notification makes sense.
@@ -61,7 +64,10 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 		},
 		{ onConflict: 'pothole_id,endpoint' }
 	);
-	if (dbError) throw error(500, 'Failed to save subscription');
+	if (dbError) {
+		logError('api/notify', 'Failed to save fill notification subscription', dbError, { potholeId: id });
+		throw error(500, 'Failed to save subscription');
+	}
 
 	const { error: rlErr } = await db
 		.from('api_rate_limit_events')
@@ -85,7 +91,10 @@ export const DELETE: RequestHandler = async ({ params, request }) => {
 		.delete()
 		.eq('pothole_id', parsedId.data.id)
 		.eq('endpoint', parsed.data.endpoint);
-	if (deleteError) throw error(500, 'Failed to remove subscription');
+	if (deleteError) {
+		logError('api/notify', 'Failed to remove fill notification subscription', deleteError, { potholeId: parsedId.data.id });
+		throw error(500, 'Failed to remove subscription');
+	}
 
 	return json({ ok: true });
 };

--- a/src/routes/api/notify/ward/+server.ts
+++ b/src/routes/api/notify/ward/+server.ts
@@ -33,7 +33,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('ip_hash', ipHash)
 		.eq('scope', 'ward_notify_subscribe')
 		.gte('created_at', windowStart);
-	if (rlErr) throw error(500, 'Failed to check rate limit');
+	if (rlErr) {
+		logError('api/notify/ward', 'Failed to check rate limit', rlErr, { wardKey: parsed.data.ward_key });
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((recent ?? 0) >= RATE_LIMIT) throw error(429, 'Too many requests. Please wait before trying again.');
 
 	const { error: dbError } = await db.from('ward_subscriptions').upsert(
@@ -45,7 +48,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		},
 		{ onConflict: 'ward_key,endpoint' }
 	);
-	if (dbError) throw error(500, 'Failed to save subscription');
+	if (dbError) {
+		logError('api/notify/ward', 'Failed to save ward subscription', dbError, { wardKey: parsed.data.ward_key });
+		throw error(500, 'Failed to save subscription');
+	}
 
 	const { error: insErr } = await db
 		.from('api_rate_limit_events')
@@ -68,7 +74,10 @@ export const DELETE: RequestHandler = async ({ request }) => {
 		.delete()
 		.eq('ward_key', parsed.data.ward_key)
 		.eq('endpoint', parsed.data.endpoint);
-	if (delErr) throw error(500, 'Failed to remove subscription');
+	if (delErr) {
+		logError('api/notify/ward', 'Failed to remove ward subscription', delErr, { wardKey: parsed.data.ward_key });
+		throw error(500, 'Failed to remove subscription');
+	}
 
 	return json({ ok: true });
 };

--- a/src/routes/api/og/[id]/+server.ts
+++ b/src/routes/api/og/[id]/+server.ts
@@ -53,7 +53,10 @@ export const GET: RequestHandler = async ({ params }) => {
 		.eq('id', parsed.data.id)
 		.single();
 
-	if (dbError && dbError.code !== 'PGRST116') throw error(500, 'Database error');
+	if (dbError && dbError.code !== 'PGRST116') {
+		logError('og/pothole', 'Failed to load pothole for OG image', dbError, { potholeId: parsed.data.id });
+		throw error(500, 'Database error');
+	}
 	if (!pothole) throw error(404, 'Hole not found');
 
 	const font = await loadFont();

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -191,7 +191,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('ip_hash', ipHash)
 		.eq('scope', 'photo_upload')
 		.gte('created_at', windowStart);
-	if (rateLimitError) throw error(500, 'Failed to check upload rate limit');
+	if (rateLimitError) {
+		logError('api/photos', 'Failed to check upload rate limit', rateLimitError);
+		throw error(500, 'Failed to check upload rate limit');
+	}
 	if ((recentUploads ?? 0) >= PHOTO_RATE_LIMIT) {
 		throw error(429, 'Too many photo uploads. Please wait before trying again.');
 	}
@@ -202,7 +205,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.select('id, status')
 		.eq('id', idParsed.data)
 		.maybeSingle();
-	if (potholeError) throw error(500, 'Failed to verify pothole status');
+	if (potholeError) {
+		logError('api/photos', 'Failed to verify pothole status', potholeError, { potholeId: idParsed.data });
+		throw error(500, 'Failed to verify pothole status');
+	}
 	if (!pothole) throw error(404, 'Pothole not found');
 	if (!ACTIVE_UPLOAD_STATUSES.has(pothole.status)) {
 		throw error(409, 'Photos are only allowed for pending or reported potholes');
@@ -221,7 +227,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.select('*', { count: 'exact', head: true })
 		.eq('pothole_id', idParsed.data)
 		.neq('moderation_status', 'rejected');
-	if (activePhotoCountError) throw error(500, 'Failed to check photo limit');
+	if (activePhotoCountError) {
+		logError('api/photos', 'Failed to check active photo count', activePhotoCountError, { potholeId: idParsed.data });
+		throw error(500, 'Failed to check photo limit');
+	}
 	if ((activePhotoCount ?? 0) >= MAX_ACTIVE_PHOTOS_PER_POTHOLE) {
 		throw error(409, 'This pothole already has the maximum number of active photos');
 	}

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -106,7 +106,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('scope', 'report_submit')
 		.gte('created_at', windowStart);
 
-	if (reportRateError) throw error(500, 'Failed to check report rate limit');
+	if (reportRateError) {
+		logError('api/report', 'Failed to check report rate limit', reportRateError);
+		throw error(500, 'Failed to check report rate limit');
+	}
 	if ((recentReports ?? 0) >= REPORT_RATE_LIMIT) {
 		throw error(429, 'Too many report attempts. Please wait before trying again.');
 	}
@@ -132,7 +135,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.gte('lng', lng - delta * 1.4)
 		.lte('lng', lng + delta * 1.4);
 
-	if (queryError) throw error(500, 'Failed to check nearby reports');
+	if (queryError) {
+		logError('api/report', 'Failed to query nearby pending reports', queryError);
+		throw error(500, 'Failed to check nearby reports');
+	}
 
 	// Find the closest pending pothole within merge radius
 	const match = nearby
@@ -154,7 +160,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 			p_threshold: confirmationsRequired
 		});
 
-		if (rpcError) throw error(500, 'Failed to update report');
+		if (rpcError) {
+			logError('api/report', 'increment_confirmation RPC failed', rpcError, { potholeId: match.id });
+			throw error(500, 'Failed to update report');
+		}
 
 		const rpc = result as ConfirmationResult;
 
@@ -228,7 +237,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.select('id')
 		.single();
 
-	if (insertError) throw error(500, 'Failed to submit report');
+	if (insertError) {
+		logError('api/report', 'Failed to insert new pending pothole', insertError);
+		throw error(500, 'Failed to submit report');
+	}
 
 	// Record the first confirmation — no conflict possible for a brand-new pothole
 	const { error: confirmInsertError } = await getAdminClient()

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -40,7 +40,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('scope', 'push_subscribe')
 		.gte('created_at', windowStart);
 
-	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if (rateLimitError) {
+		logError('api/subscribe', 'Failed to check subscribe rate limit', rateLimitError);
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((recentSubs ?? 0) >= SUBSCRIBE_RATE_LIMIT) {
 		throw error(429, 'Too many subscription attempts. Please wait before trying again.');
 	}
@@ -55,7 +58,10 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		{ onConflict: 'endpoint' }
 	);
 
-	if (dbError) throw error(500, 'Failed to save subscription');
+	if (dbError) {
+		logError('api/subscribe', 'Failed to save push subscription', dbError);
+		throw error(500, 'Failed to save subscription');
+	}
 
 	const { error: rateLimitInsertError } = await db
 		.from('api_rate_limit_events')
@@ -84,7 +90,10 @@ export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 		.eq('scope', 'push_unsubscribe')
 		.gte('created_at', windowStart);
 
-	if (rateLimitError) throw error(500, 'Failed to check rate limit');
+	if (rateLimitError) {
+		logError('api/subscribe', 'Failed to check unsubscribe rate limit', rateLimitError);
+		throw error(500, 'Failed to check rate limit');
+	}
 	if ((recentUnsubs ?? 0) >= UNSUBSCRIBE_RATE_LIMIT) {
 		throw error(429, 'Too many unsubscribe attempts. Please wait before trying again.');
 	}
@@ -93,7 +102,10 @@ export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 		.from('push_subscriptions')
 		.delete()
 		.eq('endpoint', parsed.data.endpoint);
-	if (deleteError) throw error(500, 'Failed to remove subscription');
+	if (deleteError) {
+		logError('api/subscribe', 'Failed to remove push subscription', deleteError);
+		throw error(500, 'Failed to remove subscription');
+	}
 
 	const { error: rateLimitInsertError } = await db
 		.from('api_rate_limit_events')

--- a/src/routes/api/watchlist/+server.ts
+++ b/src/routes/api/watchlist/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types';
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getAdminClient } from '$lib/server/supabase';
+import { logError } from '$lib/server/observability';
 /**
  * GET /api/watchlist?ids=uuid1,uuid2,...
  *
@@ -38,7 +39,10 @@ export const GET: RequestHandler = async ({ url }) => {
 		.select('id, address, lat, lng, status, created_at, filled_at, photos_published')
 		.in('id', parsed.data.ids);
 
-	if (dbError) throw error(500, 'Database error');
+	if (dbError) {
+		logError('api/watchlist', 'Failed to load watchlist potholes', dbError);
+		throw error(500, 'Database error');
+	}
 
 	return json(potholes ?? [], {
 		headers: {

--- a/src/routes/stats/ward/[city]/[ward]/+page.server.ts
+++ b/src/routes/stats/ward/[city]/[ward]/+page.server.ts
@@ -3,6 +3,7 @@ import { supabase } from '$lib/supabase';
 import { decodeHtmlEntities } from '$lib/escape';
 import { COUNCILLORS, fetchWards, type GeoJSONFeature } from '$lib/wards';
 import { inWardFeature } from '$lib/geo';
+import { logError } from '$lib/server/observability';
 import type { PageServerLoad } from './$types';
 import type { Pothole } from '$lib/types';
 import type { City } from '$lib/wards';
@@ -84,7 +85,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
     .order('created_at', { ascending: false });
 
   if (dbError) {
-    console.error('[ward page] supabase error:', dbError.message);
+    logError('stats/ward', 'Failed to load ward potholes', dbError);
     throw error(503, 'Pothole data temporarily unavailable');
   }
 


### PR DESCRIPTION
Closes #203.

SvelteKit only forwards *unexpected* errors to Sentry — an error thrown via the `error()`/`fail()` helper is "expected" and never reaches it. So any `if (dbError) throw error(500, ...)` / `return fail(500, ...)` that swallowed a Supabase error was invisible to the operator (a broken RPC or revoked grant would 500 every request with zero telemetry). Bare server-side `console.error` is equally invisible.

## Change (additive — no status codes or user-facing messages changed)
**70 sites across 22 files:**
- **5** bare server `console.error` → `logError`: `lib/hash.ts`, three catch blocks in `admin/login/mfa`, `stats/ward`.
- **65** `logError(area, message, err, context?)` inserted immediately before a swallowing `error()`/`fail()` — spanning `api/report` (incl. the critical `increment_confirmation` RPC path), subscribe/notify, photos, `og/[id]`, both geocode proxies, watchlist, and every qualifying admin route (audit, map, settings, potholes, photos, users, invites, signup).
- One-line CLAUDE.md convention note added.

Left unchanged (correctly): bare generic 500s with no captured error variable (validation guards, bootstrap config check) and sites that already logged.

## Judgment calls
- Geocode proxies: the `!res.ok` branch has no captured error, so logged a synthesized `Error("Nominatim upstream <status>")` + `{ status }` — the operator-blind case #203 targets.
- `hash.ts`: passed `scope` as non-PII context (the prescribed signature left it unused → lint).
- Context objects are non-PII ids only (e.g. `{ potholeId }`).

## Verification
svelte-check 0 errors, eslint clean, `api-flows` 14 passed (WebServer log confirms the new `logError` calls firing on the closed-DB path — previously silent, now visible). `admin-mfa` has 3 env-only failures (trusted-device/CSRF need live Supabase; this change doesn't touch those control-flow paths).

Touches some files #206 also edits (`export.csv`, `feed.xml`) — small merge reconcile expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird