### PR TITLE
chore: add AGENTS.md, Makefile, and a ground-truth test fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+.PHONY: help install dev build preview check check-watch lint lint-a11y test test-a11y
+
+help:
+	@echo "Available targets:"
+	@echo "  install     Install dependencies"
+	@echo "  dev         Start the dev server (http://localhost:5173)"
+	@echo "  build       Production build"
+	@echo "  preview     Preview the production build"
+	@echo "  check       Type-check (svelte-check)"
+	@echo "  check-watch Type-check in watch mode"
+	@echo "  lint        ESLint (TS + Svelte files)"
+	@echo "  lint-a11y   svelte-check at warning threshold"
+	@echo "  test        Playwright E2E tests"
+	@echo "  test-a11y   axe-core a11y tests (Playwright)"
+
+install:
+	npm install
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+preview:
+	npm run preview
+
+check:
+	npm run check
+
+check-watch:
+	npm run check:watch
+
+lint:
+	npm run lint
+
+lint-a11y:
+	npm run lint:a11y
+
+test:
+	npm run test
+
+test-a11y:
+	npm run test:a11y

--- a/tests/e2e/geofence.spec.ts
+++ b/tests/e2e/geofence.spec.ts
@@ -35,12 +35,16 @@ test.describe('Geofence API validation', () => {
 				data: { lat: point.lat, lng: point.lng },
 			});
 
-			// Geofence passes — not a 422. With real DB creds this returns 200;
-			// with placeholder creds the downstream DB query fails (500), but the
-			// geofence logic itself is verified by the non-422 response.
-			expect(response.status()).not.toBe(422);
-			const body = await response.json();
-			expect(body.message ?? '').not.toMatch(/isn't in the Waterloo Region/i);
+			// Geofence passes — with real DB creds this returns 200; with
+			// placeholder creds the downstream DB query fails (500), but the
+			// geofence logic itself is still verified either way. A 400/429
+			// would mean something other than the geofence rejected the
+			// request, so those must fail the test rather than pass silently.
+			expect([200, 500]).toContain(response.status());
+			if (response.status() === 200) {
+				const body = await response.json();
+				expect(body.message ?? '').not.toMatch(/isn't in the Waterloo Region/i);
+			}
 		});
 	}
 

--- a/tests/e2e/geofence.spec.ts
+++ b/tests/e2e/geofence.spec.ts
@@ -1,57 +1,52 @@
 import { test, expect } from '@playwright/test';
+import groundTruth from '../fixtures/ground-truth.json' with { type: 'json' };
+
+const { insideWaterlooRegion, outsideWaterlooRegion } = groundTruth.geofence;
 
 // These tests call the API directly using Playwright's request fixture, which acts
 // as a standalone HTTP client. The geofence check in /api/report runs before any
 // DB query, so rejection tests work even with placeholder Supabase credentials.
 test.describe('Geofence API validation', () => {
-	test('rejects coordinates outside Waterloo Region (Toronto)', async ({ request }) => {
-		const response = await request.post('/api/report', {
-			data: { lat: 43.7, lng: -79.4 }
+	for (const point of outsideWaterlooRegion) {
+		test(`rejects coordinates outside Waterloo Region (${point.label})`, async ({
+			request,
+		}) => {
+			const response = await request.post('/api/report', {
+				data: { lat: point.lat, lng: point.lng },
+			});
+
+			// If complete API failure, skip gracefully
+			if (response.status() === 500) {
+				test.skip(true, 'API completely unavailable - skipping geofence validation test');
+				return;
+			}
+
+			expect(response.status()).toBe(422);
+			const body = await response.json();
+			expect(body.message).toMatch(/isn't in the Waterloo Region/i);
 		});
+	}
 
-		// If complete API failure, skip gracefully
-		if (response.status() === 500) {
-			test.skip(true, 'API completely unavailable - skipping geofence validation test');
-			return;
-		}
+	for (const point of insideWaterlooRegion) {
+		test(`passes geofence for coordinates inside Waterloo Region (${point.label})`, async ({
+			request,
+		}) => {
+			const response = await request.post('/api/report', {
+				data: { lat: point.lat, lng: point.lng },
+			});
 
-		expect(response.status()).toBe(422);
-		const body = await response.json();
-		expect(body.message).toMatch(/isn't in the Waterloo Region/i);
-	});
-
-	test('rejects coordinates just outside the southern boundary', async ({ request }) => {
-		const response = await request.post('/api/report', {
-			data: { lat: 43.31, lng: -80.5 } // Just below the 43.32 minimum
+			// Geofence passes — not a 422. With real DB creds this returns 200;
+			// with placeholder creds the downstream DB query fails (500), but the
+			// geofence logic itself is verified by the non-422 response.
+			expect(response.status()).not.toBe(422);
+			const body = await response.json();
+			expect(body.message ?? '').not.toMatch(/isn't in the Waterloo Region/i);
 		});
-
-		// If complete API failure, skip gracefully
-		if (response.status() === 500) {
-			test.skip(true, 'API completely unavailable - skipping geofence validation test');
-			return;
-		}
-
-		expect(response.status()).toBe(422);
-		const body = await response.json();
-		expect(body.message).toMatch(/isn't in the Waterloo Region/i);
-	});
-
-	test('passes geofence for coordinates inside Waterloo Region', async ({ request }) => {
-		const response = await request.post('/api/report', {
-			data: { lat: 43.45, lng: -80.5 } // Central Kitchener
-		});
-
-		// Geofence passes — not a 422. With real DB creds this returns 200;
-		// with placeholder creds the downstream DB query fails (500), but the
-		// geofence logic itself is verified by the non-422 response.
-		expect(response.status()).not.toBe(422);
-		const body = await response.json();
-		expect(body.message ?? '').not.toMatch(/isn't in the Waterloo Region/i);
-	});
+	}
 
 	test('rejects request missing lat and lng', async ({ request }) => {
 		const response = await request.post('/api/report', {
-			data: { address: 'Some address', description: 'Test' }
+			data: { address: 'Some address', description: 'Test' },
 		});
 
 		// Skip if Supabase unavailable (500 error)
@@ -66,7 +61,7 @@ test.describe('Geofence API validation', () => {
 
 	test('rejects request with non-numeric coordinates', async ({ request }) => {
 		const response = await request.post('/api/report', {
-			data: { lat: 'not-a-number', lng: -80.5 }
+			data: { lat: 'not-a-number', lng: -80.5 },
 		});
 
 		// Skip if Supabase unavailable (500 error)

--- a/tests/fixtures/ground-truth.json
+++ b/tests/fixtures/ground-truth.json
@@ -1,0 +1,80 @@
+{
+  "_comment": "Synthetic, deterministic test data. Coordinates are validated against the Waterloo Region geofence (lat 43.32-43.53, lng -80.59--80.22) documented in CLAUDE.md. Addresses/descriptions are fictional. Not sourced from production.",
+  "geofence": {
+    "insideWaterlooRegion": [
+      { "label": "Central Kitchener", "lat": 43.45, "lng": -80.5 },
+      { "label": "Uptown Waterloo", "lat": 43.4643, "lng": -80.5204 },
+      { "label": "Cambridge Galt core", "lat": 43.3601, "lng": -80.3144 }
+    ],
+    "outsideWaterlooRegion": [
+      { "label": "Toronto", "lat": 43.7, "lng": -79.4 },
+      { "label": "Just below southern boundary", "lat": 43.31, "lng": -80.5 },
+      { "label": "Just above northern boundary", "lat": 43.54, "lng": -80.5 },
+      { "label": "Just west of western boundary", "lat": 43.45, "lng": -80.6 },
+      { "label": "Just east of eastern boundary", "lat": 43.45, "lng": -80.21 }
+    ]
+  },
+  "mergeRadius": {
+    "basePoint": { "lat": 43.4516, "lng": -80.4925 },
+    "duplicateReport": {
+      "lat": 43.45178,
+      "lng": -80.49224,
+      "note": "~18m from basePoint — should merge (within the 25m radius)"
+    },
+    "distinctReport": {
+      "lat": 43.455,
+      "lng": -80.4925,
+      "note": "~380m from basePoint — should NOT merge"
+    }
+  },
+  "potholes": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "status": "pending",
+      "lat": 43.4516,
+      "lng": -80.4925,
+      "address": "100 Regina St S, Waterloo, ON",
+      "description": "Deep pothole near the curb, roughly 30cm wide.",
+      "confirmed_count": 1,
+      "photos_published": false,
+      "city": "waterloo",
+      "ward": 7
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "status": "reported",
+      "lat": 43.4234,
+      "lng": -80.4801,
+      "address": "255 King St E, Kitchener, ON",
+      "description": "Large pothole spanning half the lane.",
+      "confirmed_count": 2,
+      "photos_published": true,
+      "city": "kitchener",
+      "ward": 9
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "status": "filled",
+      "lat": 43.3894,
+      "lng": -80.3125,
+      "address": "45 Ainslie St S, Cambridge, ON",
+      "description": "Pothole at the intersection, previously reported.",
+      "confirmed_count": 2,
+      "photos_published": true,
+      "city": "cambridge",
+      "ward": 3
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "status": "expired",
+      "lat": 43.475,
+      "lng": -80.54,
+      "address": "12 Bridgeport Rd E, Waterloo, ON",
+      "description": "Small surface crack, never confirmed by a second report.",
+      "confirmed_count": 1,
+      "photos_published": false,
+      "city": "waterloo",
+      "ward": 2
+    }
+  ]
+}

--- a/tests/fixtures/ground-truth.json
+++ b/tests/fixtures/ground-truth.json
@@ -17,8 +17,8 @@
   "mergeRadius": {
     "basePoint": { "lat": 43.4516, "lng": -80.4925 },
     "duplicateReport": {
-      "lat": 43.45178,
-      "lng": -80.49224,
+      "lat": 43.45176,
+      "lng": -80.4925,
       "note": "~18m from basePoint — should merge (within the 25m radius)"
     },
     "distinctReport": {


### PR DESCRIPTION
## Summary
- `AGENTS.md` symlinks to `CLAUDE.md` so other AGENTS.md-aware tools (Codex, Cursor, etc.) get identical instructions with zero drift risk, per https://agents.md.
- `Makefile` wraps the existing npm scripts (`dev`, `build`, `check`, `lint`, `test`, etc.) for contributors who reach for `make` first.
- `tests/fixtures/ground-truth.json` centralizes synthetic geofence boundary points, merge-radius cases, and sample potholes instead of duplicating magic-number coordinates per spec file. Wired into `tests/e2e/geofence.spec.ts`, which also gained 3 previously-untested boundary cases (north/west/east) as a result — was 2 outside/1 inside case, now 5 outside/3 inside.

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test tests/e2e/geofence.spec.ts` — 10/10 passed
- [x] Pre-commit hooks (eslint --fix, prettier --write) ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded geofence API coverage using deterministic fixture data with labeled, data-driven cases for inside/outside boundary points.
  * Added reusable ground-truth fixture data covering geofencing, report-merging expectations, and sample pothole records.
  * Kept validation checks for missing coordinates and geofence error handling.
* **Documentation**
  * Updated contributor guidance to point to the primary instructions document.
* **Chores**
  * Added a Makefile with streamlined development, build/preview, lint/type-check, and Playwright E2E (including accessibility) commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->