### PR TITLE
fix(a11y): collapse header push labels to icon-only below 400px (#213)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,6 +47,12 @@ export default defineConfig({
       SUPABASE_CONFIGURED: process.env.PUBLIC_SUPABASE_URL?.startsWith("http")
         ? "true"
         : "false",
+      // Enable push UI in tests so the "Blocked" nav state (headless Chromium
+      // auto-denies notification permission) gets real regression coverage —
+      // without this, PushNotifications.svelte never renders in CI (#213).
+      PUBLIC_VAPID_PUBLIC_KEY:
+        process.env.PUBLIC_VAPID_PUBLIC_KEY ??
+        "BDPlaceholderPlaceholderPlaceholderPlaceholderPlaceholderPlaceholderPlaceholderPlaceho",
     },
   },
 });

--- a/src/lib/components/PushNotifications.svelte
+++ b/src/lib/components/PushNotifications.svelte
@@ -103,7 +103,7 @@
 		title="Get notified when potholes are fixed"
 	>
 		<Icon name="bell" size={13} />
-		Notify me
+		<span class="max-[400px]:sr-only">Notify me</span>
 	</button>
 {:else if notifState === 'subscribed'}
 	<button
@@ -112,16 +112,16 @@
 		title="You're receiving fill notifications — click to turn off"
 	>
 		<Icon name="bell" size={13} />
-		Notified
+		<span class="max-[400px]:sr-only">Notified</span>
 	</button>
 {:else if notifState === 'denied'}
 	<span class="inline-flex items-center gap-1.5 text-xs text-stone-600 cursor-not-allowed" title="Notifications blocked — change in browser settings">
 		<Icon name="bell-off" size={13} />
-		Blocked
+		<span class="max-[400px]:sr-only">Blocked</span>
 	</span>
 {:else if notifState === 'pending'}
 	<span class="inline-flex items-center gap-1.5 text-xs text-stone-400 animate-pulse">
 		<Icon name="bell" size={13} />
-		…
+		<span class="max-[400px]:sr-only">…</span>
 	</span>
 {/if}


### PR DESCRIPTION
Closes #213

## What

With push configured (`PUBLIC_VAPID_PUBLIC_KEY` set, as in production) and notification permission denied, the header's "Blocked" indicator pushed the nav to **337px** of scroll width at a 320px viewport — horizontal scroll, a WCAG 1.4.10 reflow failure.

Each push state's text label ("Notify me", "Notified", "Blocked", "…") is now wrapped in `max-[400px]:sr-only`: icon-only below 400px, while the label stays in the accessibility tree — accessible names intact, no `aria-label` duplication or label-in-name (2.5.3) concerns, `title` tooltips unchanged. Markup-only change; the component's script block is untouched (avoids conflicts with #223's changes to the same file).

## CI coverage (the issue's test note)

Added a placeholder `PUBLIC_VAPID_PUBLIC_KEY` to the Playwright webServer env. Headless Chromium auto-denies notification permission, so the a11y reflow tests now exercise exactly the "Blocked" state that regressed — this bug class can't silently return. Checked before keeping it global: `static/sw.js`'s fetch handler only does network-first for same-origin GET navigations, and the a11y suite passes 14/14 both with the placeholder and with `PUBLIC_VAPID_PUBLIC_KEY=""` (true no-push path).

## Verification

- TDD: reproduced RED (both 320px reflow tests failing at 337px scroll width, "Blocked" state rendered) → GREEN with only the label change; no nav-gap or flex-wrap fallbacks needed.
- Lint clean, svelte-check 0 errors.
- Full suite locally: the only failures are a known pre-existing set of live-Supabase-dependent tests that fail identically on plain `main` (A/B verified; follow-up issue filed separately). Nothing #213 touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5jw9vuMFSmPrX3nseoCuG