### PR TITLE
docs(test-infra): document local e2e env contract; pin workers to 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,46 @@ npm run dev          # http://localhost:5173
 - **Supabase** (`.mcp.json`) — database inspection, schema management.
 - **Playwright** (`.mcp.json`) — browser automation for E2E testing.
 
+### Dependency updates (Dependabot) — recurring lockfile bug
+Dependabot's targeted (partial) `package-lock.json` updates repeatedly drop a
+nested, valid entry: `node_modules/@sentry/node/node_modules/vite@6.4.3`, an
+optional peer dependency `@sentry/node` needs because the root `vite` version
+doesn't satisfy its declared peer range. When that nested entry is missing,
+CI's `npm ci` (npm 10.9.8, bundled with the Node 22 runner) fails hard with
+`EUSAGE` / `Missing: vite@6.4.3 from lock file` (plus its rollup/esbuild
+platform binaries) — even though the PR's actual dependency bump is fine and
+`main`'s own lockfile is self-consistent. This has recurred across unrelated
+dependency groups (svelte, zod, supabase-js, tailwind), so treat it as
+Dependabot tooling noise, not a real incompatibility, unless proven otherwise.
+
+**Fix**: regenerate `package-lock.json` — but not with a bare local
+`npm install`. Two platform traps stack on top of each other:
+1. **macOS produces a platform-pruned lockfile** — missing the Linux-only
+   optional binaries (`@rollup/rollup-linux-*`, `@esbuild/linux-*`) CI needs.
+   This bit a real cleanup PR once already (see the `revert:` commit in
+   `e2c2068`) and was deferred at the time.
+2. **A newer local npm (11.x+) resolves peer deps more leniently** than CI's
+   npm 10.9.8 and will *not* re-add the nested `@sentry/node` vite entry, so
+   the regenerated lockfile still fails in CI even though it looks clean
+   locally.
+
+Regenerate inside a container matching CI's exact runtime instead:
+```bash
+container run --rm -v "$(pwd)":/work -w /work node:22 sh -c "npm install --package-lock-only"
+container run --rm -v "$(pwd)":/work -w /work node:22 sh -c "npm ci"   # verify
+```
+(`container` is Apple's runtime — see the global operating doctrine. `docker`/
+`podman` work identically if available.) Verify `npm run check`/`lint`/`build`
+too before pushing — `webServer`/build steps need real `PUBLIC_SUPABASE_*`
+values, so copy in `.env` for that step only and remove it afterward.
+
+**Don't push the fix directly to the Dependabot branch without expecting a
+reaction**: Dependabot treats any external push to its own branch as
+tampering and will auto-close the PR (sometimes) within seconds — `gh pr
+reopen <n>` immediately afterward is safe and picks the branch back up with
+your commit intact. This is inconsistent (some pushes are left alone), so
+always check `gh pr view <n> --json state,closed` after pushing.
+
 ## Environment
 
 Copy `.env.example` → `.env` with real values:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,42 @@ See [fillthehole.ca/about#privacy](https://fillthehole.ca/about#privacy) for the
 
 ---
 
+## Testing
+
+```bash
+npm run check    # svelte-check type checking
+npm run lint     # ESLint
+npm run test     # Playwright E2E (tests/e2e/)
+npm run test:a11y # axe-core accessibility checks
+```
+
+CI runs the E2E suite against a self-contained fixture server (no real Supabase
+needed) with a single worker. Running the same suite locally needs a bit more
+setup, or a handful of tests fail for reasons that have nothing to do with the
+code under test:
+
+- **`ADMIN_SESSION_SECRET` / `TOTP_ENCRYPTION_KEY` must be non-empty.** Both are
+  optional for `npm run dev`, but the admin-mfa and admin photo-upload E2E
+  specs hard-fail (`Zero-length key is not supported`) without them. Generate
+  real values (see `.env.example`) even if you're not using admin features
+  locally.
+- **Supabase-dependent tests need `PUBLIC_SUPABASE_URL` / `PUBLIC_SUPABASE_ANON_KEY` /
+  `SUPABASE_SERVICE_ROLE_KEY` exported in your shell**, not just present in
+  `.env`. `playwright.config.ts`'s `webServer.env` only forwards these from
+  `process.env`; otherwise it injects a closed-port placeholder so
+  Supabase-backed tests fail fast instead of hanging.
+- **Kill anything already listening on port 4173 before running `npm run test`
+  locally.** `reuseExistingServer` is `true` outside CI — if a stale
+  `npm run preview` from an earlier session is still up, Playwright reuses it
+  as-is instead of starting a fresh one with the fixture env
+  (`PLAYWRIGHT_E2E_FIXTURES=true`, `CI=true`) injected, so tests silently fall
+  through to real Supabase calls instead of the fixture store.
+- **A handful of tests can still flake locally with real Supabase configured**
+  (data-dependent assertions against whatever's actually in the table, plus
+  parallel workers racing on shared DB state — CI pins `workers: 1`).
+  Treat CI as the authoritative gate; a local failure that doesn't reproduce
+  in CI usually isn't a real regression.
+
 ## Contributing
 
 Issues and PRs welcome. If you're adding a feature, open an issue first to discuss it — this is a focused civic tool, not a general platform.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Pinned everywhere, not just CI: parallel workers racing against the same
+  // live Supabase project (when running locally without fixtures) produces
+  // nondeterministic failures on data-dependent assertions. See #226.
+  workers: 1,
   reporter: process.env.CI ? [["github"], ["html"]] : "list",
 
   use: {


### PR DESCRIPTION
## Summary
Partially addresses #226 (test-infra: local e2e runs diverge from CI):

- Documents the local e2e env contract in README.md — the undocumented `ADMIN_SESSION_SECRET`/`TOTP_ENCRYPTION_KEY` requirement, the need to export Supabase vars in-shell (not just `.env`), and the `reuseExistingServer` gotcha where a stale `npm run preview` on port 4173 silently bypasses the fixture/CI env injection.
- Pins Playwright's `workers` to `1` everywhere (was CI-only) to reduce nondeterminism from parallel workers racing a live Supabase project locally.

**Not addressed here** (item 2 from the issue): the fixture-store coverage gap for the trusted-device cookie and photo-moderation flows. Those routes gate their fixture short-circuit on `PLAYWRIGHT_E2E_FIXTURES === 'true' && CI === 'true'` — loosening that to also fire locally touches an auth-bypass boundary (test-only session/MFA bypass) and deserves a dedicated look rather than a drive-by change bundled with docs. Leaving #226 open for that piece.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run check` — 0 errors
- [ ] CI green on this PR