### PR TITLE
security(critical): revoke public write access to potholes/confirmations/actions (#200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,7 @@ Run migrations in this order:
 27. `schema_ward_subscriptions.sql` — adds `ward_subscriptions` table (ward-level push alert subscriptions) and extends `api_rate_limit_events_scope_check` to include `ward_notify_subscribe`
 28. `schema_pothole_reported_at.sql` — adds `reported_at` timestamptz column (backfilled for existing non-pending rows) and redefines `increment_confirmation` to stamp it on the `pending → reported` flip, so the polling endpoint can detect that transition
 29. `schema_polling_indexes.sql` — partial indexes on `filled_at`/`expired_at` (where not null) so the `/api/potholes/recent` poll's `.or(...)` filter can use a BitmapOr instead of scanning all non-pending rows (#205)
+30. `schema_revoke_public_writes.sql` — **security (critical):** drops the leftover public write RLS policies (`"Public insert"`/`"Public update"` on potholes, `"Public insert"` on confirmations/actions) and `REVOKE`s the legacy broad write grants from `anon`/`authenticated` (keeps SELECT). All writes go through the service-role client; without this the shipped anon key could INSERT/UPDATE potholes directly via PostgREST. Supersedes the (grant-only, no-revoke) `schema_grants.sql` for the write-lockdown. (#200)
 
 Eleven `pg_cron` jobs run nightly:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Run the migration files against your Supabase project in order:
 19. `schema_vote_ratelimit.sql` — adds `vote_submit` scope to `api_rate_limit_events` constraint
 20. `schema_votes_ttl.sql` — pg_cron purge job for `pothole_votes` older than 90 days
 21. `schema_polling_indexes.sql` — partial indexes on `filled_at`/`expired_at` for the `/api/potholes/recent` poll filter (#205)
+22. `schema_revoke_public_writes.sql` — security: drop leftover public write RLS policies + revoke anon/authenticated write grants (writes are service-role only) (#200)
 
 ### Run
 

--- a/schema_revoke_public_writes.sql
+++ b/schema_revoke_public_writes.sql
@@ -1,0 +1,27 @@
+-- schema_revoke_public_writes.sql
+-- SECURITY (critical): remove public write access to potholes / confirmations / actions.
+--
+-- The write flows were migrated to the service-role client long ago, but the
+-- original public write RLS policies were never dropped AND `anon` still carried
+-- Supabase's legacy broad table grants. With the anon key (shipped in the browser
+-- bundle) an attacker could hit PostgREST directly and: INSERT arbitrary potholes,
+-- self-INSERT confirmations to force pending reports live, and UPDATE ANY pothole
+-- (the "Public update" policy used `USING (true)`) — bypassing geofence, rate
+-- limits, coordinate rounding, and the confirmation gate.
+--
+-- schema_grants.sql GRANTs anon SELECT but never REVOKEd these writes, so this
+-- migration does the revoke. All application writes use the service_role client
+-- (unaffected); anon retains SELECT for SSR reads (governed by the remaining
+-- "Public read non-pending" policy).
+
+-- 1. Drop the public write policies.
+DROP POLICY IF EXISTS "Public insert"               ON potholes;
+DROP POLICY IF EXISTS "Public update"               ON potholes;
+DROP POLICY IF EXISTS "Public insert confirmations" ON pothole_confirmations;
+DROP POLICY IF EXISTS "Public insert actions"       ON pothole_actions;
+
+-- 2. Revoke the legacy broad write grants (defense in depth — even if a policy
+--    reappears, anon/authenticated cannot write). SELECT is intentionally kept.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON potholes, pothole_confirmations, pothole_actions
+  FROM anon, authenticated;

--- a/schema_vote_ratelimit.sql
+++ b/schema_vote_ratelimit.sql
@@ -1,6 +1,11 @@
 -- schema_vote_ratelimit.sql
 -- Extend the api_rate_limit_events scope check constraint to include 'vote_submit'.
--- The constraint was last defined in schema_fill_notify_ratelimit.sql.
+--
+-- NOTE: schema_ward_subscriptions.sql later redefined this same constraint with a
+-- superset that also includes 'ward_notify_subscribe'. This file's scope list is
+-- kept as that full UNION so applying it is a safe no-op regardless of order —
+-- an earlier 7-scope version would have DROPPED 'ward_notify_subscribe' and broken
+-- ward alert subscriptions. Any future scope addition must extend BOTH files.
 
 ALTER TABLE api_rate_limit_events DROP CONSTRAINT IF EXISTS api_rate_limit_events_scope_check;
 ALTER TABLE api_rate_limit_events
@@ -12,5 +17,6 @@ ALTER TABLE api_rate_limit_events
         'push_subscribe',
         'push_unsubscribe',
         'fill_notify_subscribe',
-        'vote_submit'
+        'vote_submit',
+        'ward_notify_subscribe'
     ));


### PR DESCRIPTION
Closes #200. **Already applied to the live database and verified** (see below) — this PR lands the migration in the repo.

## The vulnerability (confirmed live, not latent)
A Management-API audit of production showed `anon` (the key shipped in the browser bundle) had `INSERT, UPDATE, DELETE, TRUNCATE` grants on `potholes`, `pothole_confirmations`, `pothole_actions`, **plus** matching public write RLS policies — including a `"Public update"` policy with `USING (true)`. Via PostgREST an attacker could:
- inject arbitrary potholes (bypassing geofence / rate-limit / coordinate rounding / the 2-confirmation gate),
- self-`INSERT` confirmations to force pending reports onto the public map,
- **`UPDATE` any pothole** — mark everything filled, rewrite addresses, tamper with the whole dataset.

The writes were migrated to the service-role client long ago, but the old public policies were never dropped and `anon` kept Supabase's legacy broad grants. The merged `schema_grants.sql` only `GRANT`s SELECT — it never revoked the writes, so it did not close this.

## Fix
`schema_revoke_public_writes.sql`: drops the 4 public write policies and `REVOKE`s `INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER` from `anon`/`authenticated` (SELECT kept for SSR reads, governed by the remaining `"Public read non-pending"` policy). Verified safe — the app performs all writes via the service-role client (`getAdminClient` in report/filled/hit/vote); the anon client is read-only in `src/`.

Also widened `schema_vote_ratelimit.sql`'s scope constraint to the full union (adds `ward_notify_subscribe`) so it can never regress the live constraint.

## Verified on production (post-apply)
- `anon`/`authenticated`: **SELECT only** on all three tables (was INSERT/UPDATE/DELETE/…).
- Remaining policy on potholes: only `"Public read non-pending"`.
- Rate-limit scope constraint retains all 8 scopes (ward + vote intact).

## Also applied this pass (feature migrations that were merged but never applied)
`schema_pothole_reported_at.sql`, `schema_votes.sql`, `schema_votes_ttl.sql`, `schema_polling_indexes.sql`, `schema_grants.sql` — verified: `reported_at` + all three polling indexes present, `pothole_votes` created, votes-ttl cron scheduled. `schema_vote_ratelimit.sql` was intentionally **not** applied (the live ward migration's union already covers `vote_submit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird