### PR TITLE
chore: finish Husky + Prettier + lint-staged setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.sql]
+indent_style = space
+indent_size = 2
+
+[*.{json,jsonc}]
+indent_style = space
+indent_size = 2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["boxpositron/envsitter-guard", "shihyuho/opencode-command-inject"],
+  "mcp": {
+    "github": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{env:GITHUB_TOKEN}"
+      }
+    },
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "oauth": {}
+    }
+  }
+}

--- a/.opencode/plugins/command-inject.js
+++ b/.opencode/plugins/command-inject.js
@@ -1,0 +1,37 @@
+/**
+ * Command inject plugin — makes npm scripts available as /commands.
+ *
+ * Discovers scripts from package.json at session start so developers
+ * can run dev, build, test, check, lint, format via slash commands.
+ */
+export const CommandInject = async ({ project, client, $, directory, worktree }) => {
+	return {
+		'session.created': async () => {
+			const scripts = project.package?.scripts ?? {};
+			const commands = Object.entries(scripts)
+				.filter(([name]) => !['prepare', 'check:watch'].includes(name))
+				.map(([name, cmd]) => ({
+					name,
+					description: `npm run ${name} — ${cmd}`,
+				}));
+
+			if (commands.length > 0) {
+				await client.app.log({
+					body: {
+						service: 'command-inject',
+						level: 'info',
+						message: `Available commands: /${commands.map((c) => c.name).join(', /')}`,
+					},
+				});
+			}
+		},
+		'tui.command.execute': async (input, output) => {
+			const scripts = project.package?.scripts ?? {};
+			const name = input.command?.replace(/^\//, '');
+			if (name && scripts[name]) {
+				output.preventDefault = true;
+				await $`npm run ${name}`;
+			}
+		},
+	};
+};

--- a/.opencode/plugins/env-protection.js
+++ b/.opencode/plugins/env-protection.js
@@ -1,0 +1,32 @@
+/**
+ * Env protection plugin — prevents opencode from reading or editing
+ * sensitive .env* files, while still allowing safe inspection (key names
+ * only, never values).
+ *
+ * Based on the opencode docs example and EnvSitter Guard pattern.
+ */
+export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
+	return {
+		'tool.execute.before': async (input, output) => {
+			if (input.tool === 'read' && output.args.filePath?.includes('.env')) {
+				throw new Error(
+					'Reading .env files is not allowed. Use `npm run check:env` to verify env vars are set.',
+				);
+			}
+			if (
+				input.tool === 'edit' &&
+				output.args.filePath?.includes('.env') &&
+				!output.args.filePath?.endsWith('.env.example')
+			) {
+				throw new Error('Editing .env files is not allowed. Update .env.example instead.');
+			}
+			if (
+				input.tool === 'write' &&
+				output.args.filePath?.includes('.env') &&
+				!output.args.filePath?.endsWith('.env.example')
+			) {
+				throw new Error('Writing .env files is not allowed. Update .env.example instead.');
+			}
+		},
+	};
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+.svelte-kit/
+build/
+node_modules/
+playwright-report/
+test-results/
+.worktrees/
+.vercel/
+.netlify/
+supabase/
+docs/
+*.sql
+**/pnpm-lock.yaml
+**/package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,31 @@
+{
+	"semi": true,
+	"singleQuote": true,
+	"trailingComma": "all",
+	"tabWidth": 4,
+	"useTabs": true,
+	"printWidth": 100,
+	"plugins": ["prettier-plugin-svelte"],
+	"overrides": [
+		{
+			"files": "*.svelte",
+			"options": {
+				"parser": "svelte"
+			}
+		},
+		{
+			"files": "*.{json,jsonc,yml,yaml}",
+			"options": {
+				"tabWidth": 2,
+				"useTabs": false
+			}
+		},
+		{
+			"files": "*.sql",
+			"options": {
+				"tabWidth": 2,
+				"useTabs": false
+			}
+		}
+	]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 import svelte from "eslint-plugin-svelte";
 import svelteParser from "svelte-eslint-parser";
 import tsEslint from "typescript-eslint";
+import prettier from "eslint-config-prettier";
 
 /**
  * General ESLint flat config for the project.
@@ -47,4 +48,6 @@ export default tsEslint.config(
       "svelte/no-navigation-without-resolve": "off",
     },
   },
+  // Must stay last — disables stylistic rules that would conflict with Prettier.
+  prettier,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,12 @@
         "@tailwindcss/vite": "^4.3.2",
         "@types/web-push": "^3.6.4",
         "eslint": "^10.5.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.17.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^17.1.0",
+        "prettier": "^3.9.5",
+        "prettier-plugin-svelte": "^4.1.1",
         "svelte": "^5.56.6",
         "svelte-check": "^4.6.0",
         "tailwindcss": "^4.2.0",
@@ -5200,6 +5205,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-svelte": {
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.1.tgz",
@@ -5562,6 +5583,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iceberg-js": {
@@ -6052,6 +6089,30 @@
         "unicode-trie": "^2.0.0"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
+      "integrity": "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.5",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -6354,9 +6415,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6547,6 +6608,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/progress": {
@@ -6851,6 +6942,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
@@ -7036,6 +7137,16 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -7399,6 +7510,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "prepare": "svelte-kit sync || echo ''",
+    "prepare": "husky && (svelte-kit sync || echo '')",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint --config eslint.config.js src/",
@@ -26,7 +26,12 @@
     "@tailwindcss/vite": "^4.3.2",
     "@types/web-push": "^3.6.4",
     "eslint": "^10.5.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.17.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^17.1.0",
+    "prettier": "^3.9.5",
+    "prettier-plugin-svelte": "^4.1.1",
     "svelte": "^5.56.6",
     "svelte-check": "^4.6.0",
     "tailwindcss": "^4.2.0",
@@ -54,5 +59,12 @@
   "overrides": {
     "cookie": "^0.7.0",
     "minimatch": "^10.2.1"
+  },
+  "lint-staged": {
+    "*.{ts,svelte}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{css,json,md}": "prettier --write"
   }
 }


### PR DESCRIPTION
## Summary
CLAUDE.md has documented Husky pre-commit hooks, Prettier, and EditorConfig as shipped tooling for a while, but none of it was ever actually committed — `husky`/`lint-staged`/`prettier`/`prettier-plugin-svelte`/`eslint-config-prettier` never appear anywhere in `package.json`'s git history. Someone set up the local config files (`.husky/`, `.prettierrc`, `.prettierignore`, `.editorconfig`) and wrote the docs describing them, but never installed the dependencies or committed anything — leaving every local commit on that machine blocked by a pre-commit hook calling a `lint-staged` binary that didn't exist.

- Installs the five missing devDependencies.
- Adds the `lint-staged` config matching what CLAUDE.md already described: staged `.ts`/`.svelte` get `eslint --fix` + `prettier --write`; staged `.css`/`.json`/`.md` get `prettier --write` only.
- Wires `eslint-config-prettier` in last (after all other configs) so it can disable any ESLint stylistic rules that would otherwise fight Prettier.
- Points `prepare` at `husky`, chained with the existing `svelte-kit sync`.
- Commits `.opencode/` (project-level config + the two already-documented plugins) — same situation, real documented tooling that was sitting untracked.

Verified the hook end-to-end: staged this exact commit and watched `lint-staged` run `prettier --write` on the staged JSON files for real, no errors.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [x] `npm ci` verified in a node:22 container matching CI's npm 10.9.8
- [x] Pre-commit hook verified end-to-end on this branch's own commit
- [ ] CI green on this PR