### PR TITLE
perf: CDN-cacheable polling + indexes + batch marker add (#205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,7 @@ Run migrations in this order:
 26. `schema_votes_ttl.sql` — pg_cron purge job for `pothole_votes` older than 90 days (PIPEDA data minimization)
 27. `schema_ward_subscriptions.sql` — adds `ward_subscriptions` table (ward-level push alert subscriptions) and extends `api_rate_limit_events_scope_check` to include `ward_notify_subscribe`
 28. `schema_pothole_reported_at.sql` — adds `reported_at` timestamptz column (backfilled for existing non-pending rows) and redefines `increment_confirmation` to stamp it on the `pending → reported` flip, so the polling endpoint can detect that transition
+29. `schema_polling_indexes.sql` — partial indexes on `filled_at`/`expired_at` (where not null) so the `/api/potholes/recent` poll's `.or(...)` filter can use a BitmapOr instead of scanning all non-pending rows (#205)
 
 Eleven `pg_cron` jobs run nightly:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Run the migration files against your Supabase project in order:
 18. `schema_votes.sql` — `pothole_votes` table for community upvote/downvote signal
 19. `schema_vote_ratelimit.sql` — adds `vote_submit` scope to `api_rate_limit_events` constraint
 20. `schema_votes_ttl.sql` — pg_cron purge job for `pothole_votes` older than 90 days
+21. `schema_polling_indexes.sql` — partial indexes on `filled_at`/`expired_at` for the `/api/potholes/recent` poll filter (#205)
 
 ### Run
 

--- a/schema_polling_indexes.sql
+++ b/schema_polling_indexes.sql
@@ -1,0 +1,5 @@
+-- schema_polling_indexes.sql
+-- Fix #205: index the filled_at/expired_at OR-arms of the /api/potholes/recent
+-- poll filter so the planner can BitmapOr instead of scanning all non-pending rows.
+create index if not exists potholes_filled_at_idx  on potholes (filled_at)  where filled_at  is not null;
+create index if not exists potholes_expired_at_idx on potholes (expired_at) where expired_at is not null;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,13 +35,20 @@
 	$effect(() => {
 		if (!mapReady) return;
 		pollTimer = setInterval(async () => {
-			const since = new Date(lastPoll - 5000).toISOString();
+			// Quantize the transmitted `since` to a 60s boundary (minus a 5s safety
+			// overlap) so every client polling within the same minute requests the
+			// same URL — lets the CDN (see api/potholes/recent) serve one shared
+			// cached response instead of a unique, uncacheable ms-precision URL per client.
+			const since = new Date(Math.floor((lastPoll - 5000) / 60000) * 60000).toISOString();
 			try {
 				const res = await fetch(`/api/potholes/recent?since=${encodeURIComponent(since)}`);
 				if (!res.ok) return;
 				const { potholes: updated } = await res.json();
-				if (!updated?.length) return;
+				// Advance on every successful poll, not just when updates arrive, so a
+				// quiet tab's `since` window doesn't grow unbounded. The 5s overlap
+				// above absorbs the gap between real time and the quantized value sent.
 				lastPoll = Date.now();
+				if (!updated?.length) return;
 				const L = LRef;
 				if (!L || !mapRef) return;
 				// Announce changes for screen readers

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,12 +67,8 @@
 				for (const p of updated) {
 					const existing = markersById[p.id];
 					if (existing) {
-						const oldContent = existing.getPopup()?.getContent()?.toString() ?? '';
-						const oldStatus = oldContent.includes('popup-status--filled')
-							? 'filled'
-							: oldContent.includes('popup-status--expired')
-								? 'expired'
-								: 'reported';
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const oldStatus = ((existing as any)._status as string | undefined) ?? 'reported';
 						if (oldStatus !== p.status) {
 							const layerKey = p.status in clusterGroups ? p.status : 'reported';
 							const oldLayerKey = oldStatus in clusterGroups ? oldStatus : 'reported';
@@ -87,6 +83,8 @@
 								cg[oldLayerKey].removeLayer(existing);
 								cg[layerKey].addLayer(existing);
 							}
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							(existing as any)._status = p.status;
 						}
 						const info =
 							STATUS_CONFIG[p.status as keyof typeof STATUS_CONFIG] ??
@@ -137,6 +135,8 @@
 						});
 						const marker = L.marker([p.lat, p.lng], { icon });
 						markersById[p.id] = marker;
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						(marker as any)._status = p.status;
 						const address = escapeHtml(
 							p.address || `${p.lat.toFixed(5)}, ${p.lng.toFixed(5)}`,
 						);
@@ -621,6 +621,8 @@
 			const icon = markerIcons[pothole.status] ?? markerIcons['reported'];
 			const marker = L.marker([pothole.lat, pothole.lng], { icon });
 			markersById[pothole.id] = marker;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(marker as any)._status = pothole.status;
 
 			const address = escapeHtml(
 				pothole.address || `${pothole.lat.toFixed(5)}, ${pothole.lng.toFixed(5)}`,
@@ -727,6 +729,8 @@
 						const marker = (e as any).popup._source;
 						clusterGroups['reported']?.removeLayer(marker);
 						clusterGroups['filled']?.addLayer(marker);
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						(marker as any)._status = 'filled';
 					}
 				} catch (err: unknown) {
 					toastError(err instanceof Error ? err.message : 'Something went wrong');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -596,6 +596,7 @@
 			const group = (L as any).markerClusterGroup({
 				maxClusterRadius: 40,
 				spiderfyOnMaxZoom: true,
+				chunkedLoading: true,
 			});
 			clusterGroups[status] = group;
 			if (layers[status]) map.addLayer(group);
@@ -609,6 +610,14 @@
 		fixturePotholes = seededPotholes?.length ? seededPotholes : null;
 		clientPotholes = seededPotholes?.length ? seededPotholes : null;
 		markersById = {};
+		// Accumulate markers per status and hand each cluster group a single
+		// batch via addLayers() after the loop — markercluster's fast path for
+		// bulk population, versus one addLayer() call (and re-cluster) per marker.
+		const layerBatches: Record<(typeof statuses)[number], Marker[]> = {
+			reported: [],
+			expired: [],
+			filled: [],
+		};
 
 		for (const pothole of potholesToRender) {
 			// Any unknown legacy status falls back to the reported layer.
@@ -659,7 +668,11 @@
 				{ maxWidth: 240 },
 			);
 
-			clusterGroups[layerKey].addLayer(marker);
+			layerBatches[layerKey as (typeof statuses)[number]].push(marker);
+		}
+
+		for (const status of statuses) {
+			if (layerBatches[status].length) clusterGroups[status].addLayers(layerBatches[status]);
 		}
 
 		// Delegated listener for popup Fixed button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,11 +35,15 @@
 	$effect(() => {
 		if (!mapReady) return;
 		pollTimer = setInterval(async () => {
-			// Quantize the transmitted `since` to a 60s boundary (minus a 5s safety
-			// overlap) so every client polling within the same minute requests the
-			// same URL — lets the CDN (see api/potholes/recent) serve one shared
-			// cached response instead of a unique, uncacheable ms-precision URL per client.
-			const since = new Date(Math.floor((lastPoll - 5000) / 60000) * 60000).toISOString();
+			// Quantize the transmitted `since` to a 60s boundary so every client
+			// polling within the same minute requests the same URL — lets the CDN
+			// (see api/potholes/recent) serve one shared cached response instead of a
+			// unique, uncacheable ms-precision URL per client. Back off a FULL extra
+			// minute (not just a few seconds): the fetch window must always overlap
+			// the previous ~60s poll, or a change landing between the previous poll
+			// time and the current minute boundary would fall in a gap and never be
+			// polled. With the -1 minute, consecutive windows always overlap.
+			const since = new Date((Math.floor(lastPoll / 60000) - 1) * 60000).toISOString();
 			try {
 				const res = await fetch(`/api/potholes/recent?since=${encodeURIComponent(since)}`);
 				if (!res.ok) return;

--- a/src/routes/api/potholes/recent/+server.ts
+++ b/src/routes/api/potholes/recent/+server.ts
@@ -10,6 +10,10 @@ export const GET: RequestHandler = async ({ url }) => {
 		return json({ potholes: [] });
 	}
 
+	const cacheHeaders = {
+		'Cache-Control': 'public, s-maxage=55, stale-while-revalidate=60',
+	};
+
 	const { data, error: dbError } = await supabase
 		.from('potholes')
 		.select(
@@ -33,5 +37,5 @@ export const GET: RequestHandler = async ({ url }) => {
 		description: p.description ? decodeHtmlEntities(p.description) : null,
 	}));
 
-	return json({ potholes });
+	return json({ potholes }, { headers: cacheHeaders });
 };


### PR DESCRIPTION
Closes #205.

The 60s polling endpoint was the top scaling risk: uncacheable (unique ms `since` per client → N tabs = N DB queries/min) and two of its filter's OR-arms were unindexed.

## Changes
- **`schema_polling_indexes.sql`** (new): partial indexes on `potholes(filled_at)` and `potholes(expired_at)` so the poll's `.or(created_at, reported_at, filled_at, expired_at)` filter can BitmapOr instead of scanning all non-pending rows. (`created_at`/`reported_at` already indexed.) Added to CLAUDE.md + README migration lists.
- **CDN caching** (`api/potholes/recent`): `Cache-Control: public, s-maxage=55, stale-while-revalidate=60`, applied **only to the success response** (not the error/invalid-`since` branches, so a transient failure can't be frozen into the CDN). The client quantizes the transmitted `since` to a 60s boundary so all clients in a given minute share one cacheable URL.
- **Batch marker add** (`+page.svelte`): initial map population now accumulates per-status arrays and calls `addLayers()` once per cluster group (+ `chunkedLoading: true`) instead of `addLayer()` per marker — markercluster's fast path. Poll update path (already incremental) unchanged.
- **Low-hanging:** `lastPoll` now advances on every successful poll (quiet-tab window no longer grows unbounded); marker status tracked via a `_status` field instead of re-parsing popup HTML.

## Review fix applied
The agent's `since`-quantization backed off only 5s, which left a gap: a change landing between the previous poll time and the current minute boundary matched **neither** poll and was silently never returned (worked example: pothole going live at t=100s missed when polls are at 90s/150s). Corrected to back off a **full minute** (`(floor(lastPoll/60000) - 1) * 60000`), so consecutive fetch windows always overlap while staying cacheable. This is the flagged correctness-sensitive part — now gap-free.

## Verification
svelte-check 0, eslint clean, build ok, 49 Playwright passed. Migration (`schema_polling_indexes.sql`) applied manually to Supabase before deploy.

Touches the recent endpoint area that #203 also edits — small rebase reconcile expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird