### PR TITLE
fix(security): bump postcss to patch path-traversal vuln (GHSA, alert #34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6232,9 +6232,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6478,7 +6478,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- Bumps the transitive `postcss` resolution from 8.5.15 to 8.5.23, patching a high-severity path-traversal vulnerability: PostCSS auto-loads a "previous source map" referenced by a `sourceMappingURL` comment in parsed CSS without validating the path, allowing arbitrary `.map` file disclosure. Fixed upstream in 8.5.18.
- `postcss` is only a transitive dependency here (via `vite`, `eslint-plugin-svelte`, `svelte-eslint-parser`), all of which already declare `^8.x` ranges compatible with the patched version, so this is a lockfile-only change — `package.json` is untouched.
- Regenerated inside a Node 22 container matching CI's runtime via `npm update postcss --package-lock-only`, per this repo's documented Dependabot-lockfile-bug playbook in CLAUDE.md.

Closes Dependabot alert #34: https://github.com/BreakableHoodie/filltheholedotca/security/dependabot/34

## Test plan
- [x] `npm ci` — clean, 0 vulnerabilities reported
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)