### PR TITLE
fix(reliability): surface server 4xx detail in toasts; log corrupt confirmation_threshold

### DIFF
--- a/src/lib/components/PushNotifications.svelte
+++ b/src/lib/components/PushNotifications.svelte
@@ -3,7 +3,7 @@
 	import { env } from '$env/dynamic/public';
 	import Icon from './Icon.svelte';
 	import { urlBase64ToUint8Array } from '$lib/push';
-	import { toastError } from '$lib/toast';
+	import { toastError, toastErrorFromResponse } from '$lib/toast';
 
 	type NotifState = 'unsupported' | 'denied' | 'subscribed' | 'unsubscribed' | 'pending';
 
@@ -58,7 +58,11 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ endpoint, keys })
 			});
-			if (!res.ok) throw new Error(`subscribe failed: HTTP ${res.status}`);
+			if (!res.ok) {
+				notifState = 'unsubscribed';
+				await toastErrorFromResponse(res, 'Could not turn on notifications. Try again.');
+				return;
+			}
 			// Flag only after the server confirmed the subscription — see onMount.
 			localStorage.setItem('push-subscribed', '1');
 			notifState = 'subscribed';
@@ -84,7 +88,11 @@
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({ endpoint: sub.endpoint })
 				});
-				if (!res.ok) throw new Error(`unsubscribe failed: HTTP ${res.status}`);
+				if (!res.ok) {
+					notifState = 'subscribed';
+					await toastErrorFromResponse(res, 'Could not turn off notifications. Try again.');
+					return;
+				}
 				localStorage.removeItem('push-subscribed');
 				await sub.unsubscribe();
 			}

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -18,5 +18,15 @@ export async function getSetting(key: string, fallback: string): Promise<string>
 export async function getConfirmationThreshold(): Promise<number> {
 	const val = await getSetting('confirmation_threshold', '2');
 	const n = parseInt(val, 10);
-	return Number.isFinite(n) && n >= 1 ? n : 2;
+	if (Number.isFinite(n) && n >= 1) return n;
+	// getSetting's own fallback ('2') always parses valid, so reaching here means
+	// the DB row exists but holds a corrupt value — surface it instead of
+	// silently coercing to the default.
+	logError(
+		'settings',
+		`confirmation_threshold has an invalid stored value; falling back to 2`,
+		new Error('invalid confirmation_threshold'),
+		{ value: val }
+	);
+	return 2;
 }

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,5 +1,26 @@
 import { toast } from 'svelte-sonner';
 
+/**
+ * Show a failure toast for a non-ok fetch Response. For 4xx responses, surfaces
+ * the server's own `message` body (SvelteKit's `error()` helper serializes to
+ * `{ message: string }`) since it's often actionable — e.g. a 429 retry-after
+ * hint or a 409 "already filled" — where a generic toast tells the user
+ * nothing new. 5xx responses always get `fallback`: server error bodies aren't
+ * meant for end users and can leak internals.
+ */
+export async function toastErrorFromResponse(res: Response, fallback: string): Promise<void> {
+	if (res.status >= 400 && res.status < 500) {
+		const body: unknown = await res.json().catch(() => null);
+		const message =
+			body && typeof body === 'object' && 'message' in body ? body.message : undefined;
+		if (typeof message === 'string' && message.trim()) {
+			toastError(message);
+			return;
+		}
+	}
+	toastError(fallback);
+}
+
 export function toastError(message: string): void {
 	const hasClipboard =
 		typeof navigator !== 'undefined' &&

--- a/src/routes/hole/[id]/+page.svelte
+++ b/src/routes/hole/[id]/+page.svelte
@@ -9,7 +9,7 @@
 	  REGION_REPORT_LINK
 	} from '$lib/official-reporting';
 	import { resizeImage } from '$lib/image';
-	import { toastError } from '$lib/toast';
+	import { toastError, toastErrorFromResponse } from '$lib/toast';
 	import { getPotholeEmailUrl } from '$lib/email';
 	import type { Pothole } from '$lib/types';
 	import type { Councillor } from '$lib/wards';
@@ -107,7 +107,7 @@
 					body: JSON.stringify({ id: pothole.id })
 				});
 				if (!res.ok) {
-					toastError('Something went wrong. Try again.');
+					await toastErrorFromResponse(res, 'Something went wrong. Try again.');
 					return;
 				}
 				const result = await res.json();
@@ -120,7 +120,7 @@
 					body: JSON.stringify({ id: pothole.id, direction: 1 })
 				});
 				if (!res.ok) {
-					toastError('Something went wrong. Try again.');
+					await toastErrorFromResponse(res, 'Something went wrong. Try again.');
 					return;
 				}
 				const result = await res.json();
@@ -152,7 +152,11 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ endpoint, keys })
 			});
-			if (!res.ok) throw new Error('subscribe failed');
+			if (!res.ok) {
+				fillNotifState = 'unsubscribed';
+				await toastErrorFromResponse(res, 'Could not turn on notifications. Try again.');
+				return;
+			}
 			localStorage.setItem(`fill-notify:${pothole.id}`, '1');
 			fillNotifState = 'subscribed';
 		} catch {
@@ -176,7 +180,11 @@
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({ endpoint: sub.endpoint })
 				});
-				if (!res.ok) throw new Error(`unsubscribe failed: HTTP ${res.status}`);
+				if (!res.ok) {
+					fillNotifState = 'subscribed';
+					await toastErrorFromResponse(res, 'Could not turn off notifications. Try again.');
+					return;
+				}
 			}
 			localStorage.removeItem(`fill-notify:${pothole.id}`);
 			fillNotifState = 'unsubscribed';
@@ -196,7 +204,7 @@
 				body: JSON.stringify({ id: pothole.id })
 			});
 			if (!res.ok) {
-				toastError('Something went wrong. Try again.');
+				await toastErrorFromResponse(res, 'Something went wrong. Try again.');
 				return;
 			}
 			const result = await res.json();


### PR DESCRIPTION
## Summary
- Adds `toastErrorFromResponse()` to `$lib/toast` — surfaces the server's own `message` body for 4xx responses (SvelteKit's `error()` helper serializes to `{ message }`), falling back to a generic toast for 5xx or unparseable bodies.
- Applies it to the push subscribe/unsubscribe, per-pothole fill-notify subscribe/unsubscribe, vote toggle, and "I hit this" failure paths — so a 429 rate-limit or 409 "already filled" now tells the user something actionable instead of a generic "Something went wrong."
- `getConfirmationThreshold()` now calls `logError('settings', ...)` when the stored `confirmation_threshold` value fails validation, instead of silently coercing to the default of 2. `getSetting`'s own fallback always parses valid, so reaching that branch means the DB row itself holds a corrupt value.

Closes #224

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [ ] CI (lint/typecheck/build/E2E/a11y) green on this PR