### PR TITLE
refactor: DRY the triplicated photo-thumbnail markup via Svelte 5 snippet (#212)

### DIFF
--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -825,6 +825,22 @@
 	{/if}
 
 	<!-- Photos -->
+	{#snippet thumb(photo: (typeof photos)[number])}
+		{@const idx = photos.indexOf(photo)}
+		<button
+			onclick={() => openLightbox(idx)}
+			class="block rounded-md overflow-hidden ring-1 ring-stone-200 dark:ring-stone-700 hover:ring-amber-500 transition-shadow cursor-zoom-in"
+			aria-label="View photo {idx + 1} of {photos.length}"
+		>
+			<img
+				src={photo.thumbnailUrl}
+				alt="Pothole at {pothole.address || 'this location'}"
+				class="w-full object-cover aspect-video"
+				loading="lazy"
+				onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.onerror = null; img.src = photo.url; }}
+			/>
+		</button>
+	{/snippet}
 	{#if photos.length > 0}
 		<div class="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-md p-4 space-y-3">
 			<div class="flex items-center gap-2 text-sm font-semibold text-stone-600 dark:text-stone-300">
@@ -837,19 +853,7 @@
 						<h3 class="section-title text-sm text-stone-500 dark:text-stone-400 mb-2">Before</h3>
 						<div class="grid grid-cols-2 gap-2">
 							{#each photoSplit.before as photo (photo.id)}
-								<button
-									onclick={() => openLightbox(photos.indexOf(photo))}
-									class="block rounded-md overflow-hidden ring-1 ring-stone-200 dark:ring-stone-700 hover:ring-amber-500 transition-shadow cursor-zoom-in"
-									aria-label="View photo {photos.indexOf(photo) + 1} of {photos.length}"
-								>
-									<img
-										src={photo.thumbnailUrl}
-										alt="Pothole at {pothole.address || 'this location'}"
-										class="w-full object-cover aspect-video"
-										loading="lazy"
-										onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.onerror = null; img.src = photo.url; }}
-									/>
-								</button>
+								{@render thumb(photo)}
 							{/each}
 						</div>
 					</div>
@@ -857,39 +861,15 @@
 						<h3 class="section-title text-sm text-stone-500 dark:text-stone-400 mb-2">After</h3>
 						<div class="grid grid-cols-2 gap-2">
 							{#each photoSplit.after as photo (photo.id)}
-								<button
-									onclick={() => openLightbox(photos.indexOf(photo))}
-									class="block rounded-md overflow-hidden ring-1 ring-stone-200 dark:ring-stone-700 hover:ring-amber-500 transition-shadow cursor-zoom-in"
-									aria-label="View photo {photos.indexOf(photo) + 1} of {photos.length}"
-								>
-									<img
-										src={photo.thumbnailUrl}
-										alt="Pothole at {pothole.address || 'this location'}"
-										class="w-full object-cover aspect-video"
-										loading="lazy"
-										onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.onerror = null; img.src = photo.url; }}
-									/>
-								</button>
+								{@render thumb(photo)}
 							{/each}
 						</div>
 					</div>
 				</div>
 			{:else}
 				<div class="grid grid-cols-2 gap-2">
-					{#each photos as photo, i (photo.id)}
-						<button
-							onclick={() => openLightbox(i)}
-							class="block rounded-md overflow-hidden ring-1 ring-stone-200 dark:ring-stone-700 hover:ring-amber-500 transition-shadow cursor-zoom-in"
-							aria-label="View photo {i + 1} of {photos.length}"
-						>
-							<img
-								src={photo.thumbnailUrl}
-								alt="Pothole at {pothole.address || 'this location'}"
-								class="w-full object-cover aspect-video"
-								loading="lazy"
-								onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.onerror = null; img.src = photo.url; }}
-							/>
-						</button>
+					{#each photos as photo (photo.id)}
+						{@render thumb(photo)}
 					{/each}
 				</div>
 			{/if}


### PR DESCRIPTION
Closes #212

## What

`src/routes/hole/[id]/+page.svelte` rendered the identical thumbnail button + `<img>` block three times (Before gallery, After gallery, flat fallback) — accepted in #211 to ship the before/after split, but a drift hazard: any thumbnail change had to be made in three places.

Extracted a single `{#snippet thumb(photo)}` (typed via `(typeof photos)[number]`, no new imports) rendered in all three loops with `{@render thumb(photo)}`. The lightbox index comes from `photos.indexOf(photo)`, which is reference-equal in every gallery — `splitByFill()` filters the same array, preserving object identity — and provably identical to the loop index the flat gallery used before. Every attribute (classes, `aria-label`, alt text, `loading="lazy"`, the thumbnail→full-size `onerror` fallback) preserved verbatim. Net **−20 lines**, markup-only, a11y-neutral.

## Verification

- `tests/e2e/pothole-detail.spec.ts` — 14/14 green, including the before/after split test (the issue's acceptance criterion)
- `npm run lint` clean, `npm run check` 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5jw9vuMFSmPrX3nseoCuG