### PR TITLE
fix(#207) + refactor(#208): filled-marker copy, shared mark-filled + rate-limit helpers

### DIFF
--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -1,0 +1,50 @@
+import { error } from '@sveltejs/kit';
+import { logError } from '$lib/server/observability';
+import type { getAdminClient } from '$lib/server/supabase';
+
+type AdminClient = ReturnType<typeof getAdminClient>;
+
+/**
+ * Shared per-IP-scope rate limit for `api_rate_limit_events`: counts events
+ * for `ipHash`/`scope` within the trailing `windowMs`, throws
+ * `error(429, rateLimitedMessage)` at/over `limit`, then records this
+ * attempt. The insert is non-fatal — a broken rate-limit table should never
+ * block a legitimate action, so a failure is logged (via `logError`) rather
+ * than thrown.
+ *
+ * Route-specific extra checks (e.g. per-pothole caps in api/hit and
+ * api/vote) are separate from this per-IP check and stay inline at the
+ * call site.
+ */
+export async function checkAndRecordRateLimit(
+	db: AdminClient,
+	ipHash: string,
+	scope: string,
+	limit: number,
+	windowMs: number,
+	rateLimitedMessage: string,
+	area: string,
+	checkFailedMessage = 'Failed to check rate limit',
+	context?: Record<string, unknown>
+): Promise<void> {
+	const windowStart = new Date(Date.now() - windowMs).toISOString();
+	const { count, error: countError } = await db
+		.from('api_rate_limit_events')
+		.select('*', { count: 'exact', head: true })
+		.eq('ip_hash', ipHash)
+		.eq('scope', scope)
+		.gte('created_at', windowStart);
+
+	if (countError) {
+		logError(area, `Failed to check ${scope} rate limit`, countError, context);
+		throw error(500, checkFailedMessage);
+	}
+	if ((count ?? 0) >= limit) {
+		throw error(429, rateLimitedMessage);
+	}
+
+	const { error: insertError } = await db.from('api_rate_limit_events').insert({ ip_hash: ipHash, scope });
+	if (insertError) {
+		logError(`${area}/ratelimit`, 'Failed to record rate limit event', insertError);
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -149,7 +149,9 @@
 						const statusNote =
 							p.status === 'reported'
 								? 'Seen this too? Open details to watch it, share it, or report it officially.'
-								: 'Archived after no action. Open details if you need the full history.';
+								: p.status === 'filled'
+									? 'Marked filled by the community. Open details to review the timeline.'
+									: 'Archived after no action. Open details if you need the full history.';
 						marker.bindPopup(
 							`<div class="popup-content">
 								<div class="popup-header"><strong>${address}</strong><span class="popup-status popup-status--${p.status}">${info.label}</span></div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -380,32 +380,57 @@
 		}
 	}
 
+	/**
+	 * Shared "mark as filled" logic for the list-view button and the map
+	 * popup's "It's fixed!" button: POST /api/filled, toast the result, and
+	 * (on success) patch `clientPotholes` + move the marker into the filled
+	 * cluster group. `opts.beforeToast` lets a caller run UI cleanup (e.g.
+	 * closing a popup) at the same point the original call site did — after
+	 * the fetch resolves without throwing, but before the toast fires.
+	 */
+	async function applyFilledResult(
+		id: string,
+		opts?: { beforeToast?: () => void },
+	): Promise<{ ok: boolean }> {
+		const res = await fetch('/api/filled', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ id }),
+		});
+		const result = await res.json();
+		if (!res.ok && res.status !== 409) throw new Error(result.message || 'Failed');
+
+		opts?.beforeToast?.();
+		toast.success(result.ok ? 'Marked as fixed!' : result.message);
+		if (!result.ok) return { ok: false };
+
+		// Targeted delta: mutate only the changed element so $derived consumers
+		// don't recalculate the full array on every fill action.
+		if (!clientPotholes) clientPotholes = (potholes as Pothole[]).slice();
+		const idx = clientPotholes.findIndex((p) => p.id === id);
+		if (idx !== -1) {
+			clientPotholes[idx] = {
+				...clientPotholes[idx],
+				status: 'filled',
+				filled_at: new Date().toISOString(),
+			};
+		}
+
+		const marker = markersById[id];
+		if (marker) {
+			clusterGroups.reported?.removeLayer(marker);
+			clusterGroups.filled?.addLayer(marker);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(marker as any)._status = 'filled';
+		}
+
+		return { ok: true };
+	}
+
 	async function markPotholeFilled(id: string) {
 		try {
-			const res = await fetch('/api/filled', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ id }),
-			});
-			const result = await res.json();
-			if (!res.ok && res.status !== 409) throw new Error(result.message || 'Failed');
-
-			toast.success(result.ok ? 'Marked as fixed!' : result.message);
-			if (!result.ok) return;
-
-			if (!clientPotholes) clientPotholes = [...(potholes as Pothole[])];
-			clientPotholes = clientPotholes.map((pothole) =>
-				pothole.id === id
-					? { ...pothole, status: 'filled', filled_at: new Date().toISOString() }
-					: pothole,
-			);
-
-			const marker = markersById[id];
-			if (marker) {
-				clusterGroups.reported?.removeLayer(marker);
-				clusterGroups.filled?.addLayer(marker);
-			}
-			liveAnnouncement = 'Pothole marked fixed and moved to the filled list.';
+			const result = await applyFilledResult(id);
+			if (result.ok) liveAnnouncement = 'Pothole marked fixed and moved to the filled list.';
 		} catch (err: unknown) {
 			toastError(err instanceof Error ? err.message : 'Something went wrong');
 		}
@@ -720,37 +745,7 @@
 				if (!id) return;
 
 				try {
-					const res = await fetch('/api/filled', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ id }),
-					});
-					const result = await res.json();
-					if (!res.ok && res.status !== 409) throw new Error(result.message || 'Failed');
-
-					map.closePopup();
-					toast.success(result.ok ? 'Marked as fixed!' : result.message);
-
-					// Move marker from reported layer to filled layer.
-					if (result.ok) {
-						// Targeted delta: mutate only the changed element so $derived consumers
-						// don't recalculate the full array on every fill action.
-						if (!clientPotholes) clientPotholes = (potholes as Pothole[]).slice();
-						const idx = clientPotholes.findIndex((p) => p.id === id);
-						if (idx !== -1) {
-							clientPotholes[idx] = {
-								...clientPotholes[idx],
-								status: 'filled',
-								filled_at: new Date().toISOString(),
-							};
-						}
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const marker = (e as any).popup._source;
-						clusterGroups['reported']?.removeLayer(marker);
-						clusterGroups['filled']?.addLayer(marker);
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						(marker as any)._status = 'filled';
-					}
+					await applyFilledResult(id, { beforeToast: () => map.closePopup() });
 				} catch (err: unknown) {
 					toastError(err instanceof Error ? err.message : 'Something went wrong');
 				}

--- a/src/routes/api/hit/+server.ts
+++ b/src/routes/api/hit/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { getAdminClient } from '$lib/server/supabase';
 const schema = z.object({ id: z.string().uuid() });
 
@@ -19,21 +20,16 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const db = getAdminClient();
 
 	// Persistent per-IP rate limit — prevents spraying hits across all potholes.
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'hit_submit',
+		HIT_RATE_LIMIT,
+		HIT_RATE_WINDOW_MS,
+		'Too many requests. Please wait before trying again.',
+		'api/hit'
+	);
 	const windowStart = new Date(Date.now() - HIT_RATE_WINDOW_MS).toISOString();
-	const { count: recentHits, error: rateLimitError } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'hit_submit')
-		.gte('created_at', windowStart);
-
-	if (rateLimitError) {
-		logError('api/hit', 'Failed to check per-IP rate limit', rateLimitError);
-		throw error(500, 'Failed to check rate limit');
-	}
-	if ((recentHits ?? 0) >= HIT_RATE_LIMIT) {
-		throw error(429, 'Too many requests. Please wait before trying again.');
-	}
 
 	// Per-pothole rate limit — prevents distributed bots from inflating a single
 	// pothole's hit count across many IPs within the per-IP ceiling.
@@ -69,14 +65,6 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		}
 		logError('api/hit', 'Failed to record hit', insertError, { potholeId: parsed.data.id });
 		throw error(500, 'Failed to record hit');
-	}
-
-	// Non-fatal rate limit event record
-	const { error: rateLimitInsertError } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'hit_submit' });
-	if (rateLimitInsertError) {
-		logError('hit/ratelimit', 'Failed to record rate limit event', rateLimitInsertError);
 	}
 
 	const { count } = await db

--- a/src/routes/api/notify/[id]/+server.ts
+++ b/src/routes/api/notify/[id]/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { getAdminClient } from '$lib/server/supabase';
 import { isSafePushEndpoint } from '$lib/server/ssrf';
 
@@ -31,19 +32,17 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 	const ipHash = await hashIp(getClientAddress());
 	const db = getAdminClient();
 
-	const windowStart = new Date(Date.now() - RATE_WINDOW_MS).toISOString();
-	const { count: recent, error: rateLimitError } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'fill_notify_subscribe')
-		.gte('created_at', windowStart);
-
-	if (rateLimitError) {
-		logError('api/notify', 'Failed to check rate limit', rateLimitError, { potholeId: id });
-		throw error(500, 'Failed to check rate limit');
-	}
-	if ((recent ?? 0) >= RATE_LIMIT) throw error(429, 'Too many requests. Please wait before trying again.');
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'fill_notify_subscribe',
+		RATE_LIMIT,
+		RATE_WINDOW_MS,
+		'Too many requests. Please wait before trying again.',
+		'api/notify',
+		'Failed to check rate limit',
+		{ potholeId: id }
+	);
 
 	// Confirm the pothole exists and is in a state where a fill notification makes sense.
 	const { data: pothole, error: potholeErr } = await db
@@ -68,11 +67,6 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 		logError('api/notify', 'Failed to save fill notification subscription', dbError, { potholeId: id });
 		throw error(500, 'Failed to save subscription');
 	}
-
-	const { error: rlErr } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'fill_notify_subscribe' });
-	if (rlErr) logError('notify/ratelimit', 'Failed to record rate limit event', rlErr);
 
 	return json({ ok: true });
 };

--- a/src/routes/api/notify/ward/+server.ts
+++ b/src/routes/api/notify/ward/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { getAdminClient } from '$lib/server/supabase';
 import { isSafePushEndpoint } from '$lib/server/ssrf';
 import { isKnownWardKey } from '$lib/wards';
@@ -26,18 +27,17 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ipHash = await hashIp(getClientAddress());
 	const db = getAdminClient();
 
-	const windowStart = new Date(Date.now() - RATE_WINDOW_MS).toISOString();
-	const { count: recent, error: rlErr } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'ward_notify_subscribe')
-		.gte('created_at', windowStart);
-	if (rlErr) {
-		logError('api/notify/ward', 'Failed to check rate limit', rlErr, { wardKey: parsed.data.ward_key });
-		throw error(500, 'Failed to check rate limit');
-	}
-	if ((recent ?? 0) >= RATE_LIMIT) throw error(429, 'Too many requests. Please wait before trying again.');
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'ward_notify_subscribe',
+		RATE_LIMIT,
+		RATE_WINDOW_MS,
+		'Too many requests. Please wait before trying again.',
+		'api/notify/ward',
+		'Failed to check rate limit',
+		{ wardKey: parsed.data.ward_key }
+	);
 
 	const { error: dbError } = await db.from('ward_subscriptions').upsert(
 		{
@@ -52,11 +52,6 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		logError('api/notify/ward', 'Failed to save ward subscription', dbError, { wardKey: parsed.data.ward_key });
 		throw error(500, 'Failed to save subscription');
 	}
-
-	const { error: insErr } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'ward_notify_subscribe' });
-	if (insErr) logError('notify/ward/ratelimit', 'Failed to record rate limit event', insErr);
 
 	return json({ ok: true });
 };

--- a/src/routes/api/photos/+server.ts
+++ b/src/routes/api/photos/+server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { notify } from '$lib/server/pushover';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { stripJpegMetadata, stripPngMetadata, stripWebpMetadata } from '$lib/server/exif-strip';
 import { getAdminClient } from '$lib/server/supabase';
 import { fixturePotholes } from '$lib/server/fixture-store';
@@ -184,20 +185,15 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ipHash = await hashIp(getClientAddress());
 
 	// Persistent rate limit to prevent storage and moderation abuse.
-	const windowStart = new Date(Date.now() - PHOTO_RATE_WINDOW_MS).toISOString();
-	const { count: recentUploads, error: rateLimitError } = await getAdminClient()
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'photo_upload')
-		.gte('created_at', windowStart);
-	if (rateLimitError) {
-		logError('api/photos', 'Failed to check upload rate limit', rateLimitError);
-		throw error(500, 'Failed to check upload rate limit');
-	}
-	if ((recentUploads ?? 0) >= PHOTO_RATE_LIMIT) {
-		throw error(429, 'Too many photo uploads. Please wait before trying again.');
-	}
+	await checkAndRecordRateLimit(
+		getAdminClient(),
+		ipHash,
+		'photo_upload',
+		PHOTO_RATE_LIMIT,
+		PHOTO_RATE_WINDOW_MS,
+		'Too many photo uploads. Please wait before trying again.',
+		'api/photos'
+	);
 
 	// Confirm the pothole exists and still accepts photos.
 	const { data: pothole, error: potholeError } = await getAdminClient()
@@ -212,13 +208,6 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	if (!pothole) throw error(404, 'Pothole not found');
 	if (!ACTIVE_UPLOAD_STATUSES.has(pothole.status)) {
 		throw error(409, 'Photos are only allowed for pending or reported potholes');
-	}
-
-	const { error: rateLimitInsertError } = await getAdminClient()
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'photo_upload' });
-	if (rateLimitInsertError) {
-		logError('photos/ratelimit', 'Failed to record rate limit event', rateLimitInsertError, { ipHashPrefix: ipHash.slice(0, 8) });
 	}
 
 	// Prevent unlimited media accumulation on a single pothole.

--- a/src/routes/api/report/+server.ts
+++ b/src/routes/api/report/+server.ts
@@ -5,6 +5,7 @@ import { hashIp } from '$lib/hash';
 import { roundPublicCoord, haversineMetres } from '$lib/geo';
 import { GEOFENCE, MERGE_RADIUS_M } from '$lib/constants';
 import { getConfirmationThreshold } from '$lib/server/settings';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { notify } from '$lib/server/pushover';
 import { postConfirmed } from '$lib/server/bluesky';
 import { notifyWardSubscribers } from '$lib/server/webpush';
@@ -98,31 +99,16 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ipHash = await hashIp(getClientAddress());
 
 	// Persistent per-IP report throttling.
-	const windowStart = new Date(Date.now() - REPORT_RATE_WINDOW_MS).toISOString();
-	const { count: recentReports, error: reportRateError } = await getAdminClient()
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'report_submit')
-		.gte('created_at', windowStart);
-
-	if (reportRateError) {
-		logError('api/report', 'Failed to check report rate limit', reportRateError);
-		throw error(500, 'Failed to check report rate limit');
-	}
-	if ((recentReports ?? 0) >= REPORT_RATE_LIMIT) {
-		throw error(429, 'Too many report attempts. Please wait before trying again.');
-	}
-
-	const { error: reportRateInsertError } = await getAdminClient()
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'report_submit' });
-
-	if (reportRateInsertError) {
-		// Non-fatal: log and continue. A broken rate-limit table should not block
-		// legitimate reports — the next check will simply see a lower count.
-		logError('report', 'Failed to record rate limit event', reportRateInsertError, { ipHashPrefix: ipHash.slice(0, 8) });
-	}
+	await checkAndRecordRateLimit(
+		getAdminClient(),
+		ipHash,
+		'report_submit',
+		REPORT_RATE_LIMIT,
+		REPORT_RATE_WINDOW_MS,
+		'Too many report attempts. Please wait before trying again.',
+		'api/report',
+		'Failed to check report rate limit'
+	);
 
 	// Search for existing pending potholes nearby using a bounding box
 	const delta = 0.0005;

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { getAdminClient } from '$lib/server/supabase';
 import { isSafePushEndpoint } from '$lib/server/ssrf';
 
@@ -32,21 +33,16 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ipHash = await hashIp(getClientAddress());
 	const db = getAdminClient();
 
-	const windowStart = new Date(Date.now() - SUBSCRIBE_RATE_WINDOW_MS).toISOString();
-	const { count: recentSubs, error: rateLimitError } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'push_subscribe')
-		.gte('created_at', windowStart);
-
-	if (rateLimitError) {
-		logError('api/subscribe', 'Failed to check subscribe rate limit', rateLimitError);
-		throw error(500, 'Failed to check rate limit');
-	}
-	if ((recentSubs ?? 0) >= SUBSCRIBE_RATE_LIMIT) {
-		throw error(429, 'Too many subscription attempts. Please wait before trying again.');
-	}
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'push_subscribe',
+		SUBSCRIBE_RATE_LIMIT,
+		SUBSCRIBE_RATE_WINDOW_MS,
+		'Too many subscription attempts. Please wait before trying again.',
+		'api/subscribe',
+		'Failed to check rate limit'
+	);
 
 	const { error: dbError } = await db.from('push_subscriptions').upsert(
 		{
@@ -63,13 +59,6 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		throw error(500, 'Failed to save subscription');
 	}
 
-	const { error: rateLimitInsertError } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'push_subscribe' });
-	if (rateLimitInsertError) {
-		logError('subscribe/ratelimit', 'Failed to record rate limit event', rateLimitInsertError);
-	}
-
 	return json({ ok: true });
 };
 
@@ -82,21 +71,16 @@ export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 	const ipHash = await hashIp(getClientAddress());
 	const db = getAdminClient();
 
-	const windowStart = new Date(Date.now() - SUBSCRIBE_RATE_WINDOW_MS).toISOString();
-	const { count: recentUnsubs, error: rateLimitError } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'push_unsubscribe')
-		.gte('created_at', windowStart);
-
-	if (rateLimitError) {
-		logError('api/subscribe', 'Failed to check unsubscribe rate limit', rateLimitError);
-		throw error(500, 'Failed to check rate limit');
-	}
-	if ((recentUnsubs ?? 0) >= UNSUBSCRIBE_RATE_LIMIT) {
-		throw error(429, 'Too many unsubscribe attempts. Please wait before trying again.');
-	}
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'push_unsubscribe',
+		UNSUBSCRIBE_RATE_LIMIT,
+		SUBSCRIBE_RATE_WINDOW_MS,
+		'Too many unsubscribe attempts. Please wait before trying again.',
+		'api/subscribe',
+		'Failed to check rate limit'
+	);
 
 	const { error: deleteError } = await db
 		.from('push_subscriptions')
@@ -105,13 +89,6 @@ export const DELETE: RequestHandler = async ({ request, getClientAddress }) => {
 	if (deleteError) {
 		logError('api/subscribe', 'Failed to remove push subscription', deleteError);
 		throw error(500, 'Failed to remove subscription');
-	}
-
-	const { error: rateLimitInsertError } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'push_unsubscribe' });
-	if (rateLimitInsertError) {
-		logError('subscribe/ratelimit', 'Failed to record unsubscribe rate limit event', rateLimitInsertError);
 	}
 
 	return json({ ok: true });

--- a/src/routes/api/vote/+server.ts
+++ b/src/routes/api/vote/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { z } from 'zod';
 import { hashIp } from '$lib/hash';
 import { logError } from '$lib/server/observability';
+import { checkAndRecordRateLimit } from '$lib/server/rate-limit';
 import { getAdminClient } from '$lib/server/supabase';
 
 const postSchema = z.object({
@@ -44,17 +45,15 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const windowStart = new Date(Date.now() - VOTE_RATE_WINDOW_MS).toISOString();
 
 	// Per-IP rate limit
-	const { count: recentVotes, error: rateLimitError } = await db
-		.from('api_rate_limit_events')
-		.select('*', { count: 'exact', head: true })
-		.eq('ip_hash', ipHash)
-		.eq('scope', 'vote_submit')
-		.gte('created_at', windowStart);
-
-	if (rateLimitError) throw error(500, 'Failed to check rate limit');
-	if ((recentVotes ?? 0) >= VOTE_RATE_LIMIT) {
-		throw error(429, 'Too many requests. Please wait before trying again.');
-	}
+	await checkAndRecordRateLimit(
+		db,
+		ipHash,
+		'vote_submit',
+		VOTE_RATE_LIMIT,
+		VOTE_RATE_WINDOW_MS,
+		'Too many requests. Please wait before trying again.',
+		'api/vote'
+	);
 
 	// Per-pothole rate limit
 	const { count: potholeVotes, error: potholeRateError } = await db
@@ -79,14 +78,6 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	if (upsertError) {
 		logError('vote/upsert', 'Failed to upsert vote', upsertError);
 		throw error(500, 'Failed to record vote');
-	}
-
-	// Non-fatal rate limit event
-	const { error: rateLimitInsertError } = await db
-		.from('api_rate_limit_events')
-		.insert({ ip_hash: ipHash, scope: 'vote_submit' });
-	if (rateLimitInsertError) {
-		logError('vote/ratelimit', 'Failed to record rate limit event', rateLimitInsertError);
 	}
 
 	// Return current counts


### PR DESCRIPTION
Closes #207 and #208.

## #207 — bugfix: filled markers no longer show "Archived after no action"
The "new pothole" branch of the 60s polling handler used a two-way status note (`reported` vs everything-else), so a pothole first seen as `filled` via polling got the expired-copy. Now uses the same three-way `reported`/`filled`/`expired` ternary as the other two render sites.

## #208a — refactor: dedup mark-filled (client)
Extracted the shared "POST /api/filled → toast → patch `clientPotholes` → move marker between cluster groups" into `applyFilledResult()`, used by both the list-view path and the map-popup handler; each keeps its site-specific bit (list announces to the live region, popup closes itself). No observable behavior change.

## #208b — refactor: shared rate-limit helper
New `src/lib/server/rate-limit.ts` `checkAndRecordRateLimit(db, ipHash, scope, limit, windowMs, msg, area, …)` replaces the duplicated count→429→insert pattern in `report`, `hit`, `photos`, `notify/[id]`, `notify/ward`, `vote`, `subscribe`. Each route keeps its **exact** limit/window/scope/message; per-pothole extra caps (hit, vote) stay inline; `api/filled` left inline (it rate-limits via `pothole_actions` as an idempotency guard — structurally different). Verified: **no route double-inserts**, and the #203 `logError` on count/insert failure is preserved. Byproduct: fixed a pre-existing missing-`logError` on `api/vote`'s 500 path.

## ⚠️ One behavior change to sign off on
The consolidated helper records the rate-limit event **right after the count check** (before the main action), whereas 6 of these routes previously inserted it **after the action succeeded**. Net effect: a *validated* attempt now consumes quota even if it then fails/dedupes — a strict **tightening** (nothing newly permitted; closes a small gap where failing requests were quota-free). If you'd rather preserve the exact prior "charge only on success" timing, say so and I'll split the helper so the record stays at the call site.

## Verification
svelte-check 0 errors, eslint clean, 39 passed (api-flows + map-page), 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrSS1iBs8R2c1gznJCzird